### PR TITLE
fix(security): harden markdown rendering and local proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ npx office-addin-manifest validate manifest.xml
    ```
    (defaults to `https://localhost:3001`)
 
+   **Security:** the proxy only accepts browser requests from Pi for Excel origins by default:
+   - `https://localhost:3000` (dev)
+   - `https://pi-for-excel.vercel.app` (hosted)
+
+   If you host the add-in on a different origin, set `ALLOWED_ORIGINS` (comma-separated):
+   ```bash
+   ALLOWED_ORIGINS="https://my-addin.example.com" npm run proxy:https
+   ```
+
    If port 3001 is taken, pick another port:
    ```bash
    PORT=3003 npm run proxy:https

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -11,5 +11,7 @@ import "@mariozechner/pi-web-ui/app.css";
 import "./ui/theme.css";
 
 import { installLitClassFieldShadowingPatch } from "./compat/lit-class-field-shadowing.js";
+import { installMarkedSafetyPatch } from "./compat/marked-safety.js";
 
 installLitClassFieldShadowingPatch();
+installMarkedSafetyPatch();

--- a/src/commands/command-menu.ts
+++ b/src/commands/command-menu.ts
@@ -7,6 +7,8 @@
 
 import { commandRegistry, type SlashCommand } from "./types.js";
 
+import { escapeHtml } from "../utils/html.js";
+
 const SOURCE_BADGES: Record<string, string> = {
   builtin: "",
   extension: "ext",
@@ -115,9 +117,9 @@ function renderMenu(): void {
     const isSelected = i === selectedIndex;
     return `
       <div class="pi-cmd-item ${isSelected ? "selected" : ""}" data-index="${i}">
-        <span class="pi-cmd-name">/${cmd.name}</span>
-        ${badge ? `<span class="pi-cmd-badge">${badge}</span>` : ""}
-        <span class="pi-cmd-desc">${cmd.description}</span>
+        <span class="pi-cmd-name">/${escapeHtml(cmd.name)}</span>
+        ${badge ? `<span class="pi-cmd-badge">${escapeHtml(badge)}</span>` : ""}
+        <span class="pi-cmd-desc">${escapeHtml(cmd.description)}</span>
       </div>
     `;
   }).join("");

--- a/src/compat/marked-safety.ts
+++ b/src/compat/marked-safety.ts
@@ -1,0 +1,86 @@
+/**
+ * Marked/Markdown safety hardening.
+ *
+ * pi-web-ui uses <markdown-block> (from @mariozechner/mini-lit), which:
+ * - parses markdown via `marked`
+ * - renders HTML via Lit's `unsafeHTML`
+ * - escapes raw HTML tags in the input (good)
+ *
+ * Remaining risks we harden here:
+ * - `javascript:` / `data:` links in markdown
+ * - automatic network requests via markdown images: ![alt](https://...)
+ *
+ * We patch marked's Renderer prototype once at boot.
+ */
+
+import { marked, type Tokens } from "marked";
+
+import { escapeAttr, escapeHtml } from "../utils/html.js";
+
+let installed = false;
+
+const ALLOWED_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function isAllowedUrl(raw: string, allowedProtocols: Set<string>): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) return false;
+
+  try {
+    // Support relative URLs by resolving against current page.
+    const base = typeof window !== "undefined" && window.location?.href
+      ? window.location.href
+      : "https://localhost/";
+
+    const u = new URL(trimmed, base);
+    return allowedProtocols.has(u.protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function installMarkedSafetyPatch(): void {
+  if (installed) return;
+  installed = true;
+
+  // Defensive: marked's types are permissive, but we still narrow token shapes.
+  const rendererProto = marked.Renderer.prototype;
+
+  const originalLink = rendererProto.link;
+  rendererProto.link = function patchedLink(token: Tokens.Link): string {
+    const href = typeof token.href === "string" ? token.href : "";
+
+    // Block javascript:, data:, file:, etc.
+    if (!isAllowedUrl(href, ALLOWED_LINK_PROTOCOLS)) {
+      // Render as plain text (do not emit a link tag).
+      // token.text may contain nested markdown that is already rendered elsewhere;
+      // here we keep it simple and escape.
+      const text = typeof token.text === "string" && token.text.trim().length > 0
+        ? token.text
+        : href;
+      return escapeHtml(text);
+    }
+
+    return originalLink.call(this, token);
+  };
+
+  rendererProto.image = function patchedImage(token: Tokens.Image): string {
+    const href = typeof token.href === "string" ? token.href : "";
+    const alt = typeof token.text === "string" ? token.text : "";
+
+    // SECURITY: never render <img> from markdown.
+    // Inline images cause automatic network requests which can be used for tracking
+    // or exfiltration (e.g. embedding sensitive context into an image URL).
+    // We instead render a regular link (click-to-open).
+    if (isAllowedUrl(href, ALLOWED_LINK_PROTOCOLS)) {
+      const label = alt.trim().length > 0 ? `image: ${alt}` : "image";
+      return `<a href="${escapeAttr(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+    }
+
+    // If the URL itself is unsafe, fall back to plain text.
+    const label = alt.trim().length > 0 ? `image: ${alt}` : "image";
+    return escapeHtml(label);
+
+    // Note: we intentionally do NOT call originalImage.
+    // return originalImage.call(this, token);
+  };
+}

--- a/src/taskpane/status-bar.ts
+++ b/src/taskpane/status-bar.ts
@@ -5,6 +5,7 @@
 import type { Agent } from "@mariozechner/pi-agent-core";
 
 import { showToast } from "../ui/toast.js";
+import { escapeHtml } from "../utils/html.js";
 
 export function injectStatusBar(agent: Agent): void {
   agent.subscribe(() => updateStatusBar(agent));
@@ -22,6 +23,7 @@ export function updateStatusBar(agent: Agent): void {
   // Model alias
   const model = state.model;
   const modelAlias = model ? (model.name || model.id) : "Select model";
+  const modelAliasEscaped = escapeHtml(modelAlias);
 
   // Context usage
   let totalTokens = 0;
@@ -61,7 +63,7 @@ export function updateStatusBar(agent: Agent): void {
     <span class="pi-status-ctx has-tooltip"><span class="${ctxColor}">${pct}%</span> / ${ctxLabel}<span class="pi-tooltip pi-tooltip--left">${ctxBaseTooltip}${ctxWarning}</span></span>
     <button class="pi-status-model" data-tooltip="Switch the AI model powering this session">
       <span class="pi-status-model__mark">π</span>
-      <span class="pi-status-model__name">${modelAlias}</span>
+      <span class="pi-status-model__name">${modelAliasEscaped}</span>
       ${chevronSvg}
     </button>
     <span class="pi-status-thinking" data-tooltip="Controls how long the model &quot;thinks&quot; before answering — higher = slower but better reasoning. Click or ⇧Tab to cycle.">${brainSvg} ${thinkingLevel}</span>

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,0 +1,19 @@
+/**
+ * HTML escaping helpers.
+ *
+ * Use whenever we must interpolate dynamic text into `innerHTML`.
+ */
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function escapeAttr(text: string): string {
+  // Attribute context escape: also escape backticks.
+  return escapeHtml(text).replace(/`/g, "&#96;");
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,23 @@
   "outputDirectory": "dist",
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    },
+    {
       "source": "/src/taskpane.html",
       "headers": [
         {


### PR DESCRIPTION
Security hardening (separate from simplification work).

### What changed
- **Markdown safety:** patch `marked` at boot to:
  - block unsafe link protocols (e.g. `javascript:`, `data:`, `file:`)
  - disable markdown inline images (prevents automatic network requests / tracking)
  - files: `src/compat/marked-safety.ts`, `src/boot.ts`
- **Escape HTML in `innerHTML` sinks:**
  - slash command menu (`src/commands/command-menu.ts`)
  - status bar model label (`src/taskpane/status-bar.ts`)
  - helper: `src/utils/html.ts`
- **Local CORS proxy hardening:**
  - restrict CORS to an allowlist of Pi for Excel origins by default
  - configurable via `ALLOWED_ORIGINS` env var
  - docs update in `README.md`
  - file: `scripts/cors-proxy-server.mjs`
- **Hosted security headers:** add basic security headers on Vercel (`vercel.json`).

### Verification
- `npm run check`
- `npm run build`
- `npm run test:models`

Manual Excel smoke test still recommended.
