### PR TITLE
fix(security): stage CSP rollout in report-only mode

### DIFF
--- a/docs/deploy-vercel.md
+++ b/docs/deploy-vercel.md
@@ -15,7 +15,8 @@ Vercel is a good default host because it’s free for OSS/hobby usage and handle
 
 This repo includes `vercel.json` with:
 - `outputDirectory: dist`
-- a header rule to disable caching for `/src/taskpane.html` to make updates propagate reliably.
+- a header rule to disable caching for `/src/taskpane.html` to make updates propagate reliably
+- `Content-Security-Policy-Report-Only` on `/src/taskpane.html` for staged CSP rollout (observe violations before enforcing).
 
 ## Production URL
 

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,10 @@
         {
           "key": "Cache-Control",
           "value": "no-store"
+        },
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'none'; script-src 'self' https://appsforoffice.microsoft.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://api.anthropic.com https://console.anthropic.com https://api.openai.com https://auth.openai.com https://chatgpt.com https://generativelanguage.googleapis.com https://oauth2.googleapis.com https://github.com https://api.github.com https://*.githubcopilot.com https://localhost:* https://127.0.0.1:* http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*; object-src 'none'; base-uri 'none'; form-action 'none'"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add a staged `Content-Security-Policy-Report-Only` header for `/src/taskpane.html` in `vercel.json`
- include currently required external sources (Office.js, Google Fonts, provider domains, localhost/ws dev/proxy paths)
- keep rollout non-breaking while we collect violations before enforcing CSP
- document this staged rollout in `docs/deploy-vercel.md`

## Why
An enforced CSP in the previous shape was too likely to break real provider/proxy/font flows. This keeps security work moving while avoiding runtime regressions.

## Validation
- npm run check
- npm run test:models
- npm run build
