### PR TITLE
fix(security): close issue #26 with disconnect UX + threat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Type `/` in the message input to see all commands:
 | `/name <title>` | Rename the current session |
 | `/model` | Switch LLM model |
 | `/default-models` | Default model presets (currently opens the model selector) |
-| `/login` | Add or change API keys / OAuth |
+| `/login` | Add/change/disconnect API keys and OAuth providers |
 | `/settings` | Open settings dialog |
 | `/shortcuts` | Show keyboard shortcuts |
 | `/compact` | Summarize conversation to free context |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Short, topic-based docs (mirrors Pi's layout). Keep deeper decisions close to th
 - [Cleanup approach](./cleanup-approach.md)
 - [Codebase simplification plan](./codebase-simplification-plan.md)
 - [Context management policy (cache-safe)](./context-management-policy.md)
+- [Security threat model](./security-threat-model.md)
 - [Compaction (`/compact`)](./compaction.md)
 - [Upcoming (open issues digest)](./upcoming.md)
 - [Model/dependency update playbook](./model-updates.md)

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -1,0 +1,80 @@
+# Security threat model (v1)
+
+This document summarizes what Pi for Excel stores, where data flows, and the key trust boundaries.
+
+## Scope
+
+- Excel taskpane app running in Office webviews (WKWebView/WebView2/browser)
+- Hosted static build + optional local CORS proxy
+- Credential flows (API keys + browser OAuth)
+
+## Sensitive data
+
+- Provider API keys (IndexedDB `ProviderKeysStore`)
+- OAuth credentials (IndexedDB settings `oauth.<provider>`)
+- Workbook contents read by tools
+- Conversation/session history (IndexedDB)
+
+## Storage model
+
+- API keys: IndexedDB store via pi-web-ui storage backend
+- OAuth credentials: IndexedDB settings (legacy `localStorage` is migration-only cleanup path)
+- Sessions/settings: IndexedDB
+
+### User controls
+
+- `/login` provider overlay can add/replace/disconnect providers
+- Disconnect removes provider key and clears OAuth session for that provider
+- `/settings` includes API key + proxy configuration
+
+## Network model
+
+Taskpane communicates with:
+- Office JS CDN (`appsforoffice.microsoft.com`)
+- configured model/OAuth providers
+- optional local CORS proxy (`https://localhost:<port>`)
+
+Hosted taskpane is protected with CSP in `vercel.json` (scripts/styles/fonts/connect sources constrained to required endpoints).
+
+## Trust boundaries
+
+1. **Taskpane webview** (untrusted workbook/model text can enter UI)
+2. **Local helper services** (CORS proxy, dist server in dev/test)
+3. **Remote providers** (LLM + OAuth endpoints)
+4. **Extension loading boundary** (remote extension URL imports disabled by default)
+
+## Main threats and current controls
+
+### 1) XSS/content injection in markdown/UI
+- Marked safety patch blocks unsafe link protocols
+- Markdown images are rendered as links (no automatic `<img>` fetch)
+- Dynamic HTML sinks use escaping helpers where needed
+- CSP reduces script/connect exfil paths
+
+### 2) Token leakage via browser storage/logs
+- OAuth moved from `localStorage` to IndexedDB settings
+- No intentional token logging in auth restore/proxy paths
+- Provider disconnect clears both key and OAuth stored credentials
+
+### 3) Local proxy abuse (CORS/SSRF)
+- Loopback client requirement
+- Allowed-origin CORS allowlist
+- Loopback/private target blocking by default (+ DNS-aware checks)
+- Explicit opt-in overrides for advanced/local setups
+
+### 4) Remote extension code execution
+- `loadExtension()` blocks remote `http(s)` module URLs by default
+- Protocol-relative URLs (`//host/...`) treated as remote
+- Explicit unsafe local opt-in required for remote extension URL experiments
+
+## Known limitations
+
+- IndexedDB is not an XSS boundary; same-origin script execution can read stored credentials.
+- Full extension sandbox/capability permissions are deferred until user-supplied extension distribution ships.
+- Host-specific CSP behavior must continue to be smoke-tested in Excel macOS/Windows/Web.
+
+## Operational guidance
+
+- Prefer localhost HTTPS proxy only; remote proxies can observe prompts/tokens.
+- Keep dependencies updated (CI + Dependabot + audit checks).
+- When adding new outbound endpoints, update CSP + proxy/docs/tests in the same PR.

--- a/src/commands/builtins/overlays.ts
+++ b/src/commands/builtins/overlays.ts
@@ -60,6 +60,10 @@ export async function showProviderPicker(): Promise<void> {
         document.dispatchEvent(new CustomEvent("pi:providers-changed"));
         showToast(`${label} connected`);
       },
+      onDisconnected: (_row: HTMLElement, _id: string, label: string) => {
+        document.dispatchEvent(new CustomEvent("pi:providers-changed"));
+        showToast(`${label} disconnected`);
+      },
     });
     list.appendChild(row);
   }

--- a/src/taskpane/welcome-login.ts
+++ b/src/taskpane/welcome-login.ts
@@ -135,6 +135,14 @@ export async function showWelcomeLogin(providerKeys: ProviderKeysStore): Promise
             resolve();
           })();
         },
+        onDisconnected: (_row, _id, label) => {
+          void (async () => {
+            const updated = await providerKeys.list();
+            setActiveProviders(new Set(updated));
+            document.dispatchEvent(new CustomEvent("pi:providers-changed"));
+            showToast(`${label} disconnected`);
+          })();
+        },
       });
       providerList.appendChild(row);
     }


### PR DESCRIPTION
## Summary
- add a first-class provider disconnect flow in `/login`
  - each provider row now has a **Disconnect** action when connected
  - disconnect clears both stored provider key and OAuth credentials for that provider
  - emits provider-change events + user toast feedback
- add a canonical tracked threat model doc:
  - `docs/security-threat-model.md`
- update docs/index and README command text to surface the new disconnect capability

## Why
Issue #26 still had two practical gaps:
1. easy credential disconnect/clear UX
2. a canonical threat-model doc in tracked docs

This PR closes both with minimal architecture churn.

## Validation
- `npm run check`
- `npm run test:security`
- `npm run test:models`
- `npm run build`

Closes #26
