### PR TITLE
fix(security): remove legacy OAuth localStorage migration path

### DIFF
--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -18,7 +18,7 @@ This document summarizes what Pi for Excel stores, where data flows, and the key
 ## Storage model
 
 - API keys: IndexedDB store via pi-web-ui storage backend
-- OAuth credentials: IndexedDB settings (legacy `localStorage` is migration-only cleanup path)
+- OAuth credentials: IndexedDB settings (`oauth.<provider>`)
 - Sessions/settings: IndexedDB
 
 ### User controls
@@ -52,7 +52,7 @@ Hosted taskpane is protected with CSP in `vercel.json` (scripts/styles/fonts/con
 - CSP reduces script/connect exfil paths
 
 ### 2) Token leakage via browser storage/logs
-- OAuth moved from `localStorage` to IndexedDB settings
+- OAuth credentials are stored only in IndexedDB settings
 - No intentional token logging in auth restore/proxy paths
 - Provider disconnect clears both key and OAuth stored credentials
 

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -93,16 +93,16 @@ https://github.com/tmustier/pi-for-excel/issues/27
 
 ---
 
-### #26 — Security: credential/token handling hardening
-https://github.com/tmustier/pi-for-excel/issues/26
+### #62 — Security follow-up: sunset legacy OAuth localStorage migration path
+https://github.com/tmustier/pi-for-excel/issues/62
 
-**What it’s asking:** threat model + hardening of credential storage/handling.
+**What it’s asking:** remove the remaining compatibility path for legacy OAuth `localStorage` migration.
 
 **Key hotspots:**
-- OAuth creds currently involve localStorage restore paths
-- proxy layers and logging need review
+- `src/auth/oauth-storage.ts` should read/write IndexedDB settings only
+- docs/comments should no longer describe a localStorage OAuth fallback
 
-**Implication:** any feature that adds external tools, local bridges, or filesystem access (#24, #25, #32, #3) increases the surface area; security decisions should be made *before* those ship.
+**Implication:** keep credential persistence simple and auditable before expanding higher-risk surfaces (#24, #25, #32, #3).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "eslint \"*.ts\" \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "test:models": "node --test --experimental-strip-types tests/model-ordering.test.ts",
     "test:context": "node --test --experimental-strip-types tests/tool-result-shaping.test.ts",
-    "test:security": "node --test --experimental-strip-types tests/proxy-target-policy.test.mjs tests/cors-proxy-server.security.test.mjs tests/extension-source-policy.test.ts tests/marked-safety-policy.test.ts",
+    "test:security": "node --test --experimental-strip-types tests/proxy-target-policy.test.mjs tests/cors-proxy-server.security.test.mjs tests/extension-source-policy.test.ts tests/marked-safety-policy.test.ts tests/oauth-storage-security.test.ts",
     "validate": "npx office-addin-manifest validate manifest.xml",
     "sideload": "npx office-addin-debugging start manifest.xml desktop --app excel",
     "prepare": "node scripts/install-githooks.mjs"

--- a/src/auth/restore.ts
+++ b/src/auth/restore.ts
@@ -3,7 +3,7 @@
  *
  * Priority:
  * 1. pi's ~/.pi/agent/auth.json (served by Vite plugin at /__pi-auth)
- * 2. IndexedDB SettingsStore (migrated from legacy localStorage oauth_<providerId>)
+ * 2. IndexedDB SettingsStore (`oauth.<providerId>`)
  */
 
 import type { OAuthCredentials, OAuthProviderInterface } from "@mariozechner/pi-ai";
@@ -60,7 +60,7 @@ export async function restoreCredentials(
     return;
   }
 
-  // 2. Browser OAuth sessions (IndexedDB; migrated from legacy localStorage)
+  // 2. Browser OAuth sessions (IndexedDB settings)
   await restoreFromBrowserOAuthStorage(providerKeys, settings, getOAuthProvider);
 }
 

--- a/tests/oauth-storage-security.test.ts
+++ b/tests/oauth-storage-security.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+void test("oauth storage does not call localStorage APIs", async () => {
+  const source = await readFile(new URL("../src/auth/oauth-storage.ts", import.meta.url), "utf8");
+  const localStorageApiPattern = /\blocalStorage\s*\.\s*(?:getItem|setItem|removeItem)\b/u;
+
+  assert.equal(localStorageApiPattern.test(source), false);
+});


### PR DESCRIPTION
## Summary
Closes #62 by removing the legacy OAuth localStorage compatibility path and making IndexedDB settings the only OAuth credential source.

### Changes
- `src/auth/oauth-storage.ts`
  - removed legacy `localStorage` read/migrate fallback in `loadOAuthCredentials()`
  - removed legacy `localStorage.removeItem(...)` cleanup calls from save/clear helpers
  - kept IndexedDB-only behavior (`oauth.<providerId>`)
- `src/auth/restore.ts`
  - updated comments/docs wording to reflect IndexedDB-only OAuth restore
- `docs/security-threat-model.md`
  - updated storage model + token leakage section to reflect IndexedDB-only OAuth credentials
- `docs/upcoming.md`
  - replaced stale #26 localStorage hotspot note with #62 follow-up section
- `tests/oauth-storage-security.test.ts`
  - added regression guard asserting `src/auth/oauth-storage.ts` does not call localStorage APIs
- `package.json`
  - included new test in `test:security`

## Validation
- `npm run check`
- `npm run test:security`
- `npm run build`
