### PR TITLE
feat(compaction): preserve archived history after /compact

### DIFF
--- a/docs/context-management-policy.md
+++ b/docs/context-management-policy.md
@@ -136,6 +136,7 @@ This policy sets clear guardrails so we can improve context quality while preser
   - `qualityCap` = **88%** of context window for ≥128k models, **85%** for ≥200k models
   - soft warning = max(70% of hard trigger, hard trigger − 5% of context window, min margin 2,048 tokens)
   - auto-compaction uses hard trigger; status-bar warnings remain on the existing 40%/60% UX thresholds
+  - summarized slices are persisted in a UI-only `archivedMessages` bucket with a “Show earlier messages” card (excluded from model context)
 
 **Success:** fewer degraded late-thread responses.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint \"*.ts\" \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:fix": "eslint \"*.ts\" \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "test:models": "node --test --experimental-strip-types tests/model-ordering.test.ts",
-    "test:context": "node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/tool-result-shaping.test.ts tests/context-injection.test.ts tests/execution-policy.test.ts tests/with-workbook-coordinator.test.ts tests/compaction-thresholds.test.ts tests/auto-compaction.test.ts",
+    "test:context": "node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/tool-result-shaping.test.ts tests/context-injection.test.ts tests/execution-policy.test.ts tests/with-workbook-coordinator.test.ts tests/compaction-thresholds.test.ts tests/auto-compaction.test.ts tests/archived-history.test.ts",
     "test:security": "node --test --experimental-strip-types tests/proxy-target-policy.test.mjs tests/cors-proxy-server.security.test.mjs tests/extension-source-policy.test.ts tests/marked-safety-policy.test.ts tests/oauth-storage-security.test.ts",
     "validate": "npx office-addin-manifest validate manifest.xml",
     "sideload": "npx office-addin-debugging start manifest.xml desktop --app excel",

--- a/src/messages/archived-history.ts
+++ b/src/messages/archived-history.ts
@@ -1,0 +1,91 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export interface ArchivedMessagesMessage {
+  role: "archivedMessages";
+  archivedMessages: AgentMessage[];
+  archivedChatMessageCount: number;
+  timestamp: number;
+}
+
+declare module "@mariozechner/pi-agent-core" {
+  interface CustomAgentMessages {
+    archivedMessages: ArchivedMessagesMessage;
+  }
+}
+
+function isArchivedMessagesMessage(message: AgentMessage): message is ArchivedMessagesMessage {
+  return message.role === "archivedMessages";
+}
+
+function countChatMessages(messages: readonly AgentMessage[]): number {
+  let count = 0;
+
+  for (const message of messages) {
+    if (
+      message.role === "user" ||
+      message.role === "assistant" ||
+      message.role === "user-with-attachments"
+    ) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+function flattenArchivedPayload(messages: readonly AgentMessage[]): AgentMessage[] {
+  const flattened: AgentMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role === "artifact") {
+      // Artifacts are UI-only and already excluded from MessageList/LLM context.
+      continue;
+    }
+
+    if (isArchivedMessagesMessage(message)) {
+      flattened.push(...flattenArchivedPayload(message.archivedMessages));
+      continue;
+    }
+
+    flattened.push(message);
+  }
+
+  return flattened;
+}
+
+export function splitArchivedMessages(messages: readonly AgentMessage[]): {
+  archivedMessages: AgentMessage[];
+  messagesWithoutArchived: AgentMessage[];
+} {
+  const archivedMessages: AgentMessage[] = [];
+  const messagesWithoutArchived: AgentMessage[] = [];
+
+  for (const message of messages) {
+    if (isArchivedMessagesMessage(message)) {
+      archivedMessages.push(...flattenArchivedPayload(message.archivedMessages));
+      continue;
+    }
+
+    messagesWithoutArchived.push(message);
+  }
+
+  return { archivedMessages, messagesWithoutArchived };
+}
+
+export function createArchivedMessagesMessage(args: {
+  existingArchivedMessages: AgentMessage[];
+  newlyArchivedMessages: AgentMessage[];
+  timestamp: number;
+}): ArchivedMessagesMessage {
+  const archivedMessages = flattenArchivedPayload([
+    ...args.existingArchivedMessages,
+    ...args.newlyArchivedMessages,
+  ]);
+
+  return {
+    role: "archivedMessages",
+    archivedMessages,
+    archivedChatMessageCount: countChatMessages(archivedMessages),
+    timestamp: args.timestamp,
+  };
+}

--- a/src/messages/convert-to-llm.ts
+++ b/src/messages/convert-to-llm.ts
@@ -15,12 +15,21 @@ import { compactionSummaryToUserMessage } from "./compaction.js";
 import { shapeToolResultsForLlm } from "./tool-result-shaping.js";
 
 export function convertToLlm(messages: AgentMessage[]): Message[] {
-  const normalized: AgentMessage[] = messages.map((m) => {
-    if (m.role === "compactionSummary") {
-      return compactionSummaryToUserMessage(m);
+  const normalized: AgentMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role === "archivedMessages") {
+      // UI-only history bucket, never sent to the model.
+      continue;
     }
-    return m;
-  });
+
+    if (message.role === "compactionSummary") {
+      normalized.push(compactionSummaryToUserMessage(message));
+      continue;
+    }
+
+    normalized.push(message);
+  }
 
   const shaped = shapeToolResultsForLlm(normalized);
   return defaultConvertToLlm(shaped);

--- a/src/ui/message-renderers.ts
+++ b/src/ui/message-renderers.ts
@@ -12,9 +12,61 @@ import { registerMessageRenderer } from "@mariozechner/pi-web-ui/dist/components
 import { renderCollapsibleHeader } from "@mariozechner/pi-web-ui/dist/tools/renderer-registry.js";
 
 import type { CompactionSummaryMessage } from "../messages/compaction.js";
+import type { ArchivedMessagesMessage } from "../messages/archived-history.js";
 
 // Ensure <markdown-block> is registered.
 import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
+
+const EMPTY_PENDING_TOOL_CALLS = new Set<string>();
+
+registerMessageRenderer("archivedMessages", {
+  render(message: ArchivedMessagesMessage) {
+    const contentRef = createRef<HTMLDivElement>();
+    const chevronRef = createRef<HTMLElement>();
+
+    const title = html`
+      <span class="pi-tool-card__title">
+        <strong>Show earlier messages</strong>
+        <span class="pi-tool-card__detail-text">${message.archivedChatMessageCount} chat message${message.archivedChatMessageCount === 1 ? "" : "s"}</span>
+      </span>
+    `;
+
+    return html`
+      <div class="px-4">
+        <div class="pi-tool-card" data-state="complete" data-tool-name="archive_history">
+          <div class="pi-tool-card__header">
+            ${renderCollapsibleHeader("complete", Archive, title, contentRef, chevronRef, false)}
+          </div>
+
+          <div
+            ${ref(contentRef)}
+            class="pi-tool-card__body overflow-hidden transition-all duration-300 max-h-0"
+          >
+            <div class="pi-tool-card__inner">
+              <div class="pi-tool-card__detail">
+                <span class="pi-tool-card__tool-id">archive</span>
+              </div>
+
+              <div class="pi-tool-card__section">
+                <div class="pi-tool-card__section-label">Archived history (UI only)</div>
+                ${message.archivedMessages.length === 0
+                  ? html`<div class="pi-tool-card__plain-text">(no archived messages)</div>`
+                  : html`
+                    <message-list
+                      .messages=${message.archivedMessages}
+                      .tools=${[]}
+                      .pendingToolCalls=${EMPTY_PENDING_TOOL_CALLS}
+                      .isStreaming=${false}
+                    ></message-list>
+                  `}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  },
+});
 
 registerMessageRenderer("compactionSummary", {
   render(message: CompactionSummaryMessage) {

--- a/tests/archived-history.test.ts
+++ b/tests/archived-history.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
+
+import {
+  createArchivedMessagesMessage,
+  splitArchivedMessages,
+} from "../src/messages/archived-history.ts";
+import { createCompactionSummaryMessage } from "../src/messages/compaction.ts";
+
+function createUser(text: string, timestamp: number): UserMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp,
+  };
+}
+
+function createToolResult(text: string, timestamp: number): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: `tc-${timestamp}`,
+    toolName: "read_range",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp,
+  };
+}
+
+void test("splitArchivedMessages removes archive wrapper and preserves active messages", () => {
+  const archive = createArchivedMessagesMessage({
+    existingArchivedMessages: [],
+    newlyArchivedMessages: [
+      createUser("old user", 1),
+      createToolResult("old tool", 2),
+    ],
+    timestamp: 10,
+  });
+
+  const compactionSummary = createCompactionSummaryMessage({
+    summary: "summary",
+    messageCountBefore: 2,
+    timestamp: 11,
+  });
+
+  const activeUser = createUser("new user", 12);
+
+  const split = splitArchivedMessages([archive, compactionSummary, activeUser]);
+
+  assert.equal(split.archivedMessages.length, 2);
+  assert.equal(split.messagesWithoutArchived.length, 2);
+  assert.equal(split.messagesWithoutArchived[0]?.role, "compactionSummary");
+  assert.equal(split.messagesWithoutArchived[1]?.role, "user");
+});
+
+void test("createArchivedMessagesMessage flattens nested archived payloads", () => {
+  const nestedArchive = createArchivedMessagesMessage({
+    existingArchivedMessages: [],
+    newlyArchivedMessages: [createUser("nested", 1)],
+    timestamp: 2,
+  });
+
+  const existingArchivedMessages: AgentMessage[] = [nestedArchive];
+
+  const merged = createArchivedMessagesMessage({
+    existingArchivedMessages,
+    newlyArchivedMessages: [createUser("fresh", 3), createToolResult("tool", 4)],
+    timestamp: 5,
+  });
+
+  assert.equal(merged.archivedMessages.length, 3);
+  assert.equal(merged.archivedMessages.some((m) => m.role === "archivedMessages"), false);
+  assert.equal(merged.archivedChatMessageCount, 2);
+});


### PR DESCRIPTION
## Summary

Closes #41 by preserving compacted chat history for users while keeping model context lean.

### What changed

1. Added a new UI-only message type: `archivedMessages`
   - `src/messages/archived-history.ts`
   - stores archived `AgentMessage[]`
   - stores `archivedChatMessageCount`
   - supports flattening nested archives and filtering wrappers

2. `/compact` now archives summarized slices instead of dropping them from UI
   - `src/commands/builtins/export.ts`
   - pulls existing archived payload from state
   - computes new summarized slice
   - writes back:
     - `archivedMessages`
     - `compactionSummary`
     - kept tail

3. Added archived-history renderer with a “Show earlier messages” card
   - `src/ui/message-renderers.ts`
   - collapsed by default
   - expands to render archived content via `<message-list>`
   - preserves tool call/result pairing inside archived history

4. Ensured archived history is never sent to the model
   - `src/messages/convert-to-llm.ts`
   - explicitly skips `archivedMessages`

5. Added tests
   - `tests/archived-history.test.ts`
   - `test:context` script includes this new test

6. Updated policy doc
   - `docs/context-management-policy.md`
   - documents that summarized slices are persisted as UI-only archived history

## Acceptance criteria mapping (Issue #41)

- ✅ UI offers “Show earlier messages” after compaction (`archivedMessages` card)
- ✅ archived history excluded from LLM context (`convertToLlm` skips role)
- ✅ tool call/result pairing preserved (rendered through `message-list` with native pairing)

## Validation

- `npm run check`
- `npm run build`
- `npm run test:models`
- `npm run test:context`
