### PR TITLE
test(taskpane): validate compaction action queue ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint \"*.ts\" \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:fix": "eslint \"*.ts\" \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "test:models": "node --test --experimental-strip-types tests/model-ordering.test.ts",
-    "test:context": "node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/tool-result-shaping.test.ts tests/context-injection.test.ts tests/execution-policy.test.ts tests/with-workbook-coordinator.test.ts tests/compaction-thresholds.test.ts tests/auto-compaction.test.ts tests/archived-history.test.ts",
+    "test:context": "node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/tool-result-shaping.test.ts tests/context-injection.test.ts tests/execution-policy.test.ts tests/with-workbook-coordinator.test.ts tests/compaction-thresholds.test.ts tests/auto-compaction.test.ts tests/archived-history.test.ts tests/action-queue.test.ts",
     "test:security": "node --test --experimental-strip-types tests/proxy-target-policy.test.mjs tests/cors-proxy-server.security.test.mjs tests/extension-source-policy.test.ts tests/marked-safety-policy.test.ts tests/oauth-storage-security.test.ts",
     "validate": "npx office-addin-manifest validate manifest.xml",
     "sideload": "npx office-addin-debugging start manifest.xml desktop --app excel",

--- a/src/taskpane/action-queue.ts
+++ b/src/taskpane/action-queue.ts
@@ -9,8 +9,6 @@
 
 import type { Agent } from "@mariozechner/pi-agent-core";
 
-import type { QueueDisplay } from "./queue-display.js";
-import type { PiSidebar } from "../ui/pi-sidebar.js";
 import { commandRegistry } from "../commands/types.js";
 import { maybeAutoCompactBeforePrompt } from "../compaction/auto-compaction.js";
 
@@ -25,10 +23,18 @@ export interface ActionQueue {
   shutdown: () => void;
 }
 
+interface ActionQueueDisplay {
+  setActionQueue: (items: Array<{ type: "prompt" | "command"; label: string; text: string }>) => void;
+}
+
+interface BusyIndicatorHost {
+  setBusyIndicator: (label: string | null, hint?: string | null) => void;
+}
+
 export function createActionQueue(opts: {
   agent: Agent;
-  sidebar: PiSidebar;
-  queueDisplay: QueueDisplay;
+  sidebar: BusyIndicatorHost;
+  queueDisplay: ActionQueueDisplay;
   autoCompactEnabled: boolean;
 }): ActionQueue {
   const { agent, sidebar, queueDisplay, autoCompactEnabled } = opts;

--- a/tests/action-queue.test.ts
+++ b/tests/action-queue.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { Agent, type AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ImageContent } from "@mariozechner/pi-ai";
+
+import { commandRegistry, type SlashCommand } from "../src/commands/types.ts";
+import { createActionQueue } from "../src/taskpane/action-queue.ts";
+
+class TestAgent extends Agent {
+  promptCalls: string[] = [];
+  waitForIdleCalls = 0;
+  onPrompt?: (text: string) => void;
+
+  constructor() {
+    super({
+      initialState: {
+        messages: [],
+        tools: [],
+      },
+    });
+  }
+
+  override waitForIdle(): Promise<void> {
+    this.waitForIdleCalls += 1;
+    return Promise.resolve();
+  }
+
+  override prompt(message: AgentMessage | AgentMessage[]): Promise<void>;
+  override prompt(input: string, images?: ImageContent[]): Promise<void>;
+  override prompt(
+    input: string | AgentMessage | AgentMessage[],
+    _images?: ImageContent[],
+  ): Promise<void> {
+    if (typeof input === "string") {
+      this.promptCalls.push(input);
+      this.onPrompt?.(input);
+    }
+
+    return Promise.resolve();
+  }
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolvePromise: (() => void) | undefined;
+
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: () => {
+      resolvePromise?.();
+    },
+  };
+}
+
+async function waitForCondition(predicate: () => boolean, timeoutMs = 1500): Promise<void> {
+  const start = Date.now();
+
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 5);
+    });
+  }
+}
+
+async function withRegisteredCommand(command: SlashCommand, run: () => Promise<void>): Promise<void> {
+  const previous = commandRegistry.get(command.name);
+  commandRegistry.register(command);
+
+  try {
+    await run();
+  } finally {
+    if (previous) {
+      commandRegistry.register(previous);
+    } else {
+      commandRegistry.unregister(command.name);
+    }
+  }
+}
+
+function createUserMessage(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp,
+  };
+}
+
+void test("queued prompt survives compact replaceMessages and runs after compact", async () => {
+  const agent = new TestAgent();
+  const compactGate = createDeferred();
+  const compactStarted = createDeferred();
+  const compactFinished = createDeferred();
+
+  const executionOrder: string[] = [];
+  const busyIndicators: Array<{ label: string | null; hint: string | null }> = [];
+  const queueSnapshots: Array<Array<{ type: "prompt" | "command"; label: string; text: string }>> = [];
+
+  await withRegisteredCommand(
+    {
+      name: "compact",
+      description: "compact",
+      source: "builtin",
+      execute: async () => {
+        executionOrder.push("compact:start");
+        compactStarted.resolve();
+
+        await compactGate.promise;
+
+        // Simulate compaction replacing message history while a prompt is queued.
+        agent.replaceMessages([
+          createUserMessage("compaction summary", Date.now()),
+        ]);
+
+        executionOrder.push("compact:end");
+        compactFinished.resolve();
+      },
+    },
+    async () => {
+      const queue = createActionQueue({
+        agent,
+        autoCompactEnabled: false,
+        sidebar: {
+          setBusyIndicator: (label, hint) => {
+            busyIndicators.push({ label, hint: hint ?? null });
+          },
+        },
+        queueDisplay: {
+          setActionQueue: (items) => {
+            queueSnapshots.push(items.map((item) => ({ ...item })));
+          },
+        },
+      });
+
+      agent.onPrompt = (text) => {
+        executionOrder.push(`prompt:${text}`);
+      };
+
+      queue.enqueueCommand("compact", "");
+
+      await compactStarted.promise;
+      assert.equal(queue.isBusy(), true);
+
+      queue.enqueuePrompt("after compact");
+
+      compactGate.resolve();
+
+      await compactFinished.promise;
+      await waitForCondition(() => agent.promptCalls.length === 1 && !queue.isBusy());
+
+      assert.deepEqual(agent.promptCalls, ["after compact"]);
+      assert.deepEqual(executionOrder, [
+        "compact:start",
+        "compact:end",
+        "prompt:after compact",
+      ]);
+
+      assert.equal(busyIndicators[0]?.label, "Compacting context…");
+      assert.equal(
+        busyIndicators[0]?.hint,
+        "Send messages and Pi will see them after compaction",
+      );
+      assert.equal(busyIndicators[busyIndicators.length - 1]?.label, null);
+
+      const queuedPromptWasShown = queueSnapshots.some((snapshot) =>
+        snapshot.some((item) => item.type === "prompt" && item.text === "after compact")
+      );
+      assert.equal(queuedPromptWasShown, true);
+
+      queue.shutdown();
+    },
+  );
+});
+
+void test("ordered queue runs compact, prompt, then compact", async () => {
+  const agent = new TestAgent();
+  const compactRuns: Array<{ start: ReturnType<typeof createDeferred>; gate: ReturnType<typeof createDeferred> }> = [
+    { start: createDeferred(), gate: createDeferred() },
+    { start: createDeferred(), gate: createDeferred() },
+  ];
+
+  let compactRunIndex = 0;
+  const executionOrder: string[] = [];
+
+  await withRegisteredCommand(
+    {
+      name: "compact",
+      description: "compact",
+      source: "builtin",
+      execute: async () => {
+        const current = compactRunIndex;
+        compactRunIndex += 1;
+
+        executionOrder.push(`compact:${current + 1}:start`);
+        compactRuns[current]?.start.resolve();
+        await compactRuns[current]?.gate.promise;
+        executionOrder.push(`compact:${current + 1}:end`);
+      },
+    },
+    async () => {
+      const queue = createActionQueue({
+        agent,
+        autoCompactEnabled: false,
+        sidebar: {
+          setBusyIndicator: () => {
+            // not needed in this test
+          },
+        },
+        queueDisplay: {
+          setActionQueue: () => {
+            // not needed in this test
+          },
+        },
+      });
+
+      agent.onPrompt = (text) => {
+        executionOrder.push(`prompt:${text}`);
+      };
+
+      queue.enqueueCommand("compact", "");
+      queue.enqueuePrompt("middle prompt");
+      queue.enqueueCommand("compact", "");
+
+      await compactRuns[0].start.promise;
+      compactRuns[0].gate.resolve();
+
+      await waitForCondition(() => agent.promptCalls.includes("middle prompt"));
+      await compactRuns[1].start.promise;
+      compactRuns[1].gate.resolve();
+
+      await waitForCondition(() => !queue.isBusy());
+
+      assert.deepEqual(executionOrder, [
+        "compact:1:start",
+        "compact:1:end",
+        "prompt:middle prompt",
+        "compact:2:start",
+        "compact:2:end",
+      ]);
+
+      queue.shutdown();
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Closes #40 by hardening and validating the compaction queue UX that is already implemented in runtime wiring.

This PR focuses on regression coverage for queue ordering and compaction busy state, plus a small typing cleanup to keep `action-queue` easy to test.

## What changed

1. Added focused action-queue tests
   - `tests/action-queue.test.ts`
   - covers:
     - prompt queued while `/compact` is in-flight is not dropped and runs after compaction
     - queued prompt survives `agent.replaceMessages(...)` (compaction rewrite path)
     - strict ordered execution: `/compact` -> prompt -> `/compact`
     - compacting indicator lifecycle (`Compacting context…` set/cleared)

2. Kept `action-queue` API strict but testable
   - `src/taskpane/action-queue.ts`
   - replaced concrete UI class types with narrow interfaces for dependencies:
     - `BusyIndicatorHost`
     - `ActionQueueDisplay`
   - no runtime behavior change

3. Included the new test in context test gate
   - `package.json` (`test:context`)

## Acceptance criteria mapping (#40)

- ✅ Enter prompt after triggering `/compact` is queued and runs after compact finishes (covered by test)
- ✅ Ordered sequences including `/compact` are processed strictly in order (covered by test)
- ✅ No queued prompt is dropped when compaction rewrites messages (`replaceMessages`) (covered by test)
- ✅ Compaction progress indicator is shown/cleared around compaction execution (covered by test)

## Validation

- `npm run check`
- `npm run build`
- `npm run test:models`
- `npm run test:context`
- `npm run test:security`
