### PR TITLE
chore(dependabot): ignore eslint major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-minor-and-patch:
         patterns:


### PR DESCRIPTION
## Summary
- ignore semver-major updates for `eslint` in Dependabot
- keep minor/patch npm group behavior unchanged

## Why
`typescript-eslint@8.55.0` currently peers on ESLint 8/9 only, so ESLint 10 bumps fail CI at `npm ci`.

## Follow-up
Re-enable ESLint major updates once `typescript-eslint` supports ESLint 10.
