### PR TITLE
feat(experimental): add tmux bridge token command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Type `/` in the message input to see all commands:
 Experimental examples:
 - `/experimental on tmux-bridge`
 - `/experimental tmux-bridge-url https://localhost:3337`
+- `/experimental tmux-bridge-token <token>`
 - `/experimental tmux-bridge-url clear`
+- `/experimental tmux-bridge-token clear`
 
 ## Keyboard Shortcuts
 
@@ -265,6 +267,8 @@ Then enable and configure in the add-in:
 ```bash
 /experimental on tmux-bridge
 /experimental tmux-bridge-url https://localhost:3337
+# optional, if bridge requires bearer auth
+/experimental tmux-bridge-token <token>
 ```
 
 Bridge endpoints:
@@ -323,6 +327,7 @@ See full request/response contract: [`docs/tmux-bridge-contract.md`](./docs/tmux
 - [x] Humanized tool card inputs/outputs (color names, format labels)
 - [x] Blueprint invalidation after structural changes
 - [x] UI polish: queue layout, thinking/tool card styling, case-insensitive model search
+- [x] Experimental tmux bridge: `/experimental` feature flags + local helper + gated `tmux` tool ([#3](https://github.com/tmustier/pi-for-excel/issues/3))
 
 ### Up next
 - [ ] New tools: charts, tables, data validation ([#18](https://github.com/tmustier/pi-for-excel/issues/18))
@@ -337,7 +342,6 @@ See full request/response contract: [`docs/tmux-bridge-contract.md`](./docs/tmux
 ### Future
 - [ ] Production CORS solution ([#4](https://github.com/tmustier/pi-for-excel/issues/4)) — service worker or hosted relay
 - [ ] Distribution: non-technical install ([#16](https://github.com/tmustier/pi-for-excel/issues/16)) — hosted build + production manifest
-- [ ] Tmux tool via local bridge ([#3](https://github.com/tmustier/pi-for-excel/issues/3)) — terminal access from the add-in
 - [ ] Python code execution via Pyodide
 - [ ] SpreadsheetBench evaluation (target >43%)
 - [ ] Per-workbook instructions (like AGENTS.md)

--- a/docs/tmux-bridge-contract.md
+++ b/docs/tmux-bridge-contract.md
@@ -41,8 +41,13 @@ Optional auth token:
 TMUX_BRIDGE_TOKEN=your-secret npm run tmux:bridge:https
 ```
 
-And store the same token for the tool adapter:
-- setting key: `tmux.bridge.token`
+Store the same token for the tool adapter:
+
+```bash
+/experimental tmux-bridge-token <token>
+```
+
+(setting key: `tmux.bridge.token`)
 
 ## Endpoints
 

--- a/src/commands/builtins/experimental-overlay.ts
+++ b/src/commands/builtins/experimental-overlay.ts
@@ -128,7 +128,7 @@ export function showExperimentalDialog(): void {
   const footer = document.createElement("p");
   footer.style.cssText = "font-size: 11px; color: var(--muted-foreground); margin: 12px 0 0; font-family: var(--font-sans);";
   footer.textContent =
-    "Tip: use /experimental on <feature>, /experimental off <feature>, /experimental toggle <feature>, or /experimental tmux-bridge-url <url>.";
+    "Tip: use /experimental on <feature>, /experimental off <feature>, /experimental toggle <feature>, /experimental tmux-bridge-url <url>, or /experimental tmux-bridge-token <token>.";
 
   const closeBtn = document.createElement("button");
   closeBtn.type = "button";

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -127,5 +127,5 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
   - `capture_pane`
   - `send_and_capture`
   - `kill_session`
-- **Security posture:** local opt-in only; bridge URL validated via `validateOfficeProxyUrl`; tool execution re-checks gate before every call; bridge enforces loopback+origin checks and optional bearer token.
+- **Security posture:** local opt-in only; bridge URL validated via `validateOfficeProxyUrl`; tool execution re-checks gate before every call; bridge enforces loopback+origin checks and optional bearer token (`TMUX_BRIDGE_TOKEN` / setting `tmux.bridge.token`, managed via `/experimental tmux-bridge-token ...`).
 - **Rationale:** stable local adapter contract now (issue #3) with safe stub-first rollout and incremental hardening.


### PR DESCRIPTION
## Summary

Adds token management for the experimental tmux bridge through `/experimental`.

### What’s included
- Add `/experimental tmux-bridge-token` command support:
  - `/experimental tmux-bridge-token <token>`
  - `/experimental tmux-bridge-token show`
  - `/experimental tmux-bridge-token clear`
- Add aliases:
  - `/experimental tmux-token ...`
  - `/experimental bridge-token ...`
- Store token in setting key `tmux.bridge.token`
- Trigger runtime tool refresh on token set/clear via experimental tool-config change event
- Mask token in toast output (avoid echoing raw token)
- Add token validation (non-empty, no whitespace, bounded length)

## Docs updates
- README command examples and tmux bridge setup now include token command usage
- tmux bridge contract docs now show token command setup flow
- tool decisions doc notes token configuration path

## Tests
- Extended `tests/experimental-command.test.ts` with token command coverage:
  - show (masked)
  - set
  - clear
  - validation errors

Ran:
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/experimental-command.test.ts`

Related: #3
