### PR TITLE
docs(extensions): add MVP extension authoring guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Type `/` in the message input to see all commands:
 | `/login` | Add/change/disconnect API keys and OAuth providers |
 | `/settings` | Open settings dialog |
 | `/experimental` | Manage experimental feature flags |
+| `/extensions` | Open the extensions manager |
 | `/shortcuts` | Show keyboard shortcuts |
 | `/compact` | Summarize conversation to free context |
 | `/copy` | Copy last response to clipboard |
@@ -282,10 +283,11 @@ See full request/response contract: [`docs/tmux-bridge-contract.md`](./docs/tmux
 
 ### Extension loading safety
 
-`loadExtension()` now blocks remote `http(s)` module URLs by default.
+`loadExtension()` blocks remote `http(s)` module URLs by default.
 
-- Allowed by default: local module specifiers (`./`, `../`, `/`) and inline function activators
+- Allowed by default: local module specifiers (`./`, `../`, `/`) and blob URLs (used by pasted-code installs)
 - Blocked by default: remote extension URLs
+- Local specifiers must resolve to bundled extension modules (currently `src/extensions/*.{ts,js}`)
 - Temporary unsafe opt-in for local experiments:
 
 ```bash
@@ -293,6 +295,8 @@ See full request/response contract: [`docs/tmux-bridge-contract.md`](./docs/tmux
 ```
 
   (Equivalent low-level toggle: `localStorage.setItem("pi.allowRemoteExtensionUrls", "1")`)
+
+See also: [`docs/extensions.md`](./docs/extensions.md).
 
 ## Roadmap
 
@@ -340,7 +344,7 @@ See full request/response contract: [`docs/tmux-bridge-contract.md`](./docs/tmux
 - [ ] Auto-compaction ([#20](https://github.com/tmustier/pi-for-excel/issues/20)) — context window budget management for long conversations
 - [ ] Change approval UI ([#6](https://github.com/tmustier/pi-for-excel/issues/6)) — structured approval flow for overwrites
 - [ ] Header bar UX ([#12](https://github.com/tmustier/pi-for-excel/issues/12)) — session switcher, workbook indicator
-- [ ] Extension API build-out ([#13](https://github.com/tmustier/pi-for-excel/issues/13)) — dynamic loading, tool registration, sandboxing
+- [ ] Extension platform follow-ups ([#13](https://github.com/tmustier/pi-for-excel/issues/13)) — sandbox/permissions, widget API evolution, docs polish
 
 ### Future
 - [ ] Production CORS solution ([#4](https://github.com/tmustier/pi-for-excel/issues/4)) — service worker or hosted relay

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Short, topic-based docs (mirrors Pi's layout). Keep deeper decisions close to th
 - [Upcoming (open issues digest)](./upcoming.md)
 - [Model/dependency update playbook](./model-updates.md)
 - [UI architecture](../src/ui/README.md) — layout, styling, the `@layer` gotcha
+- [Extensions authoring guide (MVP)](./extensions.md)
 
 ## Tools
 - [Tool behavior decisions](../src/tools/DECISIONS.md)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,154 @@
+# Extensions (MVP authoring guide)
+
+Pi for Excel supports runtime extensions that can register slash commands, register tools, and render small UI elements in the sidebar.
+
+> Status: MVP. Extensions currently run in the same taskpane context (no sandbox/permission boundary yet).
+
+## Quick start
+
+1. Open the manager with:
+   - `/extensions`
+2. Install one of:
+   - **Pasted code** (recommended for quick prototypes)
+   - **URL module** (requires explicit unsafe opt-in)
+3. Enable/disable/reload/uninstall from the same manager.
+
+## Install source types
+
+| Source | How to use | Default policy |
+|---|---|---|
+| Local module specifier | Built-ins/programmatic installs (not currently exposed in `/extensions` UI) | ✅ allowed |
+| Blob URL (pasted code) | `/extensions` → install code (stored in settings, loaded via blob URL + dynamic import) | ✅ allowed |
+| Remote HTTP(S) URL | `/extensions` → install URL | ❌ blocked by default |
+
+Enable remote URLs only if you trust the code source:
+
+```txt
+/experimental on remote-extension-urls
+```
+
+## Module contract
+
+An extension module must export `activate(api)` (named export or default export).
+
+```ts
+export function activate(api) {
+  // register commands/tools/UI
+}
+```
+
+Optional cleanup hooks:
+
+- `activate(api)` may return:
+  - `void`
+  - a cleanup function
+  - an array of cleanup functions
+- Module may also export `deactivate()`
+
+On disable/reload/uninstall, Pi runs cleanup functions (reverse order), then `deactivate()`.
+
+## API surface (`ExcelExtensionAPI`)
+
+### `registerCommand(name, { description, handler })`
+Registers a slash command.
+
+### `registerTool(name, toolDef)`
+Registers an agent-callable tool.
+
+Notes:
+- `parameters` should be a JSON-schema/TypeBox-compatible object.
+- Tool names must not conflict with core built-in tools.
+- Tool names must be unique across enabled extensions.
+
+### `agent`
+Access the active `Agent` instance.
+
+### `onAgentEvent(handler)`
+Subscribe to runtime events (returns unsubscribe function).
+
+### `overlay.show(el)` / `overlay.dismiss()`
+Show or dismiss a full-screen overlay.
+
+### `widget.show(el)` / `widget.dismiss()`
+Show or dismiss an inline widget slot above the input area.
+
+### `toast(message)`
+Show a short toast notification.
+
+## Example extension
+
+```ts
+export function activate(api) {
+  api.registerCommand("hello_ext", {
+    description: "Say hello from extension",
+    handler: () => {
+      api.toast("Hello from extension 👋");
+    },
+  });
+
+  const schema = {
+    type: "object",
+    properties: {
+      text: { type: "string", description: "Text to echo" },
+    },
+    required: ["text"],
+    additionalProperties: false,
+  };
+
+  api.registerTool("echo_text", {
+    description: "Echo text back",
+    parameters: schema,
+    async execute(params) {
+      const text = typeof params.text === "string" ? params.text : "";
+      return {
+        content: [{ type: "text", text: `Echo: ${text}` }],
+        details: { length: text.length },
+      };
+    },
+  });
+
+  const onTurnEnd = api.onAgentEvent((ev) => {
+    if (ev.type === "turn_end") {
+      // optional event handling
+    }
+  });
+
+  return () => {
+    onTurnEnd();
+    api.widget.dismiss();
+    api.overlay.dismiss();
+  };
+}
+```
+
+## Local module authoring (repo contributors)
+
+Local module specifiers are used for built-ins (for example the seeded Snake extension).
+
+For built-in/repo extensions:
+
+1. Add a file under `src/extensions/*.ts`
+2. Export `activate(api)`
+3. Register/load it through app/runtime wiring (the `/extensions` UI currently exposes URL + pasted-code installs)
+
+Production builds only bundle local extension modules matched by `src/extensions/*.{ts,js}`.
+If a local specifier is not bundled, loading fails with a clear error.
+
+## Troubleshooting
+
+- **"Extension module \"...\" must export an activate(api) function"**
+  - Missing/invalid export.
+- **"Remote extension URL imports are disabled by default"**
+  - Enable with `/experimental on remote-extension-urls`.
+- **"Local extension module \"...\" was not bundled"**
+  - Local module path is outside bundled extension files.
+- **Command/tool already registered**
+  - Name conflicts with built-in or another extension.
+- **Cleanup failure during disable/reload**
+  - Check extension cleanup functions and optional `deactivate()`.
+
+## Security notes (important)
+
+- Extensions can read/write workbook data through registered tools and host APIs.
+- Remote URL loading is intentionally off by default.
+- There is no hard sandbox boundary in MVP; only run trusted extension code.

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -204,9 +204,14 @@ https://github.com/tmustier/pi-for-excel/issues/19
 ### #13 — Extensions API: design & build-out
 https://github.com/tmustier/pi-for-excel/issues/13
 
-**What it’s asking:** extension manager UI + dynamic loading + (critically) allow extensions to register tools.
+**Status note:** MVP is now shipped (extension manager UI, dynamic loading, persisted registry, extension tool registration, lifecycle cleanup).
 
-**Implication:** this is a strong argument for:
+**Remaining tracked follow-ups:**
+- #79 — sandbox + permissions model
+- #80 — widget API evolution
+- #81 — extension authoring docs
+
+**Implication:** keep extension architecture additive while we harden:
 - a centralized tool registry that can be extended dynamically
 - a clear permission model + lifecycle hooks
 


### PR DESCRIPTION
## Summary
- add a new `docs/extensions.md` guide for MVP extension authoring
- document module contract (`activate`, cleanup return values, optional `deactivate`)
- document extension source types and remote URL opt-in flow
- add API surface + example extension snippet (`registerCommand`, `registerTool`, `onAgentEvent`, UI helpers)
- link the guide from `docs/README.md` and `README.md`
- update roadmap/upcoming wording to reflect post-#77 extension follow-up scope

## Validation
- `npm run check`

Closes #81
Refs #13
