### PR TITLE
fix(ui): prevent Esc from interrupting agent when overlay is open

### DIFF
--- a/src/commands/builtins/overlays.ts
+++ b/src/commands/builtins/overlays.ts
@@ -344,7 +344,7 @@ export function showShortcutsDialog(): void {
   const shortcuts = [
     ["Enter", "Send message"],
     ["Shift+Tab", "Cycle thinking level"],
-    ["Esc", "Abort agent / dismiss menu"],
+    ["Esc", "Dismiss menu/dialog (or abort if none open)"],
     ["Enter (streaming)", "Steer — redirect agent"],
     ["⌥Enter", "Queue follow-up message"],
     ["/", "Open command menu"],

--- a/src/ui/pi-input.ts
+++ b/src/ui/pi-input.ts
@@ -12,6 +12,8 @@
 import { html, LitElement } from "lit";
 import { customElement, property, state, query } from "lit/decorators.js";
 
+import { doesOverlayClaimEscape } from "../utils/escape-guard.js";
+
 const PLACEHOLDER_HINTS = [
   "Tell Pi what to build…",
   "Type / for commands…",
@@ -68,6 +70,7 @@ export class PiInput extends LitElement {
       return;
     }
     if (e.key === "Escape" && this.isStreaming) {
+      if (doesOverlayClaimEscape(e.target)) return;
       e.preventDefault();
       this.dispatchEvent(new CustomEvent("pi-abort", { bubbles: true }));
     }

--- a/src/utils/escape-guard.ts
+++ b/src/utils/escape-guard.ts
@@ -1,0 +1,79 @@
+/**
+ * Escape-key guard helpers.
+ *
+ * When transient UI (menus, popovers, dialogs, overlays) is open,
+ * Esc should dismiss that UI instead of aborting the active agent turn.
+ */
+
+const ESCAPE_OWNER_SELECTORS = [
+  ".pi-welcome-overlay",
+  ".pi-utilities-menu",
+  ".pi-status-popover",
+  "#pi-command-menu",
+  "agent-model-selector",
+  "agent-settings-dialog",
+  "api-key-prompt-dialog",
+  "agent-api-key-dialog",
+] as const;
+
+function isElementTarget(value: EventTarget): value is Element {
+  return typeof Element !== "undefined" && value instanceof Element;
+}
+
+function isNodeTarget(value: EventTarget): value is Node {
+  return typeof Node !== "undefined" && value instanceof Node;
+}
+
+function isHTMLElementNode(value: Element): value is HTMLElement {
+  return typeof HTMLElement !== "undefined" && value instanceof HTMLElement;
+}
+
+function isElementVisible(element: Element): boolean {
+  if (isHTMLElementNode(element) && element.hidden) {
+    return false;
+  }
+
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  const style = window.getComputedStyle(element);
+  if (style.display === "none") return false;
+  if (style.visibility === "hidden") return false;
+
+  return true;
+}
+
+function getTargetElement(target: EventTarget | null | undefined): Element | null {
+  if (!target) return null;
+  if (isElementTarget(target)) return target;
+  if (isNodeTarget(target)) return target.parentElement;
+  return null;
+}
+
+function hasVisibleMatches(selector: string): boolean {
+  const matches = document.querySelectorAll(selector);
+  for (const match of matches) {
+    if (isElementVisible(match)) return true;
+  }
+  return false;
+}
+
+export function doesOverlayClaimEscape(target?: EventTarget | null): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const targetElement = getTargetElement(target ?? null);
+  if (targetElement) {
+    for (const selector of ESCAPE_OWNER_SELECTORS) {
+      if (targetElement.closest(selector)) return true;
+    }
+  }
+
+  for (const selector of ESCAPE_OWNER_SELECTORS) {
+    if (hasVisibleMatches(selector)) return true;
+  }
+
+  return false;
+}

--- a/tests/session-restore-selection.test.ts
+++ b/tests/session-restore-selection.test.ts
@@ -5,7 +5,10 @@ import {
   getCrossWorkbookResumeConfirmMessage,
   getResumeTargetLabel,
 } from "../src/commands/builtins/resume-target.ts";
-import { isReopenLastClosedShortcut } from "../src/taskpane/keyboard-shortcuts.ts";
+import {
+  isReopenLastClosedShortcut,
+  shouldAbortFromEscape,
+} from "../src/taskpane/keyboard-shortcuts.ts";
 import { RecentlyClosedStack } from "../src/taskpane/recently-closed.ts";
 import {
   getRestoreCandidateSessionIds,
@@ -144,6 +147,35 @@ void test("Cmd/Ctrl+Shift+T detection ignores Alt-modified chords", () => {
       ctrlKey: false,
       shiftKey: true,
       altKey: true,
+    }),
+    false,
+  );
+});
+
+void test("Escape abort is suppressed when overlay UI claims Escape", () => {
+  assert.equal(
+    shouldAbortFromEscape({
+      isStreaming: true,
+      hasAgent: true,
+      escapeClaimedByOverlay: true,
+    }),
+    false,
+  );
+
+  assert.equal(
+    shouldAbortFromEscape({
+      isStreaming: true,
+      hasAgent: true,
+      escapeClaimedByOverlay: false,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldAbortFromEscape({
+      isStreaming: false,
+      hasAgent: true,
+      escapeClaimedByOverlay: false,
     }),
     false,
   );


### PR DESCRIPTION
## Summary
- prevent global `Esc` abort from firing when an overlay/menu/dialog is open
- add shared escape guard logic in `src/utils/escape-guard.ts`
- gate `Esc` abort handling in:
  - `src/taskpane/keyboard-shortcuts.ts`
  - `src/ui/pi-input.ts`
- update shortcuts help text to reflect new behavior
- add regression coverage for escape-abort gating in `tests/session-restore-selection.test.ts`

## Validation
- `npm run check`
- `npm run build`
- `npm run test:context`
