### PR TITLE
feat(audit): cover remaining workbook-mutating tool paths

### DIFF
--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -77,14 +77,18 @@ Resolved outcome:
 ### #28 — Auditability: diff view + audit log for agent changes
 https://github.com/tmustier/pi-for-excel/issues/28
 
-**What it’s asking:** record before/after for mutating operations, render diffs in tool cards, export audit log.
+**Status:** closed (2026-02-12).
 
-**Status note:** first slice is now in place for `write_cells`, `fill_formula`, and `python_transform_range`:
-- tools compute structured cell-level before/after summaries (`details.changes`)
-- tool cards render a compact **Changes** diff table with clickable cell links
-- local audit entries are persisted to `workbook.change-audit.v1`
+Delivered for this phase:
+- structured mutation diffs for core cell-write paths (`write_cells`, `fill_formula`, `python_transform_range`)
+- compact in-card **Changes** rendering with clickable cell links
+- persisted workbook mutation audit log (`workbook.change-audit.v1`)
+- expanded operation-level audit coverage for formatting/structure/comment/view/history-restore mutation paths
+- JSON export via `/export audit` (download) and `/export audit clipboard`
 
-**Remaining follow-up:** broaden coverage to other mutating tools + add export/history UX on top of the persisted audit log.
+**Follow-up tracking:**
+- #100 — complete remaining workbook-mutating audit coverage alignment
+- #101 — optional “Explain these changes” UX
 
 ---
 

--- a/src/audit/workbook-change-audit.ts
+++ b/src/audit/workbook-change-audit.ts
@@ -15,7 +15,10 @@ export type WorkbookAuditToolName =
   | "python_transform_range"
   | "format_cells"
   | "conditional_format"
-  | "modify_structure";
+  | "modify_structure"
+  | "comments"
+  | "view_settings"
+  | "workbook_history";
 
 export interface WorkbookChangeAuditEntry {
   id: string;
@@ -106,7 +109,10 @@ function isWorkbookAuditToolName(value: unknown): value is WorkbookAuditToolName
     value === "python_transform_range" ||
     value === "format_cells" ||
     value === "conditional_format" ||
-    value === "modify_structure"
+    value === "modify_structure" ||
+    value === "comments" ||
+    value === "view_settings" ||
+    value === "workbook_history"
   );
 }
 

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -190,7 +190,7 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
 - **Context efficiency:**
   - diff samples are intentionally bounded (default sample limit = 12 changed cells)
   - `write_cells` verification output shows a bounded preview for large writes instead of dumping full tables
-- **Audit coverage extension:** `format_cells`, `conditional_format`, and `modify_structure` now also append structured entries to `workbook.change-audit.v1` (operation-focused summaries, not per-cell value diffs).
+- **Audit coverage extension:** `format_cells`, `conditional_format`, `modify_structure`, mutating `comments` actions, mutating `view_settings` actions, and `workbook_history` restore now append structured entries to `workbook.change-audit.v1` (operation-focused summaries, not per-cell value diffs).
 - **Export option:** `/export audit` writes the persisted workbook mutation audit log as JSON (download by default, `clipboard` optional).
 - **Rationale:** improve user trust with concrete, navigable deltas while keeping implementation incremental and low-risk.
 


### PR DESCRIPTION
## Summary
Closes #100 by extending workbook mutation audit coverage to the remaining mutating tool families in core execution policy.

## What changed

### 1) Audit schema coverage
- `src/audit/workbook-change-audit.ts`
  - Extended `WorkbookAuditToolName` with:
    - `comments`
    - `view_settings`
    - `workbook_history`
  - Parser/validation updated accordingly.

### 2) `comments` mutating actions now append audit entries
- `src/tools/comments.ts`
  - Added audit append on success/failure for mutating actions:
    - `add`, `update`, `reply`, `delete`, `resolve`, `reopen`
  - `read` remains non-mutating and does not append mutation audit entries.
  - Captures summary + output address + changed count (operation-level, `changes: []`).

### 3) `view_settings` mutating actions now append audit entries
- `src/tools/view-settings.ts`
  - Added audit append on success/failure for all mutating actions (`action !== "get"`).
  - `get` remains read-only and does not append mutation audit entries.
  - Captures summary + output address + changed count (operation-level, `changes: []`).

### 4) `workbook_history` restore now appends audit entries
- `src/tools/workbook-history.ts`
  - `action: "restore"` now appends mutation audit entries for:
    - successful restore
    - blocked/no-snapshot path
    - restore error path
  - Non-mutating history actions (`list`, `delete`, `clear`) remain unchanged.

### 5) Tests
- `tests/workbook-change-audit.test.ts`
  - Added coverage for new audit tool-name acceptance (`comments`, `view_settings`, `workbook_history`).
  - Added tool-level coverage for success/error append behavior across:
    - `comments`
    - `view_settings`
    - `workbook_history:restore`

### 6) Docs
- `src/tools/DECISIONS.md`
  - Updated audit coverage note with new tool families.
- `docs/upcoming.md`
  - Updated #28 status and linked #100/#101 follow-ups.

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
