### PR TITLE
feat(audit): add optional explain-changes drawer

### DIFF
--- a/src/audit/change-explanation.ts
+++ b/src/audit/change-explanation.ts
@@ -1,0 +1,244 @@
+/**
+ * Build concise, citation-aware change explanations from structured audit metadata.
+ *
+ * This module is deterministic and UI-only; it does not mutate workbook state or
+ * inject additional context into model prompts by default.
+ */
+
+import type { WorkbookCellChangeSummary } from "./cell-diff.js";
+
+export const MAX_EXPLANATION_PROMPT_CHARS = 1_200;
+export const MAX_EXPLANATION_TEXT_CHARS = 420;
+
+const MAX_CHANGE_SAMPLES = 6;
+const MAX_SAMPLE_VALUE_CHARS = 40;
+const MAX_CITATIONS = 8;
+
+export interface ChangeExplanationInput {
+  toolName: string;
+  blocked: boolean;
+  changedCount?: number;
+  summary?: string;
+  error?: string;
+  inputAddress?: string;
+  outputAddress?: string;
+  changes?: WorkbookCellChangeSummary;
+}
+
+export interface ChangeExplanation {
+  /** Bounded prompt-like payload used to shape the explanation source. */
+  prompt: string;
+  /** Human-readable explanation shown in the tool card. */
+  text: string;
+  /** Clickable citations (ranges/cells) that support navigation. */
+  citations: string[];
+  /** True when source payload or output text was truncated for budget/safety. */
+  truncated: boolean;
+  /** True when we had to fall back due partial/insufficient metadata. */
+  usedFallback: boolean;
+}
+
+function trimToLength(value: string, maxChars: number): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) {
+    return { text: value, truncated: false };
+  }
+
+  if (maxChars <= 1) {
+    return { text: value.slice(0, Math.max(maxChars, 0)), truncated: true };
+  }
+
+  return {
+    text: `${value.slice(0, maxChars - 1)}…`,
+    truncated: true,
+  };
+}
+
+function sanitizeInline(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function normalizeSampleValue(value: string): { value: string; truncated: boolean } {
+  const normalized = sanitizeInline(value);
+  const trimmed = trimToLength(normalized, MAX_SAMPLE_VALUE_CHARS);
+  return {
+    value: trimmed.text,
+    truncated: trimmed.truncated,
+  };
+}
+
+function uniqueCitations(input: ChangeExplanationInput): string[] {
+  const citations: string[] = [];
+
+  const addCitation = (address: string | undefined): void => {
+    if (!address) return;
+    const trimmed = address.trim();
+    if (trimmed.length === 0) return;
+    if (citations.includes(trimmed)) return;
+    citations.push(trimmed);
+  };
+
+  if (input.changes) {
+    for (const change of input.changes.sample) {
+      addCitation(change.address);
+      if (citations.length >= MAX_CITATIONS) {
+        return citations;
+      }
+    }
+  }
+
+  addCitation(input.outputAddress);
+  addCitation(input.inputAddress);
+
+  return citations.slice(0, MAX_CITATIONS);
+}
+
+function buildPrompt(input: ChangeExplanationInput): { prompt: string; truncated: boolean } {
+  const lines: string[] = [
+    "You explain spreadsheet mutations in plain language.",
+    `Tool: ${input.toolName}`,
+    `Blocked: ${input.blocked ? "yes" : "no"}`,
+    `Changed count: ${typeof input.changedCount === "number" ? String(input.changedCount) : "unknown"}`,
+    `Output address: ${input.outputAddress ?? "(none)"}`,
+    `Input address: ${input.inputAddress ?? "(none)"}`,
+    `Summary: ${input.summary ?? "(none)"}`,
+    `Error: ${input.error ?? "(none)"}`,
+    "Sample changes:",
+  ];
+
+  let truncated = false;
+
+  if (input.changes && input.changes.sample.length > 0) {
+    const samples = input.changes.sample.slice(0, MAX_CHANGE_SAMPLES);
+    if (input.changes.sample.length > MAX_CHANGE_SAMPLES) {
+      truncated = true;
+    }
+
+    for (const change of samples) {
+      const before = normalizeSampleValue(change.beforeValue);
+      const after = normalizeSampleValue(change.afterValue);
+      truncated = truncated || before.truncated || after.truncated;
+
+      const formulaChanged = change.beforeFormula !== change.afterFormula;
+      const formulaSuffix = formulaChanged ? " (formula changed)" : "";
+      lines.push(`- ${change.address}: ${before.value} -> ${after.value}${formulaSuffix}`);
+    }
+  } else {
+    lines.push("- (none)");
+  }
+
+  lines.push("Return a concise explanation (2-4 sentences) and reference cited addresses when available.");
+
+  const prompt = lines.join("\n");
+  const boundedPrompt = trimToLength(prompt, MAX_EXPLANATION_PROMPT_CHARS);
+
+  return {
+    prompt: boundedPrompt.text,
+    truncated: truncated || boundedPrompt.truncated,
+  };
+}
+
+function buildStatusLine(input: ChangeExplanationInput): string {
+  if (input.blocked) {
+    return "This mutation was blocked, so workbook data was not changed.";
+  }
+
+  if (typeof input.changedCount === "number") {
+    if (input.changedCount > 0) {
+      return `This operation changed ${input.changedCount} cell${input.changedCount === 1 ? "" : "s"}.`;
+    }
+
+    return "This operation completed without changing cell values.";
+  }
+
+  return "This operation mutated workbook state.";
+}
+
+function buildDetailLine(input: ChangeExplanationInput): string | null {
+  if (input.error) {
+    return `Reason: ${sanitizeInline(input.error)}.`;
+  }
+
+  if (input.summary) {
+    return `Summary: ${sanitizeInline(input.summary)}.`;
+  }
+
+  if (input.outputAddress) {
+    return `Primary target: ${input.outputAddress}.`;
+  }
+
+  return null;
+}
+
+function buildSampleLine(input: ChangeExplanationInput): { text: string | null; truncated: boolean } {
+  if (!input.changes || input.changes.sample.length === 0) {
+    return { text: null, truncated: false };
+  }
+
+  const sample = input.changes.sample.slice(0, 2);
+  const snippets: string[] = [];
+  let truncated = input.changes.sample.length > 2;
+
+  for (const change of sample) {
+    const before = normalizeSampleValue(change.beforeValue);
+    const after = normalizeSampleValue(change.afterValue);
+    truncated = truncated || before.truncated || after.truncated;
+
+    snippets.push(`${change.address}: ${before.value} -> ${after.value}`);
+  }
+
+  return {
+    text: `Examples: ${snippets.join("; ")}.`,
+    truncated,
+  };
+}
+
+function buildCitationLine(citations: readonly string[]): string | null {
+  if (citations.length === 0) return null;
+
+  const shown = citations.slice(0, 3);
+  const suffix = citations.length > shown.length ? ` (+${citations.length - shown.length} more)` : "";
+  return `Inspect: ${shown.join(", ")}${suffix}.`;
+}
+
+export function buildChangeExplanation(input: ChangeExplanationInput): ChangeExplanation {
+  const citations = uniqueCitations(input);
+  const promptResult = buildPrompt(input);
+
+  const statusLine = buildStatusLine(input);
+  const detailLine = buildDetailLine(input);
+  const sampleLine = buildSampleLine(input);
+  const citationLine = buildCitationLine(citations);
+
+  const lines = [statusLine, detailLine, sampleLine.text, citationLine]
+    .filter((line): line is string => typeof line === "string" && line.trim().length > 0);
+
+  let usedFallback = false;
+
+  if (lines.length === 0) {
+    usedFallback = true;
+    lines.push("Not enough audit metadata is available to explain this change yet.");
+  }
+
+  if (
+    !input.summary &&
+    !input.error &&
+    !input.outputAddress &&
+    !input.inputAddress &&
+    (!input.changes || input.changes.sample.length === 0)
+  ) {
+    usedFallback = true;
+    if (lines.length < 2) {
+      lines.push("Not enough audit metadata is available to explain this change yet.");
+    }
+  }
+
+  const textResult = trimToLength(lines.join("\n\n"), MAX_EXPLANATION_TEXT_CHARS);
+
+  return {
+    prompt: promptResult.prompt,
+    text: textResult.text,
+    citations,
+    truncated: promptResult.truncated || sampleLine.truncated || textResult.truncated,
+    usedFallback,
+  };
+}

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -192,6 +192,7 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
   - `write_cells` verification output shows a bounded preview for large writes instead of dumping full tables
 - **Audit coverage extension:** `format_cells`, `conditional_format`, `modify_structure`, mutating `comments` actions, mutating `view_settings` actions, and `workbook_history` restore now append structured entries to `workbook.change-audit.v1` (operation-focused summaries, not per-cell value diffs).
 - **Export option:** `/export audit` writes the persisted workbook mutation audit log as JSON (download by default, `clipboard` optional).
+- **Optional explanation UX:** mutation tool cards expose an on-demand **Explain these changes** drawer that synthesizes a concise explanation + clickable citations from structured audit metadata, with bounded payload/text limits.
 - **Rationale:** improve user trust with concrete, navigable deltas while keeping implementation incremental and low-risk.
 
 ## Workbook recovery checkpoints (`workbook_history`)

--- a/src/ui/theme/content/tool-card-markdown.css
+++ b/src/ui/theme/content/tool-card-markdown.css
@@ -90,6 +90,52 @@
   font-size: var(--text-xs);
 }
 
+/* Optional explanation drawer for mutation cards */
+.pi-tool-card__explain {
+  border: 1px solid var(--alpha-8);
+  border-radius: var(--radius-sm);
+  background: var(--alpha-2);
+}
+
+.pi-tool-card__explain-toggle {
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--foreground);
+  padding: 7px 9px;
+}
+
+.pi-tool-card__explain-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.pi-tool-card__explain[open] .pi-tool-card__explain-toggle {
+  border-bottom: 1px solid var(--alpha-8);
+}
+
+.pi-tool-card__explain-body {
+  padding: 8px 9px 9px;
+}
+
+.pi-tool-card__explain-citations {
+  margin-top: 7px;
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--muted-foreground);
+  line-height: 1.45;
+}
+
+.pi-tool-card__explain-citations-label {
+  margin-right: 5px;
+  font-weight: 600;
+}
+
+.pi-tool-card__explain-citations-empty {
+  font-style: italic;
+}
+
 /* Flex overflow fix for tool cards */
 tool-message {
   min-width: 0;

--- a/src/ui/tool-renderers.ts
+++ b/src/ui/tool-renderers.ts
@@ -21,9 +21,15 @@ import {
   isPythonTransformRangeDetails,
   isReadRangeCsvDetails,
   isTraceDependenciesDetails,
+  isWorkbookHistoryDetails,
   isWriteCellsDetails,
   type WriteCellsDetails,
 } from "../tools/tool-details.js";
+import { getToolExecutionMode } from "../tools/execution-policy.js";
+import {
+  buildChangeExplanation,
+  type ChangeExplanationInput,
+} from "../audit/change-explanation.js";
 import { renderCsvTable } from "./render-csv-table.js";
 import { renderDepTree } from "./render-dep-tree.js";
 
@@ -265,6 +271,198 @@ function renderWorkbookCellDiff(details: unknown): TemplateResult {
           ? html`<div class="pi-tool-card__diff-note">Showing first ${changes.sample.length} changed cell(s).</div>`
           : html``}
       </div>
+    </div>
+  `;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function extractResultError(resultText: string | undefined): string | undefined {
+  if (!resultText) return undefined;
+
+  const summary = resultSummary(resultText);
+  if (!summary) return undefined;
+
+  const normalized = summary.replace(/^\s*⚠️\s*/u, "").trim();
+  if (/^error\b/ui.test(normalized)) {
+    return normalized.replace(/^error:\s*/ui, "").trim();
+  }
+
+  return undefined;
+}
+
+function buildChangeExplanationInputForTool(
+  toolName: SupportedToolName,
+  params: unknown,
+  resultText: string | undefined,
+  details: unknown,
+): ChangeExplanationInput | null {
+  if (getToolExecutionMode(toolName, params) !== "mutate") return null;
+
+  const p = safeParseParams(params);
+  const range = optionalString(p.range);
+  const startCell = optionalString(p.start_cell);
+  const sheet = optionalString(p.sheet);
+  const action = optionalString(p.action);
+
+  const summary = resultSummary(resultText ?? "") ?? undefined;
+  const error = extractResultError(resultText);
+  const blockedFromText = Boolean(resultText && isBlocked(resultText));
+
+  if (isWriteCellsDetails(details)) {
+    return {
+      toolName,
+      blocked: details.blocked,
+      changedCount: details.changes?.changedCount,
+      summary,
+      error,
+      outputAddress: details.address ?? startCell,
+      changes: details.changes,
+    };
+  }
+
+  if (isFillFormulaDetails(details)) {
+    return {
+      toolName,
+      blocked: details.blocked,
+      changedCount: details.changes?.changedCount,
+      summary,
+      error,
+      outputAddress: details.address ?? range,
+      changes: details.changes,
+    };
+  }
+
+  if (isPythonTransformRangeDetails(details)) {
+    return {
+      toolName,
+      blocked: details.blocked || blockedFromText,
+      changedCount: details.changes?.changedCount,
+      summary,
+      error: details.error ?? error,
+      inputAddress: details.inputAddress,
+      outputAddress: details.outputAddress,
+      changes: details.changes,
+    };
+  }
+
+  if (isWorkbookHistoryDetails(details) && details.action === "restore") {
+    const historyError = optionalString(details.error);
+    return {
+      toolName,
+      blocked: blockedFromText || Boolean(historyError),
+      changedCount: details.changedCount,
+      summary,
+      error: historyError ?? error,
+      outputAddress: details.address,
+    };
+  }
+
+  if (toolName === "format_cells") {
+    const detailsAddress = isFormatCellsDetails(details) ? details.address : undefined;
+    return {
+      toolName,
+      blocked: blockedFromText,
+      summary,
+      error,
+      outputAddress: detailsAddress ?? range,
+    };
+  }
+
+  if (toolName === "conditional_format") {
+    return {
+      toolName,
+      blocked: blockedFromText,
+      summary,
+      error,
+      outputAddress: range,
+    };
+  }
+
+  if (toolName === "modify_structure") {
+    return {
+      toolName,
+      blocked: blockedFromText,
+      summary,
+      error,
+      outputAddress: range ?? sheet,
+    };
+  }
+
+  if (toolName === "comments") {
+    return {
+      toolName,
+      blocked: blockedFromText,
+      changedCount: blockedFromText ? 0 : 1,
+      summary,
+      error,
+      outputAddress: range,
+    };
+  }
+
+  if (toolName === "view_settings") {
+    const outputAddress = range ?? sheet;
+    return {
+      toolName,
+      blocked: blockedFromText,
+      changedCount: blockedFromText ? 0 : 1,
+      summary,
+      error,
+      outputAddress,
+    };
+  }
+
+  if (toolName === "workbook_history" && action === "restore") {
+    return {
+      toolName,
+      blocked: blockedFromText,
+      summary,
+      error,
+    };
+  }
+
+  return null;
+}
+
+function renderCitations(citations: readonly string[]): TemplateResult {
+  if (citations.length === 0) {
+    return html`<span class="pi-tool-card__explain-citations-empty">No range citations available.</span>`;
+  }
+
+  return html`${citations.map((address, index) => html`${index > 0 ? html`, ` : html``}${cellRefs(address)}`)}`;
+}
+
+function renderChangeExplanationSection(
+  toolName: SupportedToolName,
+  params: unknown,
+  resultText: string | undefined,
+  details: unknown,
+): TemplateResult {
+  const input = buildChangeExplanationInputForTool(toolName, params, resultText, details);
+  if (!input) return html``;
+
+  const explanation = buildChangeExplanation(input);
+
+  return html`
+    <div class="pi-tool-card__section">
+      <details class="pi-tool-card__explain">
+        <summary class="pi-tool-card__explain-toggle">Explain these changes</summary>
+        <div class="pi-tool-card__explain-body">
+          <div class="pi-tool-card__plain-text">${explanation.text}</div>
+          <div class="pi-tool-card__explain-citations">
+            <span class="pi-tool-card__explain-citations-label">Citations:</span>
+            ${renderCitations(explanation.citations)}
+          </div>
+          ${explanation.usedFallback
+            ? html`<div class="pi-tool-card__diff-note">Limited metadata available; explanation is high-level.</div>`
+            : html``}
+          ${explanation.truncated
+            ? html`<div class="pi-tool-card__diff-note">Explanation uses a bounded metadata sample.</div>`
+            : html``}
+        </div>
+      </details>
     </div>
   `;
 }
@@ -711,6 +909,7 @@ function createExcelMarkdownRenderer(toolName: SupportedToolName): ToolRenderer<
                     ${renderImages(images)}
                   </div>
                   ${renderWorkbookCellDiff(result.details)}
+                  ${renderChangeExplanationSection(toolName, params, text, result.details)}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Closes #101 by adding an optional, on-demand **Explain these changes** drawer in mutation tool cards.

## What changed

### 1) New bounded explanation engine
- Added `src/audit/change-explanation.ts`
  - `buildChangeExplanation(input)` synthesizes concise natural-language explanations from structured audit metadata.
  - Produces clickable citation targets (`citations`) and a bounded prompt-like source payload (`prompt`) for deterministic shaping.
  - Enforces strict bounds:
    - `MAX_EXPLANATION_PROMPT_CHARS = 1200`
    - `MAX_EXPLANATION_TEXT_CHARS = 420`
  - Includes graceful fallback messaging when metadata is partial.

### 2) Tool-card UX: optional explanation trigger
- Updated `src/ui/tool-renderers.ts`
  - Added mutation-aware explanation section rendering.
  - For mutate tool calls, cards now include a collapsible drawer:
    - **Explain these changes**
  - Explanation content is generated from existing `details` + result metadata only (no default context injection changes).
  - Citations render as clickable range/cell links via existing `cellRefs()` behavior.

### 3) Styling
- Updated `src/ui/theme/content/tool-card-markdown.css`
  - Added styles for explanation drawer/toggle/body/citations states.

### 4) Tests
- Extended `tests/workbook-change-audit.test.ts` with coverage for:
  - prompt-shaping and citation extraction
  - budget truncation behavior
  - sparse-metadata fallback behavior

### 5) Decisions doc
- Updated `src/tools/DECISIONS.md` with the new optional explanation UX + bounded policy.

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`

Closes #101
