### PR TITLE
feat(install): improve non-technical install and OAuth proxy guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ Existing AI add-ins for Excel are closed-source, locked to a single model, and c
 
 ## Install (recommended)
 
-See **[`docs/install.md`](./docs/install.md)**.
+Use the non-technical install guide: **[`docs/install.md`](./docs/install.md)**.
+
+It includes:
+- manifest download + Excel install steps (macOS + Windows)
+- first-run provider setup
+- OAuth/CORS troubleshooting for login-based providers
 
 ## Developer Quick Start
 
@@ -215,13 +220,15 @@ npx office-addin-manifest validate manifest.xml
 
 **Dev:** the Vite dev server proxies API + OAuth calls to providers (`/api-proxy/*`, `/oauth-proxy/*`).
 
-**Production:** some OAuth/token endpoints are blocked by browser CORS in Office webviews. Pi for Excel supports a **user-configurable CORS proxy**:
+**Production:** some OAuth/token endpoints are blocked by browser CORS in Office webviews. Pi for Excel supports a **user-configurable CORS proxy**.
+
+For non-technical install + login troubleshooting, see: **[`docs/install.md`](./docs/install.md#oauth-logins-and-cors-helper)**.
 
 1. Start the local proxy (**recommended: HTTPS**):
    ```bash
    npm run proxy:https
    ```
-   (defaults to `https://localhost:3001`)
+   (defaults to `https://localhost:3003`)
 
    **Security:** the proxy only accepts browser requests from Pi for Excel origins by default:
    - `https://localhost:3000` (dev)
@@ -257,9 +264,9 @@ npx office-addin-manifest validate manifest.xml
    STRICT_TARGET_RESOLUTION=1 npm run proxy:https
    ```
 
-   If port 3001 is taken, pick another port:
+   If port 3003 is taken, pick another port:
    ```bash
-   PORT=3003 npm run proxy:https
+   PORT=3005 npm run proxy:https
    ```
 2. In Excel, run `/settings` → **Proxy** tab → enable **Use CORS Proxy** → set Proxy URL (e.g. `https://localhost:3003`).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,30 +1,40 @@
-# Install (recommended)
+# Install Pi for Excel (recommended)
 
-Pi for Excel is an **Excel taskpane add-in**. Excel loads it as a small website from an HTTPS URL.
+Pi for Excel is an Excel taskpane add-in. Excel loads it from a manifest file that points to a hosted HTTPS app.
 
-This guide is the **non-technical install** path:
+This is the **non-technical install path**:
 - no git
 - no Node
 - no mkcert
-- no terminal
+- no local dev server
 
-## 1) Download the manifest
+---
 
-Download **`manifest.prod.xml`** (production manifest):
+## 1) Download the production manifest
 
-- https://pi-for-excel.vercel.app/manifest.prod.xml
+Download:
+- **https://pi-for-excel.vercel.app/manifest.prod.xml**
 
-> If the link 404s, the hosted build hasn’t been published yet.
+Fallbacks (if the hosted link is temporarily unavailable):
+- Latest release assets: https://github.com/tmustier/pi-for-excel/releases/latest
+- Repo copy: https://github.com/tmustier/pi-for-excel/blob/main/manifest.prod.xml
+
+Keep the filename as `manifest.prod.xml`.
+
+---
 
 ## 2) Install in Excel
+
+> Excel labels differ slightly by version (`Add-ins`, `Office Add-ins`, `My Add-ins`, `Upload My Add-in`, `Add from file`).
 
 ### macOS (Excel desktop)
 
 1. Open Excel
 2. Go to **Insert → Add-ins → My Add-ins**
-3. Choose **Add from file…** (or **Upload My Add-in…** depending on Excel version)
+3. Choose **Add from file…** / **Upload My Add-in…**
 4. Select `manifest.prod.xml`
-5. You should see **Pi for Excel** appear. Click **Open Pi**.
+5. You should see **Pi for Excel**
+6. Click **Open Pi**
 
 ### Windows (Excel desktop)
 
@@ -32,33 +42,108 @@ Download **`manifest.prod.xml`** (production manifest):
 2. Go to **Insert → Add-ins → My Add-ins**
 3. Choose **Upload My Add-in…**
 4. Select `manifest.prod.xml`
+5. Open **Pi for Excel**
 
-## 3) First run
+---
 
-When Pi for Excel opens, connect a provider:
-- Use `/login` to add an API key or sign in.
-- Use `/model` (or click the model name in the bottom status bar) to switch models.
+## 3) First-run check
+
+1. Open the taskpane (`Open Pi` button)
+2. Connect a provider (see below)
+3. Send a test prompt, e.g.:
+   - `What sheet am I currently on?`
+   - `Summarize my current selection`
+
+If you get a response, install is complete.
+
+---
+
+## 4) Connect a provider
+
+### Recommended (easiest): API key
+
+For most users, API keys are the smoothest setup and usually do **not** need the proxy helper.
+
+1. In Pi, run `/login` (or use the welcome screen)
+2. Expand a provider row (OpenAI, Google Gemini, Anthropic, etc.)
+3. Paste your API key
+4. Click **Save**
+
+### OAuth / account login (Anthropic, GitHub Copilot)
+
+1. In `/login`, click **Login with …**
+2. Complete login in the browser window that opens
+3. Return to Excel and complete any prompt shown
+
+If login fails with a CORS/network error, follow the next section.
+
+---
+
+## OAuth logins and CORS helper
+
+Some OAuth/token endpoints are blocked by CORS inside Office webviews (especially on macOS WKWebView).
+
+Typical symptoms:
+- `Login was blocked by browser CORS`
+- `Load failed`
+- `Failed to fetch`
+
+### What to do
+
+1. Run a local HTTPS proxy helper on the same machine as Excel (defaults to `https://localhost:3003`):
+
+```bash
+npm run proxy:https
+```
+
+If the user is non-technical, a teammate/admin can run this step for them on their machine.
+
+2. In Pi, open `/settings` → **Proxy**:
+   - enable **Use CORS Proxy**
+   - set URL to `https://localhost:3003`
+
+3. Retry OAuth login
+
+Notes:
+- Keep the proxy URL on **HTTPS** (`https://...`), not HTTP.
+- API-key providers generally work without proxy.
+- If port `3003` is busy, run with another port and use that same URL in settings:
+
+```bash
+PORT=3005 npm run proxy:https
+```
+
+---
 
 ## Updates
 
-### Automatic updates (hosted build)
+If you installed with `manifest.prod.xml`, Pi for Excel loads from a hosted URL and most updates are automatic.
 
-If you installed using `manifest.prod.xml`, then Pi for Excel’s UI is loaded from a hosted HTTPS URL.
+- Normal case: close/reopen Excel taskpane to pick up latest version.
+- Rare case (manifest changes): download the new `manifest.prod.xml` and upload it again in Excel.
 
-- New versions are deployed to that same URL.
-- Typically, you get updates automatically the next time you open the taskpane.
-- If you seem “stuck” on an old version, close and reopen Excel.
-
-### When you need to reinstall the manifest
-
-Rarely, a new version may require a manifest change (permissions, commands, etc.).
-In that case you’ll download a new `manifest.prod.xml` and re-upload it.
+---
 
 ## Troubleshooting
 
-- **Blank taskpane / doesn’t load**
-  - You may be on a network that blocks the host, or the hosted build URL changed.
+### Pi does not appear in My Add-ins
+- Re-open Excel and try again
+- Ensure you uploaded `manifest.prod.xml` (not the localhost dev manifest)
 
-- **Login fails with “CORS / Load failed” (macOS especially)**
-  - Some providers (OAuth/subscription flows) require the local HTTPS proxy helper.
-  - See README → “CORS / proxy”.
+### Taskpane opens but is blank
+- Your network may block `https://pi-for-excel.vercel.app`
+- Try a different network / VPN setting
+
+### I installed, but changes are not visible
+- Close and reopen Excel to clear cached taskpane state
+
+### OAuth login still fails
+- Confirm proxy is running and reachable at the exact URL in `/settings`
+- Confirm proxy URL is `https://localhost:<port>` (not `http://`)
+- Try API key auth as a fallback
+
+---
+
+## Developer setup (separate)
+
+If you want to run from source (`localhost`, Vite, mkcert), use the root README: [Developer Quick Start](../README.md#developer-quick-start).

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -6,17 +6,17 @@
  * Why this exists:
  * - Some provider OAuth/token endpoints (and some LLM APIs) block browser requests via CORS.
  * - In dev we rely on Vite's proxy. In production, you can run this locally and point
- *   Pi for Excel's proxy setting at it (default: https://localhost:3001).
+ *   Pi for Excel's proxy setting at it (default: https://localhost:3003).
  *
  * Usage:
  *   npm run proxy:https   # HTTPS (recommended for Office webviews)
  *   npm run proxy         # HTTP  (may be blocked as mixed content)
  *
  * Proxy format:
- *   https://localhost:3001/?url=<target-url>
+ *   https://localhost:3003/?url=<target-url>
  *
  * Example:
- *   curl 'https://localhost:3001/?url=https%3A%2F%2Fexample.com'
+ *   curl 'https://localhost:3003/?url=https%3A%2F%2Fexample.com'
  */
 
 import http from "node:http";
@@ -43,7 +43,7 @@ if (useHttps && useHttp) {
 }
 
 const HOST = process.env.HOST || (useHttps ? "localhost" : "127.0.0.1");
-const PORT = Number.parseInt(process.env.PORT || "3001", 10);
+const PORT = Number.parseInt(process.env.PORT || "3003", 10);
 
 const rootDir = path.resolve(process.cwd());
 const keyPath = path.join(rootDir, "key.pem");

--- a/src/auth/proxy-validation.ts
+++ b/src/auth/proxy-validation.ts
@@ -6,6 +6,10 @@
  * "Load failed" / "Connection error".
  */
 
+export const DEFAULT_LOCAL_PROXY_URL = "https://localhost:3003";
+export const PROXY_HELPER_DOCS_URL =
+  "https://github.com/tmustier/pi-for-excel/blob/main/docs/install.md#oauth-logins-and-cors-helper";
+
 export function normalizeProxyUrl(url: string): string {
   return url.trim().replace(/\/+$/, "");
 }
@@ -15,7 +19,7 @@ export function validateOfficeProxyUrl(url: string): string {
 
   if (!/^https?:\/\//i.test(normalized)) {
     throw new Error(
-      `Invalid Proxy URL: "${url}". Expected a full URL like https://localhost:3003`,
+      `Invalid Proxy URL: "${url}". Expected a full URL like ${DEFAULT_LOCAL_PROXY_URL}`,
     );
   }
 
@@ -24,7 +28,7 @@ export function validateOfficeProxyUrl(url: string): string {
     parsed = new URL(normalized);
   } catch {
     throw new Error(
-      `Invalid Proxy URL: "${url}". Expected a full URL like https://localhost:3003`,
+      `Invalid Proxy URL: "${url}". Expected a full URL like ${DEFAULT_LOCAL_PROXY_URL}`,
     );
   }
 
@@ -33,7 +37,7 @@ export function validateOfficeProxyUrl(url: string): string {
   if (typeof window !== "undefined" && window.location?.protocol === "https:" && parsed.protocol === "http:") {
     throw new Error(
       `Proxy URL is HTTP (${normalized}) but the add-in is served over HTTPS. Office webviews may block this as mixed content. ` +
-        `Use https://localhost:<port> and start the proxy with \"npm run proxy:https\".`,
+        `Use ${DEFAULT_LOCAL_PROXY_URL} and run a local HTTPS proxy helper. See ${PROXY_HELPER_DOCS_URL}.`,
     );
   }
 

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -14,7 +14,11 @@ import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.
 import type { SessionData } from "@mariozechner/pi-web-ui/dist/storage/types.js";
 
 import { createOfficeStreamFn } from "../auth/stream-proxy.js";
-import { isLoopbackProxyUrl } from "../auth/proxy-validation.js";
+import {
+  DEFAULT_LOCAL_PROXY_URL,
+  PROXY_HELPER_DOCS_URL,
+  isLoopbackProxyUrl,
+} from "../auth/proxy-validation.js";
 import { restoreCredentials } from "../auth/restore.js";
 import { invalidateBlueprint } from "../context/blueprint.js";
 import { ChangeTracker } from "../context/change-tracker.js";
@@ -725,7 +729,7 @@ export async function initTaskpane(opts: {
           if (isLikelyCorsErrorMessage(err)) {
             showErrorBanner(
               errorRoot,
-              "Network error (likely CORS). Start the local HTTPS proxy (npm run proxy:https) and enable it in /settings → Proxy.",
+              `Network error (likely CORS). If you're using OAuth, enable /settings → Proxy with ${DEFAULT_LOCAL_PROXY_URL} and retry. Guide: ${PROXY_HELPER_DOCS_URL}`,
             );
           } else {
             showErrorBanner(errorRoot, `LLM error: ${err}`);

--- a/src/taskpane/welcome-login.ts
+++ b/src/taskpane/welcome-login.ts
@@ -9,6 +9,10 @@ import { requestChatInputFocus } from "../ui/input-focus.js";
 import { installOverlayEscapeClose } from "../ui/overlay-escape.js";
 import { showToast } from "../ui/toast.js";
 import { setActiveProviders } from "../compat/model-selector-patch.js";
+import {
+  DEFAULT_LOCAL_PROXY_URL,
+  PROXY_HELPER_DOCS_URL,
+} from "../auth/proxy-validation.js";
 
 async function testLocalHttpsProxy(proxyUrl: string): Promise<boolean> {
   const controller = new AbortController();
@@ -28,15 +32,13 @@ async function testLocalHttpsProxy(proxyUrl: string): Promise<boolean> {
 export async function showWelcomeLogin(providerKeys: ProviderKeysStore): Promise<void> {
   const { ALL_PROVIDERS, buildProviderRow } = await import("../ui/provider-login.js");
 
-  // Make Anthropic OAuth usable even before the user can access /settings.
-  // Prefer 3003 (3001 is commonly occupied by other local services).
+  // Make OAuth flows usable even before the user can access /settings.
   try {
     const storage = getAppStorage();
     const enabled = await storage.settings.get("proxy.enabled");
     const url = await storage.settings.get("proxy.url");
 
-    const preferred = "https://localhost:3003";
-    const currentUrl = typeof url === "string" && url.trim().length > 0 ? url.trim() : preferred;
+    const currentUrl = typeof url === "string" && url.trim().length > 0 ? url.trim() : DEFAULT_LOCAL_PROXY_URL;
 
     if (url === null) {
       await storage.settings.set("proxy.url", currentUrl);
@@ -88,7 +90,11 @@ export async function showWelcomeLogin(providerKeys: ProviderKeysStore): Promise
             <input class="pi-welcome-proxy__url" type="text" spellcheck="false" />
             <button class="pi-welcome-proxy__save" type="button">Save</button>
           </div>
-          <div class="pi-welcome-proxy__hint">Required for Anthropic OAuth in Excel. Start the proxy with <code>npm run proxy:https</code>.</div>
+          <div class="pi-welcome-proxy__hint">
+            Needed only when OAuth login is blocked by CORS.
+            Keep this URL at <code>${DEFAULT_LOCAL_PROXY_URL}</code>, run a local HTTPS proxy helper, then enable this toggle.
+            <a href="${PROXY_HELPER_DOCS_URL}" target="_blank" rel="noopener noreferrer">Step-by-step guide</a>.
+          </div>
         </div>
 
         <div class="pi-welcome-providers"></div>
@@ -111,10 +117,10 @@ export async function showWelcomeLogin(providerKeys: ProviderKeysStore): Promise
         const enabled = await storage.settings.get("proxy.enabled");
         const url = await storage.settings.get("proxy.url");
         proxyEnabledEl.checked = Boolean(enabled);
-        proxyUrlEl.value = typeof url === "string" && url.trim().length > 0 ? url.trim() : "https://localhost:3003";
+        proxyUrlEl.value = typeof url === "string" && url.trim().length > 0 ? url.trim() : DEFAULT_LOCAL_PROXY_URL;
       } catch {
         proxyEnabledEl.checked = false;
-        proxyUrlEl.value = "https://localhost:3003";
+        proxyUrlEl.value = DEFAULT_LOCAL_PROXY_URL;
       }
     };
 

--- a/src/ui/provider-login.ts
+++ b/src/ui/provider-login.ts
@@ -11,6 +11,10 @@ import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.
 import { isCorsError } from "@mariozechner/pi-web-ui/dist/utils/proxy-utils.js";
 import { getOAuthProvider } from "../auth/oauth-provider-registry.js";
 import { clearOAuthCredentials, saveOAuthCredentials } from "../auth/oauth-storage.js";
+import {
+  DEFAULT_LOCAL_PROXY_URL,
+  PROXY_HELPER_DOCS_URL,
+} from "../auth/proxy-validation.js";
 import { getErrorMessage } from "../utils/errors.js";
 
 export interface ProviderDef {
@@ -352,7 +356,10 @@ export function buildProviderRow(
             (typeof msg === "string" && /load failed|failed to fetch|cors|cross-origin|networkerror/i.test(msg));
 
           if (isLikelyCors) {
-            errorEl.textContent = "Login was blocked by browser CORS. Start the local HTTPS proxy (npm run proxy:https) and enable it (Proxy toggle above, or /settings → Proxy).";
+            errorEl.textContent =
+              "Login was blocked by browser CORS. Enable /settings → Proxy with " +
+              `${DEFAULT_LOCAL_PROXY_URL} (local HTTPS proxy helper running), then retry. ` +
+              `Guide: ${PROXY_HELPER_DOCS_URL}`;
           } else {
             errorEl.textContent = msg || "Login failed";
           }

--- a/src/ui/theme/components.css
+++ b/src/ui/theme/components.css
@@ -1729,6 +1729,15 @@ pi-working-indicator {
   border-radius: var(--radius-xs);
 }
 
+.pi-welcome-proxy__hint a {
+  color: var(--pi-green);
+  text-decoration: underline;
+}
+
+.pi-welcome-proxy__hint a:hover {
+  color: var(--pi-green-strong);
+}
+
 .pi-welcome-providers {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Closes #16.

This PR improves the non-technical distribution/onboarding path and makes OAuth/CORS troubleshooting clearer for end users.

### What changed

- Reworked `docs/install.md` into a complete end-user install guide:
  - production manifest download + fallback links
  - explicit macOS + Windows install steps
  - first-run success check
  - provider setup guidance (API key first, OAuth second)
  - dedicated OAuth/CORS helper section with clear symptoms + remediation
  - troubleshooting and update expectations
- Updated README install section to point clearly to the non-technical flow.
- Updated README CORS/proxy section to link directly to the install troubleshooting anchor.
- Standardized local proxy default on `https://localhost:3003`:
  - proxy helper script default port and examples
  - shared proxy constants in app code
- Improved in-app messaging for login failures:
  - welcome overlay proxy hint now explains when it is needed and links to docs
  - OAuth CORS error text now gives concrete next steps
  - runtime CORS error banner now points to Proxy settings + docs
- Added link styling for the welcome overlay proxy hint.

## Why

Issue #16 asks for an install route that non-technical Excel users can follow and for clear login guidance when CORS is involved.

This change focuses on:
- reducing install ambiguity,
- making first-run success measurable,
- and giving users explicit recovery instructions when OAuth is blocked by Office webview CORS.

## Validation

- `npm run check`
- `npm run test:security`
- `npm run build`
