### PR TITLE
fix(ui): rewrite user-facing copy and move instructions hint above textarea

### DIFF
--- a/src/commands/builtins/extensions-overlay.ts
+++ b/src/commands/builtins/extensions-overlay.ts
@@ -280,7 +280,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
 
   const sandboxHint = document.createElement("p");
   sandboxHint.textContent =
-    "Inline-code and remote-URL extensions run in sandbox by default. Use rollback mode only as a temporary safety valve if sandbox rollout causes issues.";
+    "Untrusted extensions (inline code, remote URLs) run in isolation by default. Use rollback mode as a temporary safety valve if sandbox causes issues.";
   sandboxHint.className = "pi-overlay-hint";
 
   sandboxCard.append(sandboxStatusRow, sandboxActions, sandboxHint);
@@ -321,7 +321,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
 
   const localBridgeHint = document.createElement("p");
   localBridgeHint.textContent =
-    "One-step setup from this menu: enable python-bridge + save URL (same as two /experimental commands).";
+    "Enable the Python bridge and save the URL in one step (equivalent to two /experimental commands).";
   localBridgeHint.className = "pi-overlay-hint";
 
   localBridgeCard.append(localBridgeStatusRow, localBridgeUrlRow, localBridgeHint);

--- a/src/commands/builtins/instructions-overlay.ts
+++ b/src/commands/builtins/instructions-overlay.ts
@@ -83,13 +83,13 @@ export async function showInstructionsDialog(opts?: {
 
   const userTab = document.createElement("button");
   userTab.type = "button";
-  userTab.textContent = "My Instructions";
+  userTab.textContent = "Personal";
   userTab.className = "pi-overlay-tab";
   userTab.setAttribute("role", "tab");
 
   const workbookTab = document.createElement("button");
   workbookTab.type = "button";
-  workbookTab.textContent = "Workbook";
+  workbookTab.textContent = "This Workbook";
   workbookTab.className = "pi-overlay-tab";
   workbookTab.setAttribute("role", "tab");
 
@@ -126,8 +126,8 @@ export async function showInstructionsDialog(opts?: {
   saveBtn.className = "pi-overlay-btn pi-overlay-btn--primary";
 
   actions.append(cancelBtn, saveBtn);
-  footer.append(counter, hint, actions);
-  card.append(title, tabs, workbookTag, textarea, footer);
+  footer.append(counter, actions);
+  card.append(title, tabs, workbookTag, hint, textarea, footer);
   overlay.appendChild(card);
 
   let closed = false;
@@ -163,7 +163,7 @@ export async function showInstructionsDialog(opts?: {
       counter.classList.toggle("is-warning", count > USER_INSTRUCTIONS_SOFT_LIMIT);
 
       hint.textContent =
-        "Private to your machine. These apply to all workbooks and can be updated automatically when you express preferences.";
+        "Rules Pi follows in every conversation. Pi can also update these when you tell it your preferences — e.g. \"always use EUR\".";
       workbookTag.hidden = true;
       return;
     }
@@ -178,10 +178,10 @@ export async function showInstructionsDialog(opts?: {
 
     if (!workbookId) {
       hint.textContent =
-        "Workbook identity is unavailable right now, so workbook instructions can't be saved for this file.";
+        "Can't identify this workbook right now — try saving the file first.";
     } else {
       hint.textContent =
-        "Saved for this workbook on this machine. The assistant should ask before adding workbook-level notes.";
+        "Rules that only apply when this workbook is open. Pi will confirm before adding anything here.";
     }
 
     workbookTag.hidden = false;

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -404,7 +404,7 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
   title.className = "pi-overlay-title";
 
   const subtitle = document.createElement("p");
-  subtitle.textContent = "Integrations can inject instructions and external tools. Keep external access opt-in.";
+  subtitle.textContent = "Add capabilities like web search and external integrations. External tools are off by default.";
   subtitle.className = "pi-overlay-subtitle";
 
   titleWrap.append(title, subtitle);

--- a/src/commands/builtins/settings.ts
+++ b/src/commands/builtins/settings.ts
@@ -31,7 +31,7 @@ export function createSettingsCommands(actions: SettingsCommandActions): SlashCo
     },
     {
       name: "instructions",
-      description: "Edit persistent user/workbook instructions",
+      description: "Edit custom rules for Pi (personal + workbook-specific)",
       source: "builtin",
       execute: async () => {
         await actions.openInstructionsEditor();

--- a/src/taskpane/status-bar.ts
+++ b/src/taskpane/status-bar.ts
@@ -63,20 +63,20 @@ function renderStatusBar(
 
   // Context health: color + tooltip based on usage
   let ctxColor = "";
-  const ctxBaseTooltip = `How much of the model's context window has been used (${totalTokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens). As it fills up the model may lose track of earlier details — start a new chat if quality drops.`;
+  const ctxBaseTooltip = `How much of Pi's memory (context window) the conversation is using — ${totalTokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens. As this fills up, Pi may lose track of earlier details — start a new chat if quality drops.`;
   let ctxWarning = "";
   let ctxWarningText = "";
   if (pct > 100) {
     ctxColor = "pi-status-ctx--red";
-    ctxWarningText = "Context window exceeded — the next message will fail. Use /compact to free up some context, or /new to clear the chat.";
+    ctxWarningText = "Context is full — the next message will fail. Use /compact to summarize earlier messages, or /new for a fresh chat.";
     ctxWarning = `<span class="pi-tooltip__warn pi-tooltip__warn--red">${ctxWarningText}</span>`;
   } else if (pct > 60) {
     ctxColor = "pi-status-ctx--red";
-    ctxWarningText = `Context ${pct}% used up — quality will degrade. Use /compact to free up some context, or /new to clear the chat.`;
+    ctxWarningText = `Context ${pct}% full — responses will get less accurate. Use /compact to free space, or /new for a fresh chat.`;
     ctxWarning = `<span class="pi-tooltip__warn pi-tooltip__warn--red">${ctxWarningText}</span>`;
   } else if (pct > 40) {
     ctxColor = "pi-status-ctx--yellow";
-    ctxWarningText = `Context ${pct}% used up. Consider using /compact to free up some context, or /new to clear the chat.`;
+    ctxWarningText = `Context ${pct}% full. Consider /compact to free space, or /new for a fresh chat.`;
     ctxWarning = `<span class="pi-tooltip__warn pi-tooltip__warn--yellow">${ctxWarningText}</span>`;
   }
 
@@ -101,7 +101,7 @@ function renderStatusBar(
   }
 
   const instructionsBadge = instructionsActive
-    ? `<button class="pi-status-instructions" data-tooltip="Persistent instructions are active. Click to edit.">📋 instr</button>`
+    ? `<button class="pi-status-instructions" data-tooltip="Custom rules are being applied. Click to edit.">📋 rules</button>`
     : "";
 
   const integrationsBadge = activeIntegrations.length > 0
@@ -109,7 +109,7 @@ function renderStatusBar(
     : "";
 
   const thinkingTooltip = escapeAttr(
-    "Controls how long the model \"thinks\" before answering — higher = slower but better reasoning. Click to choose a level, or use ⇧Tab to cycle.",
+    "How deeply Pi reasons before answering — higher is slower but more thorough. Click to choose, or ⇧Tab to cycle.",
   );
 
   el.innerHTML = `

--- a/src/taskpane/status-popovers.ts
+++ b/src/taskpane/status-popovers.ts
@@ -39,12 +39,12 @@ const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
 };
 
 const THINKING_LEVEL_HINTS: Record<ThinkingLevel, string> = {
-  off: "Fastest",
-  minimal: "Very light reasoning",
-  low: "Balanced speed",
-  medium: "Stronger reasoning",
-  high: "Deep reasoning",
-  xhigh: "Deepest reasoning (slow)",
+  off: "Fastest — no reasoning step",
+  minimal: "Quick — light reasoning",
+  low: "Fast — moderate reasoning",
+  medium: "Balanced — solid reasoning",
+  high: "Slow — thorough reasoning",
+  xhigh: "Slowest — deepest reasoning",
 };
 
 let activePopover: ActivePopoverState | null = null;

--- a/src/ui/pi-input.ts
+++ b/src/ui/pi-input.ts
@@ -15,10 +15,10 @@ import { customElement, property, state, query } from "lit/decorators.js";
 import { doesOverlayClaimEscape } from "../utils/escape-guard.js";
 
 const PLACEHOLDER_HINTS = [
-  "Tell Pi what to build…",
+  "Ask Pi anything about your workbook…",
   "Type / for commands…",
-  "Tell Pi what to build…",
-  "Tell Pi what to build…",
+  "Ask Pi anything about your workbook…",
+  "Tell Pi what to change…",
 ];
 
 @customElement("pi-input")
@@ -155,7 +155,7 @@ export class PiInput extends LitElement {
         <textarea
           class="pi-input-textarea"
           .value=${this._value}
-          placeholder=${this.isStreaming ? "Steer (↵) · Follow-up (⌥↵)" : PLACEHOLDER_HINTS[this._placeholderIndex]}
+          placeholder=${this.isStreaming ? "Guide response (↵) · New question (⌥↵)" : PLACEHOLDER_HINTS[this._placeholderIndex]}
           rows="1"
           @input=${this._onInput}
           @keydown=${this._onKeydown}

--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -555,7 +555,7 @@ export class PiSidebar extends LitElement {
           Settings…
         </button>
         <button class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenFiles?.(); }}>
-          Files workspace…
+          Files…
         </button>
         <div class="pi-utilities-menu__divider"></div>
         <button class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenResumePicker?.(); }}>
@@ -565,7 +565,7 @@ export class PiSidebar extends LitElement {
           Recovery checkpoints…
         </button>
         <button class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenShortcuts?.(); }}>
-          Keyboard shortcuts
+          Keyboard shortcuts…
         </button>
       </div>
     `;

--- a/src/ui/working-indicator.ts
+++ b/src/ui/working-indicator.ts
@@ -14,10 +14,10 @@ import { pickWhimsicalMessage } from "./whimsical-messages.js";
 
 const HINTS: string[] = [
   "press Esc to stop",
-  "Shift+Tab to change thinking depth",
+  "⇧Tab to adjust reasoning depth",
   "type / to see commands",
-  "Ctrl+O to hide details",
-  "press Enter to guide the response",
+  "⌃O to collapse tool details",
+  "press Enter to redirect Pi",
 ];
 
 @customElement("pi-working-indicator")


### PR DESCRIPTION
## What

Rewrites all user-facing UI copy to be clearer and more precise, and fixes hint placement in the Instructions overlay.

## Why

The existing copy had several issues:
- **Instructions overlay**: the explanation of what instructions *are* was buried below the Save/Cancel buttons — users saw an empty textarea with no context
- **"Persistent instructions are active"** tooltip is unintuitive jargon
- Copy like "updated automatically when you express preferences" was unclear
- Implementation jargon leaked into user-facing text ("sandbox iframes", "host runtime", "inject instructions")
- Inconsistent hint formatting (thinking levels mixed speed/quality framing)

## Changes (9 files, copy-only — no logic changes)

### Instructions overlay
- **Moved hint text above the textarea** — users now read *what the feature is for* before the empty box
- Tabs: "My Instructions" / "Workbook" → "Personal" / "This Workbook"
- User hint: → "Rules Pi follows in every conversation. Pi can also update these when you tell it your preferences — e.g. \"always use EUR\"."
- Workbook hint: → "Rules that only apply when this workbook is open. Pi will confirm before adding anything here."
- Workbook unavailable: → "Can't identify this workbook right now — try saving the file first."

### Status bar
- Badge: `📋 instr` → `📋 rules`, tooltip → "Custom rules are being applied. Click to edit."
- Context tooltip: → "How much of Pi's memory (context window) the conversation is using — N / M tokens."
- Context warnings: "used up" → "full", tighter phrasing
- Thinking tooltip: removed scare-quotes, cleaner phrasing

### Input
- Placeholders: "Tell Pi what to build…" → "Ask Pi anything about your workbook…" / "Tell Pi what to change…"
- Streaming: "Steer (↵)" → "Guide response (↵)"

### Working indicator
- Use Unicode shortcuts (⇧Tab, ⌃O) matching macOS conventions
- "change thinking depth" → "adjust reasoning depth"
- "hide details" → "collapse tool details"

### Thinking popover
- Consistent "Speed — quality" format for all levels

### Overlays
- Skills subtitle: "inject instructions and external tools" → "Add capabilities like web search and external integrations"
- Extensions sandbox hint: removed "sandbox iframes" / "host runtime"
- Menu: "Files workspace…" → "Files…"; added trailing ellipsis to "Keyboard shortcuts…"

## Testing
- `npm run check` ✅ (lint + typecheck)
- `npm run build` ✅
