### PR TITLE
fix(extensions): align sandbox rollback semantics for untrusted sources

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,7 +2,7 @@
 
 Pi for Excel supports runtime extensions that can register slash commands, register tools, and render small UI elements in the sidebar.
 
-> Status: MVP+ (in progress). Inline-code and remote-URL extensions now run in sandbox runtime by default; built-in/local-module extensions stay on host runtime. Additive Widget API v2 is behind `/experimental on extension-widget-v2`.
+> Status: MVP+ (in progress). Inline-code and remote-URL extensions run in sandbox runtime by default; built-in/local-module extensions stay on host runtime. Roll back untrusted sources to host runtime only via `/experimental on extension-sandbox-rollback`. Additive Widget API v2 is behind `/experimental on extension-widget-v2`.
 
 ## Quick start
 
@@ -176,23 +176,26 @@ High-risk capabilities include:
 - `agent.read`
 - `agent.events.read`
 
-## Sandbox runtime (default-on)
-
-Sandboxed runtime execution is now the default for untrusted extension sources.
+## Sandbox runtime default + rollback kill switch
 
 Default behavior:
 - inline-code and remote-URL extensions run in an iframe sandbox runtime
 - built-in/local-module extensions stay on host runtime
 - `/extensions` shows runtime mode per extension
 
-Rollback kill switch (temporary rollout safety valve):
+If maintainers need an emergency rollback path, enable host-runtime fallback for untrusted sources:
 
 ```txt
-/experimental off extension-sandbox   # rollback: untrusted extensions run in host runtime
-/experimental on extension-sandbox    # re-enable sandbox default behavior
+/experimental on extension-sandbox-rollback
 ```
 
-You can also toggle rollback mode directly in `/extensions` via the **Sandbox runtime (default for untrusted sources)** card.
+Disable rollback and return to default sandbox routing:
+
+```txt
+/experimental off extension-sandbox-rollback
+```
+
+You can also toggle this in `/extensions` via the **Sandbox runtime (default for untrusted sources)** card.
 
 Current sandbox bridge limitations (intentional for this slice):
 - `api.agent` is not available in sandbox runtime
@@ -230,6 +233,7 @@ If a local specifier is not bundled, loading fails with a clear error.
 
 - Extensions can read/write workbook data through registered tools and host APIs.
 - Remote URL loading is intentionally off by default.
-- Untrusted extension sources (`inline-code`, `remote-url`) default to sandbox runtime; trusted local/built-in modules stay host-side.
-- If you must roll back quickly, use `/experimental off extension-sandbox` (and re-enable with `/experimental on extension-sandbox` once stable).
+- Untrusted extension sources (inline/remote) run in sandbox runtime by default.
+- Built-in/local-module extensions remain on host runtime.
 - Experimental capability gates can be enabled with `/experimental on extension-permissions`.
+- Rollback kill switch for untrusted host-runtime fallback: `/experimental on extension-sandbox-rollback`.

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -223,11 +223,11 @@ https://github.com/tmustier/pi-for-excel/issues/13
 **Status note:** MVP is now shipped (extension manager UI, dynamic loading, persisted registry, extension tool registration, lifecycle cleanup).
 
 **Remaining tracked follow-ups:**
-- #111 — graduate sandbox runtime for untrusted sources (default-on rollout + rollback switch)
 - #80 — widget API evolution
 
 **Recently closed:**
-- #79 — sandbox + permissions model (delivered via #84/#86/#92/#107)
+- #111 — sandbox runtime default-on for untrusted sources + rollback kill switch
+- #79 — sandbox + permissions model umbrella
 - #81 — extension authoring docs (merged in #82)
 
 **Implication:** keep extension architecture additive while we harden:

--- a/src/experiments/flags.ts
+++ b/src/experiments/flags.ts
@@ -93,16 +93,13 @@ const EXPERIMENTAL_FEATURES = [
   },
   {
     id: "extension_sandbox_runtime",
-    slug: "extension-sandbox",
-    aliases: ["extensions-sandbox", "sandboxed-extensions"],
-    title: "Extension sandbox runtime",
-    description:
-      "Default-on for inline/remote extensions. Disable only to enable temporary rollback mode.",
-    warning:
-      "Security-sensitive: disabling this runs untrusted extensions in host runtime and reduces isolation.",
+    slug: "extension-sandbox-rollback",
+    aliases: ["extension-sandbox", "extensions-sandbox", "sandboxed-extensions", "extension-host-fallback"],
+    title: "Extension sandbox rollback",
+    description: "Temporarily route untrusted extensions back to host runtime (kill switch).",
+    warning: "Use only as a rollback path. Default behavior runs untrusted extensions in sandbox iframes.",
     wiring: "wired",
-    storageKey: "pi.experimental.extensionSandboxRuntime",
-    defaultEnabled: true,
+    storageKey: "pi.experimental.extensionSandboxHostFallback",
   },
   {
     id: "extension_widget_v2",

--- a/src/extensions/runtime-manager.ts
+++ b/src/extensions/runtime-manager.ts
@@ -175,7 +175,7 @@ export class ExtensionRuntimeManager {
 
   list(): ExtensionRuntimeStatus[] {
     const permissionsEnforced = isExperimentalFeatureEnabled("extension_permission_gates");
-    const sandboxRuntimeActive = isExperimentalFeatureEnabled("extension_sandbox_runtime");
+    const sandboxHostFallbackEnabled = isExperimentalFeatureEnabled("extension_sandbox_runtime");
 
     return this.entries.map((entry) => {
       const state = this.activeStates.get(entry.id);
@@ -185,7 +185,7 @@ export class ExtensionRuntimeManager {
         : listAllExtensionCapabilities();
       const runtimeMode = state
         ? state.runtimeMode
-        : resolveExtensionRuntimeMode(entry.trust, sandboxRuntimeActive);
+        : resolveExtensionRuntimeMode(entry.trust, sandboxHostFallbackEnabled);
 
       return {
         id: entry.id,

--- a/src/extensions/runtime-mode.ts
+++ b/src/extensions/runtime-mode.ts
@@ -12,13 +12,13 @@ export function isSandboxCandidateTrust(trust: StoredExtensionTrust): boolean {
 
 export function resolveExtensionRuntimeMode(
   trust: StoredExtensionTrust,
-  sandboxRuntimeEnabled: boolean,
+  sandboxHostFallbackEnabled: boolean,
 ): ExtensionRuntimeMode {
-  if (!sandboxRuntimeEnabled) {
+  if (!isSandboxCandidateTrust(trust)) {
     return "host";
   }
 
-  return isSandboxCandidateTrust(trust) ? "sandbox-iframe" : "host";
+  return sandboxHostFallbackEnabled ? "host" : "sandbox-iframe";
 }
 
 export function describeExtensionRuntimeMode(mode: ExtensionRuntimeMode): string {

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -188,12 +188,13 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
 - **Execution policy:** treated as `read/none` for workbook coordination (mutates local extension registry/runtime only, not workbook cells/structure).
 - **Rationale:** supports non-engineer extension authoring by allowing users to ask Pi to generate + install an extension directly.
 
-## Extension sandbox UI bridge (`extension-sandbox`)
-- **Activation model:** default-on for untrusted sources with a temporary rollback kill switch via `/experimental off extension-sandbox`.
-- **Surface:** inline-code + remote-url extensions route to iframe runtime by default; built-in/local modules remain host-side.
+## Extension sandbox UI bridge (default-on for untrusted)
+- **Default routing:** inline-code + remote-url extensions run in iframe sandbox runtime by default; built-in/local modules remain host-side.
+- **Rollback switch:** maintainers can temporarily route untrusted extensions back to host runtime via `/experimental on extension-sandbox-rollback`.
+- **Surface:** sandbox runtime bridges command/tool/event/UI calls through explicit host contracts rather than exposing host internals directly.
 - **UI model:** sandbox may only send a structured UI tree (allowed tag set, sanitized class names/action ids), never raw HTML.
 - **Interactivity:** host supports explicit action callbacks via `data-pi-action` markers mapped to click dispatch inside the sandbox.
-- **Rationale:** incremental security hardening—default isolation for untrusted code without reopening HTML injection risk.
+- **Rationale:** graduate sandbox hardening into default behavior while preserving a guarded rollback path.
 
 ## Experimental extension widget API v2 (`extension-widget-v2`)
 - **Activation:** opt-in via `/experimental on extension-widget-v2`; default behavior stays on legacy `widget.show/dismiss` semantics.

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -84,7 +84,7 @@ void test("builtins registry wires /experimental, /extensions, and /integrations
   assert.match(extensionsOverlaySource, /Sandbox runtime \(default for untrusted sources\)/);
   assert.match(extensionsOverlaySource, /setExperimentalFeatureEnabled\("extension_sandbox_runtime", true\)/);
   assert.match(extensionsOverlaySource, /setExperimentalFeatureEnabled\("extension_sandbox_runtime", false\)/);
-  assert.match(extensionsOverlaySource, /Rollback mode is active: this untrusted extension runs in host runtime/);
+  assert.match(extensionsOverlaySource, /Host-runtime fallback is enabled: this untrusted extension runs in host runtime/);
   assert.match(extensionsOverlaySource, /higher-risk permissions/);
   assert.match(extensionsOverlaySource, /Updated permissions for/);
   assert.match(extensionsOverlaySource, /reload failed \(see Last error\)/);
@@ -99,8 +99,7 @@ void test("builtins registry wires /experimental, /extensions, and /integrations
   assert.match(experimentalFlagsSource, /extension_permission_gates/);
   assert.match(experimentalFlagsSource, /extension-permissions/);
   assert.match(experimentalFlagsSource, /extension_sandbox_runtime/);
-  assert.match(experimentalFlagsSource, /extension-sandbox/);
-  assert.match(experimentalFlagsSource, /defaultEnabled:\s*true/);
+  assert.match(experimentalFlagsSource, /extension-sandbox-rollback/);
   assert.match(experimentalFlagsSource, /extension_widget_v2/);
   assert.match(experimentalFlagsSource, /extension-widget-v2/);
 });

--- a/tests/extensions-runtime-manager-sandbox.test.ts
+++ b/tests/extensions-runtime-manager-sandbox.test.ts
@@ -44,7 +44,7 @@ class MemoryLocalStorage {
   }
 }
 
-const EXTENSION_SANDBOX_RUNTIME_STORAGE_KEY = "pi.experimental.extensionSandboxRuntime";
+const EXTENSION_SANDBOX_RUNTIME_STORAGE_KEY = "pi.experimental.extensionSandboxHostFallback";
 
 function clearLocalStorageKey(key: string): void {
   const storage = Reflect.get(globalThis, "localStorage");
@@ -180,7 +180,7 @@ void test("rollback kill switch routes untrusted extensions back to host runtime
   const restoreLocalStorage = installLocalStorageStub();
 
   try {
-    setExperimentalFeatureEnabled("extension_sandbox_runtime", false);
+    setExperimentalFeatureEnabled("extension_sandbox_runtime", true);
 
     const settings = new MemorySettingsStore();
     settings.writeRaw(EXTENSIONS_REGISTRY_STORAGE_KEY, {
@@ -312,7 +312,7 @@ void test("sandbox activation failures are isolated per extension during initial
   const restoreLocalStorage = installLocalStorageStub();
 
   try {
-    setExperimentalFeatureEnabled("extension_sandbox_runtime", true);
+    setExperimentalFeatureEnabled("extension_sandbox_runtime", false);
     setExperimentalFeatureEnabled("extension_permission_gates", true);
 
     const settings = new MemorySettingsStore();
@@ -377,7 +377,7 @@ void test("sandbox capability denial surfaces deterministic permission error", a
   const restoreLocalStorage = installLocalStorageStub();
 
   try {
-    setExperimentalFeatureEnabled("extension_sandbox_runtime", true);
+    setExperimentalFeatureEnabled("extension_sandbox_runtime", false);
     setExperimentalFeatureEnabled("extension_permission_gates", true);
 
     const basePermissions = getDefaultPermissionsForTrust("inline-code");

--- a/tests/extensions-runtime-mode.test.ts
+++ b/tests/extensions-runtime-mode.test.ts
@@ -18,18 +18,18 @@ void test("isSandboxCandidateTrust only flags inline/remote trust", () => {
   assert.equal(isSandboxCandidateTrust("remote-url"), true);
 });
 
-void test("resolveExtensionRuntimeMode uses host runtime when sandbox flag is disabled", () => {
+void test("resolveExtensionRuntimeMode defaults untrusted sources to sandbox runtime", () => {
   assert.equal(resolveExtensionRuntimeMode("builtin", false), "host");
   assert.equal(resolveExtensionRuntimeMode("local-module", false), "host");
-  assert.equal(resolveExtensionRuntimeMode("inline-code", false), "host");
-  assert.equal(resolveExtensionRuntimeMode("remote-url", false), "host");
+  assert.equal(resolveExtensionRuntimeMode("inline-code", false), "sandbox-iframe");
+  assert.equal(resolveExtensionRuntimeMode("remote-url", false), "sandbox-iframe");
 });
 
-void test("resolveExtensionRuntimeMode routes inline/remote trust to sandbox when enabled", () => {
+void test("resolveExtensionRuntimeMode rollback flag routes untrusted sources to host runtime", () => {
   assert.equal(resolveExtensionRuntimeMode("builtin", true), "host");
   assert.equal(resolveExtensionRuntimeMode("local-module", true), "host");
-  assert.equal(resolveExtensionRuntimeMode("inline-code", true), "sandbox-iframe");
-  assert.equal(resolveExtensionRuntimeMode("remote-url", true), "sandbox-iframe");
+  assert.equal(resolveExtensionRuntimeMode("inline-code", true), "host");
+  assert.equal(resolveExtensionRuntimeMode("remote-url", true), "host");
 });
 
 void test("describeExtensionRuntimeMode returns user-facing labels", () => {


### PR DESCRIPTION
## Summary
- make untrusted extension routing semantics explicit: sandbox remains default, while `extension_sandbox_runtime` is treated as a **host-runtime fallback kill switch**
- align `/extensions` sandbox card copy, status badges, warnings, and toasts with rollback semantics
- keep `/experimental` compatibility while renaming the primary slug to `extension-sandbox-rollback`
- update docs/tests for the default-on sandbox + rollback path model

## Changes
- `src/extensions/runtime-mode.ts`
- `src/extensions/runtime-manager.ts`
- `src/experiments/flags.ts`
- `src/commands/builtins/extensions-overlay.ts`
- `tests/extensions-runtime-mode.test.ts`
- `tests/extensions-runtime-manager-sandbox.test.ts`
- `tests/builtins-registry.test.ts`
- `docs/extensions.md`
- `docs/upcoming.md`
- `src/tools/DECISIONS.md`

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`

## Notes
- follow-up semantic cleanup after #116 so flag/copy behavior consistently reflects rollback intent.
