### PR TITLE
feat(skills): slice B refresh semantics + structured details

### DIFF
--- a/docs/agent-skills-interop.md
+++ b/docs/agent-skills-interop.md
@@ -31,6 +31,7 @@ The add-in now exposes a `skills` tool for standards-based skill loading:
 
 - `skills` action=`list` → lists bundled Agent Skills
 - `skills` action=`read` + `name` → returns full `SKILL.md`
+- `skills` action=`read` + `name` + `refresh=true` → bypasses cache and refreshes from catalog
 
 Runtime note: `skills` reads are cached per session runtime so repeated reads for the same skill avoid repeated catalog lookup. The cache is cleared when the runtime session identity changes (new/resume/switch context).
 

--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -100,7 +100,7 @@ function buildAvailableSkillsSection(availableSkills: AvailableSkillPromptEntry[
   const lines: string[] = [
     "## Available Agent Skills",
     "When a task matches one of these skills, call the **skills** tool with action=\"read\" and the skill name.",
-    "Read each skill once per session and reuse it from context; avoid repeated reads unless the user asks to refresh.",
+    "Read each skill once per session and reuse it from context; avoid repeated reads unless the user asks to refresh (then use action=\"read\" with refresh=true).",
     "",
     "<available_skills>",
   ];

--- a/src/skills/read-cache.ts
+++ b/src/skills/read-cache.ts
@@ -3,6 +3,7 @@
  */
 
 export interface SkillReadCacheEntry {
+  skillName: string;
   markdown: string;
   cachedAt: number;
   readCount: number;
@@ -49,6 +50,7 @@ export function createSkillReadCache(): SkillReadCache {
       const previous = sessionCache.get(normalizedName);
 
       const next: SkillReadCacheEntry = {
+        skillName,
         markdown,
         cachedAt: Date.now(),
         readCount: previous ? previous.readCount + 1 : 1,

--- a/src/tools/tool-details.ts
+++ b/src/tools/tool-details.ts
@@ -199,6 +199,31 @@ export interface WorkbookHistoryDetails {
   error?: string;
 }
 
+export interface SkillsListDetails {
+  kind: "skills_list";
+  count: number;
+  names: string[];
+}
+
+export interface SkillsReadDetails {
+  kind: "skills_read";
+  skillName: string;
+  cacheHit: boolean;
+  refreshed: boolean;
+  sessionScoped: boolean;
+  readCount?: number;
+}
+
+export interface SkillsErrorDetails {
+  kind: "skills_error";
+  action: "read";
+  message: string;
+  requestedName?: string;
+  availableNames?: string[];
+}
+
+export type SkillsToolDetails = SkillsListDetails | SkillsReadDetails | SkillsErrorDetails;
+
 export interface WebSearchDetails {
   kind: "web_search";
   ok: boolean;
@@ -300,6 +325,7 @@ export type ExcelToolDetails =
   | LibreOfficeBridgeDetails
   | PythonTransformRangeDetails
   | WorkbookHistoryDetails
+  | SkillsToolDetails
   | WebSearchDetails
   | McpGatewayDetails
   | FilesToolDetails;
@@ -326,6 +352,10 @@ function isOptionalTraceDependencySource(value: unknown): value is TraceDependen
 
 function isOptionalStringArray(value: unknown): value is string[] | undefined {
   return value === undefined || (Array.isArray(value) && value.every((item) => typeof item === "string"));
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 function isRecoveryCheckpointDetails(value: unknown): value is RecoveryCheckpointDetails {
@@ -655,6 +685,41 @@ export function isWorkbookHistoryDetails(value: unknown): value is WorkbookHisto
     isOptionalNumber(value.changedCount) &&
     isOptionalNumber(value.deletedCount) &&
     isOptionalString(value.error)
+  );
+}
+
+export function isSkillsListDetails(value: unknown): value is SkillsListDetails {
+  if (!isRecord(value)) return false;
+  if (value.kind !== "skills_list") return false;
+
+  return (
+    typeof value.count === "number" &&
+    isStringArray(value.names)
+  );
+}
+
+export function isSkillsReadDetails(value: unknown): value is SkillsReadDetails {
+  if (!isRecord(value)) return false;
+  if (value.kind !== "skills_read") return false;
+
+  return (
+    typeof value.skillName === "string" &&
+    typeof value.cacheHit === "boolean" &&
+    typeof value.refreshed === "boolean" &&
+    typeof value.sessionScoped === "boolean" &&
+    isOptionalNumber(value.readCount)
+  );
+}
+
+export function isSkillsErrorDetails(value: unknown): value is SkillsErrorDetails {
+  if (!isRecord(value)) return false;
+  if (value.kind !== "skills_error") return false;
+  if (value.action !== "read") return false;
+
+  return (
+    typeof value.message === "string" &&
+    isOptionalString(value.requestedName) &&
+    isOptionalStringArray(value.availableNames)
   );
 }
 

--- a/src/ui/humanize-params.ts
+++ b/src/ui/humanize-params.ts
@@ -737,6 +737,10 @@ function humanizeSkills(p: Record<string, unknown>): ParamItem[] {
     items.push({ label: "Skill", value: str(p.name) });
   }
 
+  if (p.refresh === true) {
+    items.push({ label: "Refresh", value: "yes" });
+  }
+
   return items;
 }
 

--- a/src/ui/tool-renderers.ts
+++ b/src/ui/tool-renderers.ts
@@ -24,6 +24,7 @@ import {
   isModifyStructureDetails,
   isPythonTransformRangeDetails,
   isReadRangeCsvDetails,
+  isSkillsReadDetails,
   isTraceDependenciesDetails,
   isViewSettingsDetails,
   isWorkbookHistoryDetails,
@@ -937,9 +938,24 @@ function describeToolCall(
     case "skills": {
       const action = p.action as string | undefined;
       const name = p.name as string | undefined;
+      const refresh = p.refresh === true;
+
       if (action === "read") {
-        return { action: "Read skill", detail: name ?? "name" };
+        const detailName = isSkillsReadDetails(details)
+          ? details.skillName
+          : name ?? "name";
+
+        if (isSkillsReadDetails(details) && details.cacheHit) {
+          return { action: "Read skill", detail: `${detailName} (cached)` };
+        }
+
+        if (refresh) {
+          return { action: "Refresh skill", detail: detailName };
+        }
+
+        return { action: "Read skill", detail: detailName };
       }
+
       return { action: "List skills", detail: "" };
     }
     case "web_search": {

--- a/tests/skills-read-cache.test.ts
+++ b/tests/skills-read-cache.test.ts
@@ -11,6 +11,7 @@ void test("skill read cache stores and retrieves per session", () => {
 
   const cached = cache.get("session-1", "web-search");
   assert.ok(cached);
+  assert.equal(cached?.skillName, "web-search");
   assert.equal(cached?.markdown, "# Web Search");
   assert.equal(cached?.readCount, 1);
 });

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -104,6 +104,7 @@ void test("system prompt renders available skills XML section", () => {
 
   assert.match(prompt, /## Available Agent Skills/);
   assert.match(prompt, /Read each skill once per session/i);
+  assert.match(prompt, /refresh=true/);
   assert.match(prompt, /<available_skills>/);
   assert.match(prompt, /<name>web-search<\/name>/);
   assert.match(prompt, /<location>skills\/web-search\/SKILL\.md<\/location>/);


### PR DESCRIPTION
## Summary

Implements **Issue #124 Slice B**: duplicate-read suppression semantics for the `skills` tool with explicit refresh behavior and structured result metadata.

## What changed

- Added `refresh` option to `skills` tool (`action="read"`):
  - `refresh=true` bypasses session cache and reloads from catalog.
- Added structured `ToolResultMessage.details` payloads for skills operations:
  - `skills_list`
  - `skills_read`
  - `skills_error`
- Added central types/guards in `src/tools/tool-details.ts`.
- Updated `skills` tool implementation to return structured details and expose cache-hit/refresh/session-scope metadata.
- Enhanced UI rendering/humanization for skills calls:
  - input shows `refresh: yes`
  - renderer label distinguishes cached reads / refresh reads
- Tightened prompt guidance to explicitly reference `refresh=true` for refresh requests.
- Updated docs (`docs/agent-skills-interop.md`) with refresh semantics.

## Validation

- `npm run check`
- `npm run test:context`
- targeted tests:
  - `tests/skills-read-cache.test.ts`
  - `tests/skills-tool.test.ts`
  - `tests/system-prompt.test.ts`
