### PR TITLE
feat(recovery): broaden conditional_format checkpoint rule coverage

### DIFF
--- a/docs/design-yolo-recovery.md
+++ b/docs/design-yolo-recovery.md
@@ -60,6 +60,7 @@ Replace cumbersome up-front approval selectors with a low-friction workflow:
 - Coverage signaling:
   - unsupported mutation tools/actions explicitly state when no checkpoint is created
   - `format_cells` checkpoint coverage now includes merge/unmerge state
+  - `conditional_format` checkpoint coverage includes `custom`, `cell_value`, `contains_text`, `top_bottom`, and `preset_criteria` rules
   - `modify_structure` currently checkpoints only `rename_sheet`, `hide_sheet`, and `unhide_sheet`
 
 ## Why this is better than approval selectors for now
@@ -70,7 +71,7 @@ Replace cumbersome up-front approval selectors with a low-friction workflow:
 
 ## Follow-ups
 
-1. Extend checkpointing to remaining unsupported `modify_structure` actions (`insert_rows`, `delete_rows`, `insert_columns`, `delete_columns`, `add_sheet`, `delete_sheet`, `duplicate_sheet`) and broaden conditional-format coverage to additional rule types.
+1. Extend checkpointing to remaining unsupported `modify_structure` actions (`insert_rows`, `delete_rows`, `insert_columns`, `delete_columns`, `add_sheet`, `delete_sheet`, `duplicate_sheet`) and the remaining conditional-format visual rule types (`data_bar`, `color_scale`, `icon_set`).
 2. Enrich checkpoint history UX (search/filter/export, retention controls).
 3. Evaluate host-specific full-file snapshot feasibility for coarse-grained restore points.
 4. Potentially expose “YOLO mode” toggle once we have both lightweight and strict workflows fully defined.

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -102,9 +102,10 @@ https://github.com/tmustier/pi-for-excel/issues/27
 - dedicated backup browser overlay (menu + `/history`) with restore/delete/clear controls
 - restore creates an inverse backup so rollbacks are themselves reversible
 - unsupported mutation tools/actions (including unsupported `modify_structure` variants) explicitly report when no backup is created
+- conditional-format backup restore now covers `custom`, `cell_value`, `contains_text`, `top_bottom`, and `preset_criteria` rules
 
 **Remaining follow-up:**
-- broader remaining coverage (unsupported `modify_structure` actions plus additional conditional-format rule types)
+- broader remaining coverage (unsupported `modify_structure` actions plus remaining conditional-format visual rules: `data_bar`, `color_scale`, `icon_set`)
 - richer history UX (search/filter/export, retention controls)
 - feasibility deep-dive for full-file snapshots vs range snapshots in Office.js
 

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -249,5 +249,6 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
 - **Coverage signaling:** unsupported `modify_structure` actions and mutating `view_settings` actions explicitly report when no backup was created.
 - **Current `modify_structure` backup limits:** captures/restores only `rename_sheet`, `hide_sheet`, and `unhide_sheet` actions.
 - **Current `format_cells` backup scope:** captures/restores core range-format properties (font/fill/number format/alignment/wrap/borders), row/column dimensions (`column_width`, `row_height`, `auto_fit`), and merge state (`merge`/`unmerge`).
+- **Current `conditional_format` backup scope:** captures/restores `custom`, `cell_value`, `contains_text`, `top_bottom`, and `preset_criteria` rules (including per-rule applies-to ranges). Visual rule families (`data_bar`, `color_scale`, `icon_set`) remain unsupported for now.
 - **Quick affordance:** users can restore via `/history` (Backups overlay) or `/revert` (latest backup).
 - **Rationale:** addresses #27 by shifting from cumbersome up-front approvals to versioned recovery with explicit user-controlled rollback.

--- a/src/workbook/recovery-log.ts
+++ b/src/workbook/recovery-log.ts
@@ -522,10 +522,16 @@ function isRecoveryConditionalFormatRule(value: unknown): value is RecoveryCondi
   if (!isRecord(value)) return false;
 
   const type = value.type;
-  if (type !== "custom" && type !== "cell_value") return false;
+  const validType =
+    type === "custom" ||
+    type === "cell_value" ||
+    type === "text_comparison" ||
+    type === "top_bottom" ||
+    type === "preset_criteria";
+  if (!validType) return false;
 
   const operator = value.operator;
-  const validOperator = operator === undefined || (
+  const validCellValueOperator = operator === undefined || (
     operator === "Between" ||
     operator === "NotBetween" ||
     operator === "EqualTo" ||
@@ -535,21 +541,87 @@ function isRecoveryConditionalFormatRule(value: unknown): value is RecoveryCondi
     operator === "GreaterThanOrEqual" ||
     operator === "LessThanOrEqual"
   );
+  if (!validCellValueOperator) return false;
 
-  if (!validOperator) return false;
-
-  return (
-    (value.stopIfTrue === undefined || typeof value.stopIfTrue === "boolean") &&
-    (value.formula === undefined || typeof value.formula === "string") &&
-    (value.formula1 === undefined || typeof value.formula1 === "string") &&
-    (value.formula2 === undefined || typeof value.formula2 === "string") &&
-    (value.fillColor === undefined || typeof value.fillColor === "string") &&
-    (value.fontColor === undefined || typeof value.fontColor === "string") &&
-    (value.bold === undefined || typeof value.bold === "boolean") &&
-    (value.italic === undefined || typeof value.italic === "boolean") &&
-    (value.underline === undefined || typeof value.underline === "boolean") &&
-    (value.appliesToAddress === undefined || typeof value.appliesToAddress === "string")
+  const textOperator = value.textOperator;
+  const validTextOperator = textOperator === undefined || (
+    textOperator === "Contains" ||
+    textOperator === "NotContains" ||
+    textOperator === "BeginsWith" ||
+    textOperator === "EndsWith"
   );
+  if (!validTextOperator) return false;
+
+  const topBottomType = value.topBottomType;
+  const validTopBottomType = topBottomType === undefined || (
+    topBottomType === "TopItems" ||
+    topBottomType === "TopPercent" ||
+    topBottomType === "BottomItems" ||
+    topBottomType === "BottomPercent"
+  );
+  if (!validTopBottomType) return false;
+
+  const presetCriterion = value.presetCriterion;
+  const validPresetCriterion = presetCriterion === undefined || (
+    presetCriterion === "Blanks" ||
+    presetCriterion === "NonBlanks" ||
+    presetCriterion === "Errors" ||
+    presetCriterion === "NonErrors" ||
+    presetCriterion === "Yesterday" ||
+    presetCriterion === "Today" ||
+    presetCriterion === "Tomorrow" ||
+    presetCriterion === "LastSevenDays" ||
+    presetCriterion === "LastWeek" ||
+    presetCriterion === "ThisWeek" ||
+    presetCriterion === "NextWeek" ||
+    presetCriterion === "LastMonth" ||
+    presetCriterion === "ThisMonth" ||
+    presetCriterion === "NextMonth" ||
+    presetCriterion === "AboveAverage" ||
+    presetCriterion === "BelowAverage" ||
+    presetCriterion === "EqualOrAboveAverage" ||
+    presetCriterion === "EqualOrBelowAverage" ||
+    presetCriterion === "OneStdDevAboveAverage" ||
+    presetCriterion === "OneStdDevBelowAverage" ||
+    presetCriterion === "TwoStdDevAboveAverage" ||
+    presetCriterion === "TwoStdDevBelowAverage" ||
+    presetCriterion === "ThreeStdDevAboveAverage" ||
+    presetCriterion === "ThreeStdDevBelowAverage" ||
+    presetCriterion === "UniqueValues" ||
+    presetCriterion === "DuplicateValues"
+  );
+  if (!validPresetCriterion) return false;
+
+  if (value.stopIfTrue !== undefined && typeof value.stopIfTrue !== "boolean") return false;
+  if (value.formula !== undefined && typeof value.formula !== "string") return false;
+  if (value.formula1 !== undefined && typeof value.formula1 !== "string") return false;
+  if (value.formula2 !== undefined && typeof value.formula2 !== "string") return false;
+  if (value.text !== undefined && typeof value.text !== "string") return false;
+  if (value.rank !== undefined && (typeof value.rank !== "number" || !Number.isFinite(value.rank))) return false;
+  if (value.fillColor !== undefined && typeof value.fillColor !== "string") return false;
+  if (value.fontColor !== undefined && typeof value.fontColor !== "string") return false;
+  if (value.bold !== undefined && typeof value.bold !== "boolean") return false;
+  if (value.italic !== undefined && typeof value.italic !== "boolean") return false;
+  if (value.underline !== undefined && typeof value.underline !== "boolean") return false;
+  if (value.appliesToAddress !== undefined && typeof value.appliesToAddress !== "string") return false;
+
+  if (type === "custom") {
+    return typeof value.formula === "string";
+  }
+
+  if (type === "cell_value") {
+    return validCellValueOperator && typeof value.operator === "string" && typeof value.formula1 === "string";
+  }
+
+  if (type === "text_comparison") {
+    return validTextOperator && typeof value.textOperator === "string" && typeof value.text === "string";
+  }
+
+  if (type === "top_bottom") {
+    return validTopBottomType && typeof value.topBottomType === "string" && typeof value.rank === "number";
+  }
+
+  return validPresetCriterion && typeof value.presetCriterion === "string";
 }
 
 function isRecoveryCommentThreadState(value: unknown): value is RecoveryCommentThreadState {

--- a/src/workbook/recovery-states.ts
+++ b/src/workbook/recovery-states.ts
@@ -11,13 +11,65 @@ export type RecoveryConditionalCellValueOperator =
   | "GreaterThanOrEqual"
   | "LessThanOrEqual";
 
+export type RecoveryConditionalTextOperator =
+  | "Contains"
+  | "NotContains"
+  | "BeginsWith"
+  | "EndsWith";
+
+export type RecoveryConditionalTopBottomCriterionType =
+  | "TopItems"
+  | "TopPercent"
+  | "BottomItems"
+  | "BottomPercent";
+
+export type RecoveryConditionalPresetCriterion =
+  | "Blanks"
+  | "NonBlanks"
+  | "Errors"
+  | "NonErrors"
+  | "Yesterday"
+  | "Today"
+  | "Tomorrow"
+  | "LastSevenDays"
+  | "LastWeek"
+  | "ThisWeek"
+  | "NextWeek"
+  | "LastMonth"
+  | "ThisMonth"
+  | "NextMonth"
+  | "AboveAverage"
+  | "BelowAverage"
+  | "EqualOrAboveAverage"
+  | "EqualOrBelowAverage"
+  | "OneStdDevAboveAverage"
+  | "OneStdDevBelowAverage"
+  | "TwoStdDevAboveAverage"
+  | "TwoStdDevBelowAverage"
+  | "ThreeStdDevAboveAverage"
+  | "ThreeStdDevBelowAverage"
+  | "UniqueValues"
+  | "DuplicateValues";
+
+export type RecoveryConditionalFormatRuleType =
+  | "custom"
+  | "cell_value"
+  | "text_comparison"
+  | "top_bottom"
+  | "preset_criteria";
+
 export interface RecoveryConditionalFormatRule {
-  type: "custom" | "cell_value";
+  type: RecoveryConditionalFormatRuleType;
   stopIfTrue?: boolean;
   formula?: string;
   operator?: RecoveryConditionalCellValueOperator;
   formula1?: string;
   formula2?: string;
+  textOperator?: RecoveryConditionalTextOperator;
+  text?: string;
+  topBottomType?: RecoveryConditionalTopBottomCriterionType;
+  rank?: number;
+  presetCriterion?: RecoveryConditionalPresetCriterion;
   fillColor?: string;
   fontColor?: string;
   bold?: boolean;
@@ -133,6 +185,49 @@ const SUPPORTED_CELL_VALUE_OPERATORS: readonly RecoveryConditionalCellValueOpera
   "LessThanOrEqual",
 ];
 
+const SUPPORTED_TEXT_OPERATORS: readonly RecoveryConditionalTextOperator[] = [
+  "Contains",
+  "NotContains",
+  "BeginsWith",
+  "EndsWith",
+];
+
+const SUPPORTED_TOP_BOTTOM_TYPES: readonly RecoveryConditionalTopBottomCriterionType[] = [
+  "TopItems",
+  "TopPercent",
+  "BottomItems",
+  "BottomPercent",
+];
+
+const SUPPORTED_PRESET_CRITERIA: readonly RecoveryConditionalPresetCriterion[] = [
+  "Blanks",
+  "NonBlanks",
+  "Errors",
+  "NonErrors",
+  "Yesterday",
+  "Today",
+  "Tomorrow",
+  "LastSevenDays",
+  "LastWeek",
+  "ThisWeek",
+  "NextWeek",
+  "LastMonth",
+  "ThisMonth",
+  "NextMonth",
+  "AboveAverage",
+  "BelowAverage",
+  "EqualOrAboveAverage",
+  "EqualOrBelowAverage",
+  "OneStdDevAboveAverage",
+  "OneStdDevBelowAverage",
+  "TwoStdDevAboveAverage",
+  "TwoStdDevBelowAverage",
+  "ThreeStdDevAboveAverage",
+  "ThreeStdDevBelowAverage",
+  "UniqueValues",
+  "DuplicateValues",
+];
+
 const RECOVERY_BORDER_KEYS = [
   "borderTop",
   "borderBottom",
@@ -166,6 +261,42 @@ function isRecoveryConditionalCellValueOperator(value: unknown): value is Recove
 
   for (const operator of SUPPORTED_CELL_VALUE_OPERATORS) {
     if (operator === value) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isRecoveryConditionalTextOperator(value: unknown): value is RecoveryConditionalTextOperator {
+  if (typeof value !== "string") return false;
+
+  for (const operator of SUPPORTED_TEXT_OPERATORS) {
+    if (operator === value) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isRecoveryConditionalTopBottomCriterionType(value: unknown): value is RecoveryConditionalTopBottomCriterionType {
+  if (typeof value !== "string") return false;
+
+  for (const type of SUPPORTED_TOP_BOTTOM_TYPES) {
+    if (type === value) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isRecoveryConditionalPresetCriterion(value: unknown): value is RecoveryConditionalPresetCriterion {
+  if (typeof value !== "string") return false;
+
+  for (const criterion of SUPPORTED_PRESET_CRITERIA) {
+    if (criterion === value) {
       return true;
     }
   }
@@ -298,13 +429,25 @@ function isRecoverySheetVisibility(value: unknown): value is RecoverySheetVisibi
   return value === "Visible" || value === "Hidden" || value === "VeryHidden";
 }
 
-function normalizeConditionalFormatType(type: unknown): "custom" | "cell_value" | null {
+function normalizeConditionalFormatType(type: unknown): RecoveryConditionalFormatRuleType | null {
   if (type === "Custom" || type === "custom") {
     return "custom";
   }
 
   if (type === "CellValue" || type === "cellValue") {
     return "cell_value";
+  }
+
+  if (type === "ContainsText" || type === "containsText") {
+    return "text_comparison";
+  }
+
+  if (type === "TopBottom" || type === "topBottom") {
+    return "top_bottom";
+  }
+
+  if (type === "PresetCriteria" || type === "presetCriteria") {
+    return "preset_criteria";
   }
 
   return null;
@@ -377,6 +520,11 @@ function cloneRecoveryConditionalFormatRule(rule: RecoveryConditionalFormatRule)
     operator: rule.operator,
     formula1: rule.formula1,
     formula2: rule.formula2,
+    textOperator: rule.textOperator,
+    text: rule.text,
+    topBottomType: rule.topBottomType,
+    rank: rule.rank,
+    presetCriterion: rule.presetCriterion,
     fillColor: rule.fillColor,
     fontColor: rule.fontColor,
     bold: rule.bold,
@@ -1458,9 +1606,30 @@ async function captureConditionalFormatRulesInRange(
       continue;
     }
 
-    conditionalFormat.cellValue.load("rule");
-    conditionalFormat.cellValue.format.fill.load("color");
-    conditionalFormat.cellValue.format.font.load("bold,italic,underline,color");
+    if (normalizedType === "cell_value") {
+      conditionalFormat.cellValue.load("rule");
+      conditionalFormat.cellValue.format.fill.load("color");
+      conditionalFormat.cellValue.format.font.load("bold,italic,underline,color");
+      continue;
+    }
+
+    if (normalizedType === "text_comparison") {
+      conditionalFormat.textComparison.load("rule");
+      conditionalFormat.textComparison.format.fill.load("color");
+      conditionalFormat.textComparison.format.font.load("bold,italic,underline,color");
+      continue;
+    }
+
+    if (normalizedType === "top_bottom") {
+      conditionalFormat.topBottom.load("rule");
+      conditionalFormat.topBottom.format.fill.load("color");
+      conditionalFormat.topBottom.format.font.load("bold,italic,underline,color");
+      continue;
+    }
+
+    conditionalFormat.preset.load("rule");
+    conditionalFormat.preset.format.fill.load("color");
+    conditionalFormat.preset.format.font.load("bold,italic,underline,color");
   }
 
   await context.sync();
@@ -1492,37 +1661,126 @@ async function captureConditionalFormatRulesInRange(
       continue;
     }
 
-    const cellValue = conditionalFormat.cellValue;
-    const ruleData = cellValue.rule;
-    const operator = isRecord(ruleData) ? ruleData.operator : undefined;
+    if (normalizedType === "cell_value") {
+      const cellValue = conditionalFormat.cellValue;
+      const ruleData = cellValue.rule;
+      const operator = isRecord(ruleData) ? ruleData.operator : undefined;
 
-    if (!isRecoveryConditionalCellValueOperator(operator)) {
-      return {
-        supported: false,
-        rules: [],
-        reason: "Unsupported conditional format rule operator.",
-      };
+      if (!isRecoveryConditionalCellValueOperator(operator)) {
+        return {
+          supported: false,
+          rules: [],
+          reason: "Unsupported conditional format rule operator.",
+        };
+      }
+
+      const formula1 = isRecord(ruleData) ? ruleData.formula1 : undefined;
+      const formula2 = isRecord(ruleData) ? ruleData.formula2 : undefined;
+
+      if (typeof formula1 !== "string") {
+        return {
+          supported: false,
+          rules: [],
+          reason: "Conditional format rule is missing formula1.",
+        };
+      }
+
+      rules.push({
+        type: "cell_value",
+        stopIfTrue: normalizeOptionalBoolean(conditionalFormat.stopIfTrue),
+        operator,
+        formula1,
+        formula2: typeof formula2 === "string" ? formula2 : undefined,
+        appliesToAddress,
+        ...captureRuleFormatting(cellValue.format),
+      });
+      continue;
     }
 
-    const formula1 = isRecord(ruleData) ? ruleData.formula1 : undefined;
-    const formula2 = isRecord(ruleData) ? ruleData.formula2 : undefined;
+    if (normalizedType === "text_comparison") {
+      const textComparison = conditionalFormat.textComparison;
+      const ruleData = textComparison.rule;
+      const operator = isRecord(ruleData) ? ruleData.operator : undefined;
 
-    if (typeof formula1 !== "string") {
+      if (!isRecoveryConditionalTextOperator(operator)) {
+        return {
+          supported: false,
+          rules: [],
+          reason: "Unsupported conditional format text operator.",
+        };
+      }
+
+      const text = isRecord(ruleData) ? ruleData.text : undefined;
+      if (typeof text !== "string") {
+        return {
+          supported: false,
+          rules: [],
+          reason: "Conditional format text-comparison rule is missing text.",
+        };
+      }
+
+      rules.push({
+        type: "text_comparison",
+        stopIfTrue: normalizeOptionalBoolean(conditionalFormat.stopIfTrue),
+        textOperator: operator,
+        text,
+        appliesToAddress,
+        ...captureRuleFormatting(textComparison.format),
+      });
+      continue;
+    }
+
+    if (normalizedType === "top_bottom") {
+      const topBottom = conditionalFormat.topBottom;
+      const ruleData = topBottom.rule;
+      const topBottomType = isRecord(ruleData) ? ruleData.type : undefined;
+      const rank = isRecord(ruleData) ? ruleData.rank : undefined;
+
+      if (!isRecoveryConditionalTopBottomCriterionType(topBottomType)) {
+        return {
+          supported: false,
+          rules: [],
+          reason: "Unsupported conditional format top/bottom criterion type.",
+        };
+      }
+
+      if (typeof rank !== "number" || !Number.isFinite(rank)) {
+        return {
+          supported: false,
+          rules: [],
+          reason: "Conditional format top/bottom rule is missing rank.",
+        };
+      }
+
+      rules.push({
+        type: "top_bottom",
+        stopIfTrue: normalizeOptionalBoolean(conditionalFormat.stopIfTrue),
+        topBottomType,
+        rank,
+        appliesToAddress,
+        ...captureRuleFormatting(topBottom.format),
+      });
+      continue;
+    }
+
+    const preset = conditionalFormat.preset;
+    const ruleData = preset.rule;
+    const criterion = isRecord(ruleData) ? ruleData.criterion : undefined;
+
+    if (!isRecoveryConditionalPresetCriterion(criterion)) {
       return {
         supported: false,
         rules: [],
-        reason: "Conditional format rule is missing formula1.",
+        reason: "Unsupported conditional format preset criterion.",
       };
     }
 
     rules.push({
-      type: "cell_value",
+      type: "preset_criteria",
       stopIfTrue: normalizeOptionalBoolean(conditionalFormat.stopIfTrue),
-      operator,
-      formula1,
-      formula2: typeof formula2 === "string" ? formula2 : undefined,
+      presetCriterion: criterion,
       appliesToAddress,
-      ...captureRuleFormatting(cellValue.format),
+      ...captureRuleFormatting(preset.format),
     });
   }
 
@@ -1563,22 +1821,87 @@ function applyConditionalFormatRule(
     return;
   }
 
-  if (!rule.operator || typeof rule.formula1 !== "string") {
-    throw new Error("Conditional format checkpoint is invalid: cell value rule is incomplete.");
+  if (rule.type === "cell_value") {
+    if (!rule.operator || typeof rule.formula1 !== "string") {
+      throw new Error("Conditional format checkpoint is invalid: cell value rule is incomplete.");
+    }
+
+    const conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.cellValue);
+    const cellValueRule: Excel.ConditionalCellValueRule = {
+      operator: rule.operator,
+      formula1: rule.formula1,
+    };
+
+    if (typeof rule.formula2 === "string") {
+      cellValueRule.formula2 = rule.formula2;
+    }
+
+    conditionalFormat.cellValue.rule = cellValueRule;
+    applyRuleFormatting(conditionalFormat.cellValue.format, rule);
+
+    if (rule.stopIfTrue !== undefined) {
+      conditionalFormat.stopIfTrue = rule.stopIfTrue;
+    }
+
+    conditionalFormat.setRanges(targetAddress);
+    return;
   }
 
-  const conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.cellValue);
-  const cellValueRule: Excel.ConditionalCellValueRule = {
-    operator: rule.operator,
-    formula1: rule.formula1,
+  if (rule.type === "text_comparison") {
+    if (!rule.textOperator || typeof rule.text !== "string") {
+      throw new Error("Conditional format checkpoint is invalid: text-comparison rule is incomplete.");
+    }
+
+    const conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.containsText);
+    const textRule: Excel.ConditionalTextComparisonRule = {
+      operator: rule.textOperator,
+      text: rule.text,
+    };
+
+    conditionalFormat.textComparison.rule = textRule;
+    applyRuleFormatting(conditionalFormat.textComparison.format, rule);
+
+    if (rule.stopIfTrue !== undefined) {
+      conditionalFormat.stopIfTrue = rule.stopIfTrue;
+    }
+
+    conditionalFormat.setRanges(targetAddress);
+    return;
+  }
+
+  if (rule.type === "top_bottom") {
+    if (!rule.topBottomType || typeof rule.rank !== "number" || !Number.isFinite(rule.rank)) {
+      throw new Error("Conditional format checkpoint is invalid: top/bottom rule is incomplete.");
+    }
+
+    const conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.topBottom);
+    const topBottomRule: Excel.ConditionalTopBottomRule = {
+      type: rule.topBottomType,
+      rank: rule.rank,
+    };
+
+    conditionalFormat.topBottom.rule = topBottomRule;
+    applyRuleFormatting(conditionalFormat.topBottom.format, rule);
+
+    if (rule.stopIfTrue !== undefined) {
+      conditionalFormat.stopIfTrue = rule.stopIfTrue;
+    }
+
+    conditionalFormat.setRanges(targetAddress);
+    return;
+  }
+
+  if (!rule.presetCriterion) {
+    throw new Error("Conditional format checkpoint is invalid: preset-criteria rule is incomplete.");
+  }
+
+  const conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.presetCriteria);
+  const presetRule: Excel.ConditionalPresetCriteriaRule = {
+    criterion: rule.presetCriterion,
   };
 
-  if (typeof rule.formula2 === "string") {
-    cellValueRule.formula2 = rule.formula2;
-  }
-
-  conditionalFormat.cellValue.rule = cellValueRule;
-  applyRuleFormatting(conditionalFormat.cellValue.format, rule);
+  conditionalFormat.preset.rule = presetRule;
+  applyRuleFormatting(conditionalFormat.preset.format, rule);
 
   if (rule.stopIfTrue !== undefined) {
     conditionalFormat.stopIfTrue = rule.stopIfTrue;

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -7,9 +7,10 @@ import { resolveConventions } from "../src/conventions/store.ts";
 void test("system prompt includes default placeholders when instructions are absent", () => {
   const prompt = buildSystemPrompt();
 
-  assert.match(prompt, /## Persistent Instructions/);
-  assert.match(prompt, /\(No user instructions set\.\)/);
-  assert.match(prompt, /\(No workbook instructions set\.\)/);
+  assert.match(prompt, /## Rules/);
+  assert.match(prompt, /\(No rules set\.\)/);
+  assert.match(prompt, /### All my files/);
+  assert.match(prompt, /### This file/);
 });
 
 void test("system prompt embeds provided user and workbook instructions", () => {

--- a/tests/workbook-recovery-log.test.ts
+++ b/tests/workbook-recovery-log.test.ts
@@ -198,6 +198,82 @@ void test("persisted format checkpoints retain dimension state", async () => {
   assert.deepEqual(withoutUndefined(entries[0]?.formatRangeState), withoutUndefined(formatState));
 });
 
+void test("persisted conditional-format checkpoints retain extended rule types", async () => {
+  const settingsStore = createInMemorySettingsStore();
+
+  const getWorkbookContext = (): Promise<WorkbookContext> => Promise.resolve({
+    workbookId: "url_sha256:workbook-conditional-format-persist",
+    workbookName: "Ops.xlsx",
+    source: "document.url",
+  });
+
+  const rules = [
+    {
+      type: "custom",
+      formula: "=A1>10",
+      fillColor: "#FF0000",
+      appliesToAddress: "Sheet1!A1:A2",
+    },
+    {
+      type: "cell_value",
+      operator: "GreaterThan",
+      formula1: "10",
+      fillColor: "#0000FF",
+      appliesToAddress: "Sheet1!B1:B2",
+    },
+    {
+      type: "text_comparison",
+      textOperator: "Contains",
+      text: "urgent",
+      fillColor: "#FFE599",
+      appliesToAddress: "Sheet1!C1:C2",
+    },
+    {
+      type: "top_bottom",
+      topBottomType: "TopItems",
+      rank: 3,
+      fillColor: "#E2EFDA",
+      appliesToAddress: "Sheet1!D1:D10",
+    },
+    {
+      type: "preset_criteria",
+      presetCriterion: "DuplicateValues",
+      fillColor: "#FCE4D6",
+      appliesToAddress: "Sheet1!E1:E10",
+    },
+  ] as const;
+
+  const logA = new WorkbookRecoveryLog({
+    getSettingsStore: () => Promise.resolve(settingsStore),
+    getWorkbookContext,
+    now: () => 1700000000150,
+    createId: () => "snap-conditional-format-persist-1",
+    applySnapshot: () => Promise.resolve({ values: [["old"]], formulas: [["old"]] }),
+  });
+
+  const appended = await logA.appendConditionalFormat({
+    toolName: "conditional_format",
+    toolCallId: "call-conditional-format-persist",
+    address: "Sheet1!A1:E10",
+    changedCount: 50,
+    cellCount: 50,
+    conditionalFormatRules: [...rules],
+  });
+
+  assert.ok(appended);
+
+  const logB = new WorkbookRecoveryLog({
+    getSettingsStore: () => Promise.resolve(settingsStore),
+    getWorkbookContext,
+    applySnapshot: () => Promise.resolve({ values: [["old"]], formulas: [["old"]] }),
+  });
+
+  const entries = await logB.listForCurrentWorkbook(10);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]?.snapshotKind, "conditional_format_rules");
+  assert.deepEqual(withoutUndefined(entries[0]?.conditionalFormatRules), withoutUndefined(rules));
+});
+
 void test("append is skipped when workbook identity is unavailable", async () => {
   const settingsStore = createInMemorySettingsStore();
 
@@ -667,10 +743,31 @@ void test("restore applies conditional-format checkpoints and creates inverse ch
         appliesToAddress: "Sheet1!A1:A2",
       },
       {
-        type: "custom",
-        formula: "=B1>10",
+        type: "cell_value",
+        operator: "GreaterThan",
+        formula1: "10",
         fillColor: "#0000FF",
         appliesToAddress: "Sheet1!B1:B2",
+      },
+      {
+        type: "text_comparison",
+        textOperator: "Contains",
+        text: "urgent",
+        fillColor: "#FFE599",
+        appliesToAddress: "Sheet1!C1:C2",
+      },
+      {
+        type: "top_bottom",
+        topBottomType: "TopItems",
+        rank: 3,
+        fillColor: "#E2EFDA",
+        appliesToAddress: "Sheet1!D1:D10",
+      },
+      {
+        type: "preset_criteria",
+        presetCriterion: "DuplicateValues",
+        fillColor: "#FCE4D6",
+        appliesToAddress: "Sheet1!E1:E10",
       },
     ],
   });
@@ -682,13 +779,20 @@ void test("restore applies conditional-format checkpoints and creates inverse ch
   assert.equal(restored.address, "Sheet1!A1:B2");
   assert.equal(restored.restoredSnapshotId, appended?.id);
   assert.equal(appliedAddress, "Sheet1!A1:B2");
-  assert.equal(appliedRules.length, 2);
+  assert.equal(appliedRules.length, 5);
   assert.deepEqual(
     appliedRules.map((rule) =>
       typeof rule === "object" && rule !== null
         ? {
             type: "type" in rule ? rule.type : undefined,
             formula: "formula" in rule ? rule.formula : undefined,
+            operator: "operator" in rule ? rule.operator : undefined,
+            formula1: "formula1" in rule ? rule.formula1 : undefined,
+            textOperator: "textOperator" in rule ? rule.textOperator : undefined,
+            text: "text" in rule ? rule.text : undefined,
+            topBottomType: "topBottomType" in rule ? rule.topBottomType : undefined,
+            rank: "rank" in rule ? rule.rank : undefined,
+            presetCriterion: "presetCriterion" in rule ? rule.presetCriterion : undefined,
             fillColor: "fillColor" in rule ? rule.fillColor : undefined,
             appliesToAddress: "appliesToAddress" in rule ? rule.appliesToAddress : undefined,
           }
@@ -698,14 +802,67 @@ void test("restore applies conditional-format checkpoints and creates inverse ch
       {
         type: "custom",
         formula: "=A1>10",
+        operator: undefined,
+        formula1: undefined,
+        textOperator: undefined,
+        text: undefined,
+        topBottomType: undefined,
+        rank: undefined,
+        presetCriterion: undefined,
         fillColor: "#FF0000",
         appliesToAddress: "Sheet1!A1:A2",
       },
       {
-        type: "custom",
-        formula: "=B1>10",
+        type: "cell_value",
+        formula: undefined,
+        operator: "GreaterThan",
+        formula1: "10",
+        textOperator: undefined,
+        text: undefined,
+        topBottomType: undefined,
+        rank: undefined,
+        presetCriterion: undefined,
         fillColor: "#0000FF",
         appliesToAddress: "Sheet1!B1:B2",
+      },
+      {
+        type: "text_comparison",
+        formula: undefined,
+        operator: undefined,
+        formula1: undefined,
+        textOperator: "Contains",
+        text: "urgent",
+        topBottomType: undefined,
+        rank: undefined,
+        presetCriterion: undefined,
+        fillColor: "#FFE599",
+        appliesToAddress: "Sheet1!C1:C2",
+      },
+      {
+        type: "top_bottom",
+        formula: undefined,
+        operator: undefined,
+        formula1: undefined,
+        textOperator: undefined,
+        text: undefined,
+        topBottomType: "TopItems",
+        rank: 3,
+        presetCriterion: undefined,
+        fillColor: "#E2EFDA",
+        appliesToAddress: "Sheet1!D1:D10",
+      },
+      {
+        type: "preset_criteria",
+        formula: undefined,
+        operator: undefined,
+        formula1: undefined,
+        textOperator: undefined,
+        text: undefined,
+        topBottomType: undefined,
+        rank: undefined,
+        presetCriterion: "DuplicateValues",
+        fillColor: "#FCE4D6",
+        appliesToAddress: "Sheet1!E1:E10",
       },
     ],
   );


### PR DESCRIPTION
## Summary
- broaden `conditional_format` recovery checkpoint capture/restore beyond the previous `custom` + `cell_value` subset
- add checkpoint support for additional rule families:
  - `contains_text`
  - `top_bottom`
  - `preset_criteria`
- preserve per-rule `appliesToAddress` behavior while restoring these additional types
- extend checkpoint cloning and persisted snapshot validation to handle the new rule metadata safely
- update recovery docs/decision notes to reflect current conditional-format checkpoint scope and remaining unsupported visual rule families (`data_bar`, `color_scale`, `icon_set`)
- align `system-prompt` placeholder test with current prompt wording (`## Rules` + `(No rules set.)`)

## Why
This continues the issue #27 rollback-first track by reducing "no backup created" cases when ranges already contain non-`custom`/`cell_value` conditional formats.

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
- `npm run test:models`
