### PR TITLE
fix(ui): consolidate overlay lifecycle and restore overlay scrolling

### DIFF
--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -86,6 +86,7 @@ pi-web-ui uses Light DOM (`createRenderRoot() { return this; }`), so styles leak
 | `toast.ts` | — | `showToast(msg, duration)` — positions a fixed notification |
 | `loading.ts` | — | Splash screen shown during init |
 | `provider-login.ts` | — | API key entry rows for the welcome overlay |
+| `overlay-dialog.ts` | — | Shared overlay lifecycle helper (single-instance toggle, Escape/backdrop close, focus restore) |
 
 ## Wiring (taskpane.ts)
 

--- a/src/ui/overlay-dialog.ts
+++ b/src/ui/overlay-dialog.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared helpers for fullscreen overlays.
+ *
+ * Consolidates:
+ * - single-instance toggle behavior by overlay id
+ * - Escape handling
+ * - backdrop-click close
+ * - focus restoration after close
+ */
+
+import { requestChatInputFocus } from "./input-focus.js";
+import { installOverlayEscapeClose } from "./overlay-escape.js";
+
+const overlayClosers = new WeakMap<HTMLElement, () => void>();
+
+export function closeOverlayById(overlayId: string): boolean {
+  const existing = document.getElementById(overlayId);
+  if (!(existing instanceof HTMLElement)) {
+    return false;
+  }
+
+  const closeExisting = overlayClosers.get(existing);
+  if (closeExisting) {
+    closeExisting();
+  } else {
+    existing.remove();
+  }
+
+  return true;
+}
+
+export interface OverlayDialogOptions {
+  overlayId: string;
+  cardClassName: string;
+  closeOnBackdrop?: boolean;
+  restoreFocusOnClose?: boolean;
+  zIndex?: number;
+}
+
+export interface OverlayDialogController {
+  overlay: HTMLDivElement;
+  card: HTMLDivElement;
+  close: () => void;
+  mount: () => void;
+  addCleanup: (cleanup: () => void) => void;
+}
+
+export function createOverlayDialog(options: OverlayDialogOptions): OverlayDialogController {
+  const overlay = document.createElement("div");
+  overlay.id = options.overlayId;
+  overlay.className = "pi-welcome-overlay";
+  if (options.zIndex !== undefined) {
+    overlay.style.zIndex = String(options.zIndex);
+  }
+
+  const card = document.createElement("div");
+  card.className = options.cardClassName;
+  overlay.appendChild(card);
+
+  const cleanups: Array<() => void> = [];
+  let closed = false;
+
+  const close = () => {
+    if (closed) {
+      return;
+    }
+
+    closed = true;
+    overlayClosers.delete(overlay);
+
+    for (let index = cleanups.length - 1; index >= 0; index -= 1) {
+      try {
+        cleanups[index]();
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+
+    overlay.remove();
+
+    if (options.restoreFocusOnClose !== false) {
+      requestChatInputFocus();
+    }
+  };
+
+  const cleanupEscape = installOverlayEscapeClose(overlay, close);
+  cleanups.push(cleanupEscape);
+
+  if (options.closeOnBackdrop !== false) {
+    const onBackdropClick = (event: MouseEvent) => {
+      if (event.target === overlay) {
+        close();
+      }
+    };
+
+    overlay.addEventListener("click", onBackdropClick);
+    cleanups.push(() => {
+      overlay.removeEventListener("click", onBackdropClick);
+    });
+  }
+
+  overlayClosers.set(overlay, close);
+
+  return {
+    overlay,
+    card,
+    close,
+    mount: () => {
+      document.body.appendChild(overlay);
+    },
+    addCleanup: (cleanup) => {
+      if (closed) {
+        cleanup();
+        return;
+      }
+
+      cleanups.push(cleanup);
+    },
+  };
+}

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -175,6 +175,8 @@
 .pi-overlay-body {
   overflow-y: auto;
   display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
   flex-direction: column;
   gap: 12px;
   padding-right: 4px;

--- a/src/ui/theme/overlays/provider-resume-shortcuts.css
+++ b/src/ui/theme/overlays/provider-resume-shortcuts.css
@@ -6,7 +6,12 @@
 }
 
 .pi-provider-picker-list {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
   gap: 4px;
+  overflow-y: auto;
 }
 
 .pi-resume-dialog {
@@ -57,6 +62,8 @@
 .pi-resume-list {
   overflow-y: auto;
   display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
   flex-direction: column;
   gap: 4px;
 }

--- a/src/ui/theme/overlays/recovery.css
+++ b/src/ui/theme/overlays/recovery.css
@@ -22,6 +22,8 @@
 
 .pi-recovery-list {
   display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
   flex-direction: column;
   gap: 8px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add a shared `createOverlayDialog()` / `closeOverlayById()` helper for overlay lifecycle
- migrate built-in overlays (`/rules`, `/experimental`, provider/resume/recovery/shortcuts), integrations/extensions overlays, files dialog, and welcome login to the shared helper
- fix clipped overlay content by using a consistent scroll-body pattern (`.pi-overlay-body`) and flex-safe scroll containers for provider/resume/recovery lists

## Why
Some overlays could clip content without a usable scroll area (notably `/rules` → **Number format** and `/experimental`), leaving users stuck. This change standardizes overlay mount/close behavior and ensures tall content is scrollable.

## Verification
- `npm run check`
- `npm run build`
