### PR TITLE
refactor(ui): centralize renderer/humanizer metadata for issue-18

### DIFF
--- a/src/tools/capabilities.ts
+++ b/src/tools/capabilities.ts
@@ -265,3 +265,38 @@ export const UI_TOOL_NAMES: readonly UiToolName[] = [
   ...CORE_TOOL_NAMES,
   ...AUXILIARY_UI_TOOL_NAMES,
 ];
+
+export interface ToolUiMetadata {
+  renderer: boolean;
+  humanizer: boolean;
+}
+
+export const TOOL_UI_METADATA = {
+  get_workbook_overview: { renderer: true, humanizer: true },
+  read_range: { renderer: true, humanizer: true },
+  write_cells: { renderer: true, humanizer: true },
+  fill_formula: { renderer: true, humanizer: true },
+  search_workbook: { renderer: true, humanizer: true },
+  modify_structure: { renderer: true, humanizer: true },
+  format_cells: { renderer: true, humanizer: true },
+  conditional_format: { renderer: true, humanizer: true },
+  trace_dependencies: { renderer: true, humanizer: true },
+  explain_formula: { renderer: true, humanizer: true },
+  view_settings: { renderer: true, humanizer: true },
+  comments: { renderer: true, humanizer: true },
+  instructions: { renderer: true, humanizer: true },
+  conventions: { renderer: true, humanizer: true },
+  workbook_history: { renderer: true, humanizer: true },
+  skills: { renderer: true, humanizer: true },
+  web_search: { renderer: true, humanizer: true },
+  mcp: { renderer: true, humanizer: true },
+  files: { renderer: true, humanizer: true },
+  python_transform_range: { renderer: true, humanizer: true },
+  execute_office_js: { renderer: true, humanizer: true },
+} as const satisfies Record<UiToolName, ToolUiMetadata>;
+
+export const TOOL_NAMES_WITH_RENDERER: readonly UiToolName[] = UI_TOOL_NAMES
+  .filter((name) => TOOL_UI_METADATA[name].renderer);
+
+export const TOOL_NAMES_WITH_HUMANIZER: readonly UiToolName[] = UI_TOOL_NAMES
+  .filter((name) => TOOL_UI_METADATA[name].humanizer);

--- a/src/ui/humanize-params.ts
+++ b/src/ui/humanize-params.ts
@@ -9,7 +9,10 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { cellRef, cellRefs } from "./cell-link.js";
 import { formatColorLabel } from "./color-names.js";
-import type { AuxiliaryUiToolName } from "../tools/capabilities.js";
+import {
+  TOOL_NAMES_WITH_HUMANIZER,
+  type AuxiliaryUiToolName,
+} from "../tools/capabilities.js";
 import type { CoreToolName } from "../tools/names.js";
 
 /* ── Types ──────────────────────────────────────────────────── */
@@ -958,6 +961,8 @@ const HUMANIZERS: Record<string, HumanizerFn> = {
   ...EXTRA_HUMANIZERS,
 };
 
+const HUMANIZABLE_TOOL_NAME_SET = new Set<string>(TOOL_NAMES_WITH_HUMANIZER);
+
 /* ── Public API ─────────────────────────────────────────────── */
 
 /**
@@ -968,6 +973,8 @@ export function humanizeToolInput(
   toolName: string,
   params: unknown,
 ): TemplateResult | null {
+  if (!HUMANIZABLE_TOOL_NAME_SET.has(toolName)) return null;
+
   const fn = HUMANIZERS[toolName];
   if (!fn) return null;
 

--- a/src/ui/tool-renderers.ts
+++ b/src/ui/tool-renderers.ts
@@ -14,7 +14,7 @@ import { renderCollapsibleToolCardHeader, renderToolCardHeader } from "./tool-ca
 import { cellRef, cellRefDisplay, cellRefs } from "./cell-link.js";
 import { humanizeToolInput } from "./humanize-params.js";
 import { humanizeColorsInText } from "./color-names.js";
-import { UI_TOOL_NAMES, type UiToolName } from "../tools/capabilities.js";
+import { TOOL_NAMES_WITH_RENDERER, type UiToolName } from "../tools/capabilities.js";
 import {
   isCommentsDetails,
   isConditionalFormatDetails,
@@ -1155,7 +1155,7 @@ function createExcelMarkdownRenderer(toolName: SupportedToolName): ToolRenderer<
   };
 }
 
-const CUSTOM_RENDERED_TOOL_NAMES: readonly SupportedToolName[] = UI_TOOL_NAMES;
+const CUSTOM_RENDERED_TOOL_NAMES: readonly SupportedToolName[] = TOOL_NAMES_WITH_RENDERER;
 
 for (const name of CUSTOM_RENDERED_TOOL_NAMES) {
   registerToolRenderer(name, createExcelMarkdownRenderer(name));

--- a/tests/tool-capabilities.test.ts
+++ b/tests/tool-capabilities.test.ts
@@ -8,6 +8,9 @@ import {
   TOOL_DISCLOSURE_BUNDLES,
   TOOL_DISCLOSURE_FULL_ACCESS_PATTERNS,
   TOOL_DISCLOSURE_TRIGGER_PATTERNS,
+  TOOL_NAMES_WITH_HUMANIZER,
+  TOOL_NAMES_WITH_RENDERER,
+  TOOL_UI_METADATA,
   UI_TOOL_NAMES,
 } from "../src/tools/capabilities.ts";
 import { CORE_TOOL_NAMES } from "../src/tools/names.ts";
@@ -34,14 +37,31 @@ void test("system prompt core tool section is generated from capability metadata
   }
 });
 
-void test("UI tool registration derives from centralized UI tool names", async () => {
+void test("UI tool registration derives from centralized UI metadata", async () => {
   const rendererSource = await readFile(new URL("../src/ui/tool-renderers.ts", import.meta.url), "utf8");
-  assert.match(rendererSource, /import\s*\{\s*UI_TOOL_NAMES/);
-  assert.match(rendererSource, /CUSTOM_RENDERED_TOOL_NAMES:\s*readonly SupportedToolName\[\]\s*=\s*UI_TOOL_NAMES/);
+  assert.match(rendererSource, /import\s*\{\s*TOOL_NAMES_WITH_RENDERER/);
+  assert.match(rendererSource, /CUSTOM_RENDERED_TOOL_NAMES:\s*readonly SupportedToolName\[\]\s*=\s*TOOL_NAMES_WITH_RENDERER/);
+
+  const humanizerSource = await readFile(new URL("../src/ui/humanize-params.ts", import.meta.url), "utf8");
+  assert.match(humanizerSource, /TOOL_NAMES_WITH_HUMANIZER/);
+  assert.match(humanizerSource, /HUMANIZABLE_TOOL_NAME_SET/);
 
   const uniqueNames = new Set(UI_TOOL_NAMES);
   assert.equal(uniqueNames.size, UI_TOOL_NAMES.length);
   assert.ok(UI_TOOL_NAMES.includes("execute_office_js"));
+});
+
+void test("UI metadata drives renderer and humanizer tool subsets", () => {
+  assert.equal(TOOL_NAMES_WITH_RENDERER.length > 0, true);
+  assert.equal(TOOL_NAMES_WITH_HUMANIZER.length > 0, true);
+
+  for (const name of TOOL_NAMES_WITH_RENDERER) {
+    assert.equal(TOOL_UI_METADATA[name].renderer, true);
+  }
+
+  for (const name of TOOL_NAMES_WITH_HUMANIZER) {
+    assert.equal(TOOL_UI_METADATA[name].humanizer, true);
+  }
 });
 
 void test("disclosure bundles keep shared core safety tools and add category-specific tools", () => {


### PR DESCRIPTION
## Summary

Issue #18 Slice C: centralize UI tool registration metadata so renderer and humanizer surfaces stay in sync.

## What changed

### 1) Added centralized UI metadata in capability registry

- `src/tools/capabilities.ts`
  - added `ToolUiMetadata`
  - added `TOOL_UI_METADATA` keyed by `UiToolName`
  - added derived lists:
    - `TOOL_NAMES_WITH_RENDERER`
    - `TOOL_NAMES_WITH_HUMANIZER`

This makes UI registration capabilities explicit in one place.

### 2) Renderer registration now derives from metadata

- `src/ui/tool-renderers.ts`
  - uses `TOOL_NAMES_WITH_RENDERER` instead of `UI_TOOL_NAMES`

### 3) Humanizer gating now derives from metadata

- `src/ui/humanize-params.ts`
  - uses `TOOL_NAMES_WITH_HUMANIZER`
  - introduces `HUMANIZABLE_TOOL_NAME_SET` guard before lookup

### 4) Tests

- `tests/tool-capabilities.test.ts`
  - validates renderer/humanizer metadata integration
  - checks source wiring uses centralized metadata exports

## Validation

- `npm run check`
- `npm run test:context`
- targeted:
  - `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/tool-capabilities.test.ts tests/tool-disclosure.test.ts tests/builtins-registry.test.ts`
