### PR TITLE
feat(tools): graduate execute_office_js to always-on approval flow

### DIFF
--- a/src/experiments/flags.ts
+++ b/src/experiments/flags.ts
@@ -17,8 +17,7 @@ export type ExperimentalFeatureId =
   | "remote_extension_urls"
   | "extension_permission_gates"
   | "extension_sandbox_runtime"
-  | "extension_widget_v2"
-  | "office_js_execute";
+  | "extension_widget_v2";
 
 export type ExperimentalFeatureWiring = "wired" | "flag-only";
 
@@ -83,16 +82,6 @@ const EXPERIMENTAL_FEATURES = [
     warning: "Security: external skills can contain untrusted instructions and executable references.",
     wiring: "flag-only",
     storageKey: "pi.experimental.externalSkillsDiscovery",
-  },
-  {
-    id: "office_js_execute",
-    slug: "office-js-execute",
-    aliases: ["execute-office-js", "office-js", "excel-js"],
-    title: "Direct Office.js execution",
-    description: "Allow direct execute_office_js calls with Excel.RequestContext.",
-    warning: "High impact: arbitrary Office.js can mutate workbook structure, formulas, and formatting.",
-    wiring: "wired",
-    storageKey: "pi.experimental.officeJsExecute",
   },
   {
     id: "remote_extension_urls",

--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -169,7 +169,7 @@ const TOOLS = `## Tools
 Core workbook tools:
 ${CORE_TOOL_PROMPT_LINES}
 - **extensions_manager** — list/install/reload/enable/disable/uninstall sidebar extensions from code (for extension authoring from chat)
-- **execute_office_js** — run direct Office.js against the active workbook when structured tools cannot express the operation (experimental; explanation + user approval required)
+- **execute_office_js** — run direct Office.js against the active workbook when structured tools cannot express the operation (explanation + user approval required)
 
 Other tools may be available depending on enabled experiments/integrations.
 Use **files** for workspace artifacts (list/read/write/delete files).

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -181,14 +181,13 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
 - **MCP integration:** configurable server registry (`mcp.servers.v1`), UI add/remove/test, and a single `mcp` gateway tool for list/search/describe/call flows.
 - **Rationale:** satisfy issue #24 with explicit consent, clear attribution, and minimal overlap with the extension system.
 
-## Experimental direct Office.js tool (`execute_office_js`)
-- **Availability:** non-core experimental tool, always registered via `createAllTools()`; execution is hard-gated by `applyExperimentalToolGates()` and `/experimental on office-js-execute`.
+## Direct Office.js tool (`execute_office_js`)
+- **Availability:** always available (not behind `/experimental`), always registered via `createAllTools()`.
 - **Contract:** accepts `code` (async function body receiving `context: Excel.RequestContext`) plus a short user-facing `explanation`.
 - **Safety guards:** blocks nested `Excel.run(...)` usage (host already provides context), enforces explanation/code length limits, requires explicit user confirmation on every execution, and fails closed if confirmation UI is unavailable.
 - **Result policy:** tool output must be JSON-serializable; non-serializable results are returned as deterministic errors.
-- **Audit/recovery:** appends operation-level entries to `workbook.change-audit.v1` and explicitly reports that no workbook checkpoint is created.
 - **Execution policy:** treated as `mutate/structure` to force conservative workbook-context refresh after execution.
-- **Rationale:** unlock advanced Office.js scenarios when structured tools are insufficient while preserving explicit consent and auditability.
+- **Rationale:** unlock advanced Office.js scenarios when structured tools are insufficient while preserving explicit consent.
 
 ## Extension manager tool (`extensions_manager`)
 - **Availability:** always registered via `createAllTools()`.

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -104,8 +104,6 @@ void test("builtins registry wires /experimental, /extensions, and /integrations
   assert.match(experimentalFlagsSource, /extension-widget-v2/);
   assert.match(experimentalFlagsSource, /external_skills_discovery/);
   assert.match(experimentalFlagsSource, /external-skills-discovery/);
-  assert.match(experimentalFlagsSource, /office_js_execute/);
-  assert.match(experimentalFlagsSource, /office-js-execute/);
 });
 
 void test("taskpane init keeps getIntegrationToolNames imported when used", async () => {

--- a/tests/execute-office-js-tool.test.ts
+++ b/tests/execute-office-js-tool.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { createExecuteOfficeJsTool } from "../src/tools/execute-office-js.ts";
-import type { AppendWorkbookChangeAuditEntryArgs } from "../src/audit/workbook-change-audit.ts";
 
 function firstText(result: { content: Array<{ type: string; text: string }> }): string {
   const block = result.content[0];
@@ -13,19 +12,13 @@ function firstText(result: { content: Array<{ type: string; text: string }> }): 
   return block.text;
 }
 
-void test("execute_office_js runs code, serializes result, and appends audit entry", async () => {
-  const auditEntries: AppendWorkbookChangeAuditEntryArgs[] = [];
-
+void test("execute_office_js runs code and serializes result", async () => {
   const tool = createExecuteOfficeJsTool({
     runCode: () => Promise.resolve({
       ok: true,
       sheet: "Sheet1",
       changedCells: 4,
     }),
-    appendAuditEntry: (entry) => {
-      auditEntries.push(entry);
-      return Promise.resolve();
-    },
   });
 
   const result = await tool.execute("tool-call-1", {
@@ -37,25 +30,15 @@ void test("execute_office_js runs code, serializes result, and appends audit ent
   assert.match(text, /Executed Office\.js: Recalculate dashboard totals/u);
   assert.match(text, /```json/u);
   assert.match(text, /"ok": true/u);
-
-  assert.equal(auditEntries.length, 1);
-  assert.equal(auditEntries[0]?.toolName, "execute_office_js");
-  assert.equal(auditEntries[0]?.blocked, false);
-  assert.match(auditEntries[0]?.summary ?? "", /Recalculate dashboard totals/u);
 });
 
 void test("execute_office_js blocks nested Excel.run usage", async () => {
-  const auditEntries: AppendWorkbookChangeAuditEntryArgs[] = [];
   let runCalled = false;
 
   const tool = createExecuteOfficeJsTool({
     runCode: () => {
       runCalled = true;
       return Promise.resolve(null);
-    },
-    appendAuditEntry: (entry) => {
-      auditEntries.push(entry);
-      return Promise.resolve();
     },
   });
 
@@ -67,22 +50,14 @@ void test("execute_office_js blocks nested Excel.run usage", async () => {
   const text = firstText(result);
   assert.match(text, /Do not call Excel\.run\(\)/u);
   assert.equal(runCalled, false);
-
-  assert.equal(auditEntries.length, 1);
-  assert.equal(auditEntries[0]?.blocked, true);
 });
 
 void test("execute_office_js reports non-serializable result payloads", async () => {
-  const auditEntries: AppendWorkbookChangeAuditEntryArgs[] = [];
   const circular: { self?: unknown } = {};
   circular.self = circular;
 
   const tool = createExecuteOfficeJsTool({
     runCode: () => Promise.resolve(circular),
-    appendAuditEntry: (entry) => {
-      auditEntries.push(entry);
-      return Promise.resolve();
-    },
   });
 
   const result = await tool.execute("tool-call-3", {
@@ -92,7 +67,4 @@ void test("execute_office_js reports non-serializable result payloads", async ()
 
   const text = firstText(result);
   assert.match(text, /Result is not JSON-serializable/u);
-
-  assert.equal(auditEntries.length, 1);
-  assert.equal(auditEntries[0]?.blocked, true);
 });


### PR DESCRIPTION
## Summary
- graduate `execute_office_js` from experimental feature-flag gating so it is always available
- keep strict per-run user approval in `applyExperimentalToolGates()` (fail closed if approval UI is unavailable)
- remove per-execution audit append + non-checkpoint note from the tool output, per requested scope
- update prompt/docs/tests to match the new behavior

## Changes
- removed `office_js_execute` from `src/experiments/flags.ts`
- simplified Office.js gating in `src/tools/experimental-tool-gates.ts` to approval-only for `execute_office_js`
- removed audit dependencies/calls from `src/tools/execute-office-js.ts`
- updated wording in:
  - `src/prompt/system-prompt.ts`
  - `src/tools/DECISIONS.md`
- updated tests:
  - `tests/experimental-tool-gates.test.ts`
  - `tests/execute-office-js-tool.test.ts`
  - `tests/builtins-registry.test.ts`

## Validation
- `npm run check`
- `npm run test:context`
