### PR TITLE
docs(recovery): record full-file snapshot feasibility decision

### DIFF
--- a/docs/archive/design-yolo-recovery.md
+++ b/docs/archive/design-yolo-recovery.md
@@ -20,8 +20,12 @@ Replace cumbersome up-front approval selectors with a low-friction workflow:
 ### 2) Full-file snapshots / Save As each step
 - **Pros:** strongest recovery semantics
 - **Cons:** expensive; potentially heavy/slow; awkward lifecycle (storage, naming, cleanup)
-- **Feasibility note:** Office.js can expose document/file APIs depending on host/runtime, but “checkpoint every tool call as full workbook copy” is not practical as a first slice
-- **Decision:** keep as future exploration, not first implementation
+- **Feasibility findings (2026-02):**
+  - `getFileAsync(Compressed)` is not uniformly available across hosts (Excel on web is PDF-only for this API surface)
+  - Office.js does not expose a simple atomic in-place "replace current workbook from snapshot" API
+  - per-mutation full-file capture would be operationally heavy (slice IO + storage overhead)
+- **Decision:** do not use per-mutation full-file snapshots as baseline; if needed later, consider optional/manual desktop-oriented export + open-new-workbook flow
+- **Research notes:** see `.research/full-file-snapshot-feasibility.md` for API-level analysis and constraints.
 
 ### 3) Range-level pre-write checkpoints (selected)
 - **Pros:** cheap, deterministic, aligns with tool-level mutations
@@ -74,5 +78,5 @@ Replace cumbersome up-front approval selectors with a low-friction workflow:
 
 1. Decide whether to support value-preserving destructive restore (capture/deep-restore deleted row/column/sheet data) vs intentionally keep destructive checkpoints limited to value-empty targets.
 2. Enrich checkpoint history UX (search/filter/export, retention controls).
-3. Evaluate host-specific full-file snapshot feasibility for coarse-grained restore points.
+3. If needed, design an optional/manual desktop-oriented full-backup flow (not per-mutation).
 4. Potentially expose “YOLO mode” toggle once we have both lightweight and strict workflows fully defined.

--- a/docs/archive/upcoming.md
+++ b/docs/archive/upcoming.md
@@ -98,8 +98,7 @@ https://github.com/tmustier/pi-for-excel/issues/27
 **Status note:** rollback UX is now in place:
 - automatic backups for `write_cells`, `fill_formula`, `python_transform_range`, `format_cells` (with scoped limits), `conditional_format`, mutating `comments` actions, and all `modify_structure` actions (destructive deletes checkpoint only when target has no value data)
 - new `workbook_history` tool (list / restore / delete / clear)
-- backup browser overlay (menu + `/history`) plus `/revert` for latest-backup rollback
-- dedicated backup browser overlay (menu + `/history`) with restore/delete/clear controls
+- backup browser overlay (menu + `/history`) with restore/delete/clear controls, plus `/revert` for latest-backup rollback
 - restore creates an inverse backup so rollbacks are themselves reversible
 - unsupported mutation tools/actions (and conditionally unsafe `modify_structure` deletes) explicitly report when no backup is created
 - structure-absence restores (`sheet_absent`, `rows_absent`, `columns_absent`) are blocked when target data exists to avoid irreversible deletes
@@ -108,7 +107,7 @@ https://github.com/tmustier/pi-for-excel/issues/27
 **Remaining follow-up:**
 - decide whether to support value-preserving destructive restore (deleted row/column/sheet data) or intentionally keep delete checkpoints limited to value-empty targets
 - richer history UX (search/filter/export, retention controls)
-- feasibility deep-dive for full-file snapshots vs range snapshots in Office.js
+- optional/manual desktop-oriented full-backup flow design (if needed), now that full per-mutation snapshot feasibility has been documented
 
 ---
 


### PR DESCRIPTION
## Summary
- document Office.js feasibility findings for full-file snapshot recovery in `docs/design-yolo-recovery.md`
- clarify that per-mutation full-file snapshots are not the baseline path due to host/API constraints
- update issue #27 remaining follow-ups in `docs/upcoming.md` to reflect the completed feasibility deep-dive and keep only an optional/manual backup-flow follow-up
- remove duplicate bullet wording in the #27 status note

## Why
Issue #27’s remaining scope included a full-file snapshot feasibility spike. This PR records the decision so future work can focus on value-preserving destructive restore and history UX instead of re-litigating baseline recovery strategy.

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
- `npm run test:models`
