### PR TITLE
docs(readme): point Pi link to pi.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pi for Excel
 
-Open-source, multi-model AI sidebar add-in for Microsoft Excel. Powered by [Pi](https://github.com/mariozechner/pi-coding-agent).
+Open-source, multi-model AI sidebar add-in for Microsoft Excel. Powered by [Pi](https://pi.dev).
 
 Pi for Excel gives you a conversational AI assistant that can read, write, and format your spreadsheets — directly from an Excel sidebar panel. Bring your own API key or OAuth login for Anthropic, OpenAI, Google Gemini, or GitHub Copilot.
 


### PR DESCRIPTION
## Summary\n- update the top README Pi link to point to https://pi.dev instead of the GitHub repo URL\n\n## Validation\n- pre-commit hooks passed (
> pi-for-excel@0.3.0-pre lint
> eslint "*.ts" "src/**/*.ts" "tests/**/*.ts", 
> pi-for-excel@0.3.0-pre typecheck
> tsc --noEmit)\n