### PR TITLE
feat(workspace): folder conventions + files list path filter

### DIFF
--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -139,6 +139,7 @@ export function buildSystemPrompt(opts: SystemPromptOptions = {}): string {
   }
 
   sections.push(TOOLS);
+  sections.push(WORKSPACE);
   sections.push(WORKFLOW);
   sections.push(CONVENTIONS);
 
@@ -172,9 +173,27 @@ ${CORE_TOOL_PROMPT_LINES}
 - **execute_office_js** — run direct Office.js against the active workbook when structured tools cannot express the operation (explanation + user approval required)
 
 Other tools may be available depending on enabled experiments/integrations.
-Use **files** for workspace artifacts (list/read/write/delete files).
+Use **files** for workspace artifacts (list/read/write/delete files). Pass \`path\` on \`list\` to scope to a folder.
 Built-in assistant docs are always available under \`assistant-docs/\` (for example \`assistant-docs/docs/extensions.md\`).
 If **execute_office_js** is available, keep code minimal, call \`context.sync()\` after \`load()\`, and return JSON-serializable results.`;
+
+const WORKSPACE = `## Workspace
+
+You have a persistent file workspace that survives across sessions and workbooks. Use it to save notes, analysis artifacts, and working files.
+
+### Folder conventions
+- \`notes/\` — Your persistent memory. Write things you learn here so you can recall them in future sessions. Keep a brief \`notes/index.md\` listing what each note covers.
+- \`workbooks/<name>/\` — Artifacts tied to a specific workbook (CSVs, analysis, charts). Use a short slug derived from the workbook name.
+- \`scratch/\` — Temporary working files. May be auto-cleaned.
+- \`imports/\` — Files uploaded by the user.
+- \`assistant-docs/\` — Built-in read-only documentation.
+
+You may create other folders as needed — these are conventions, not constraints.
+
+### Tips
+- When you learn something useful about a workbook or domain, save it to \`notes/\`. Future sessions can read \`notes/index.md\` to pick up where you left off.
+- Use \`files list notes/\` or \`files list workbooks/\` to scope listings to a folder instead of listing everything.
+- Prefer text formats (Markdown, CSV, JSON) for workspace files.`;
 
 const WORKFLOW = `## Workflow
 

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -81,6 +81,17 @@ void test("system prompt mentions files workspace and built-in docs prefix", () 
   assert.match(prompt, /assistant-docs\//i);
 });
 
+void test("system prompt includes workspace folder conventions", () => {
+  const prompt = buildSystemPrompt();
+  assert.match(prompt, /## Workspace/);
+  assert.match(prompt, /notes\//);
+  assert.match(prompt, /workbooks\//);
+  assert.match(prompt, /scratch\//);
+  assert.match(prompt, /imports\//);
+  assert.match(prompt, /notes\/index\.md/);
+  assert.match(prompt, /persistent memory/i);
+});
+
 void test("system prompt mentions extension manager tool for chat-driven authoring", () => {
   const prompt = buildSystemPrompt();
   assert.match(prompt, /\*\*extensions_manager\*\*/);


### PR DESCRIPTION
Two quick wins from #178 that require no infrastructure changes:

## 1. Workspace folder conventions in system prompt

Adds a `## Workspace` section teaching the agent standard folder layout:

- `notes/` — persistent memory across sessions (with `notes/index.md` as an index)
- `workbooks/<name>/` — per-workbook artifacts
- `scratch/` — temporary working files
- `imports/` — user-uploaded files

This is static text — no code changes to workspace internals, no caching impact.

## 2. `files list` path filter

The `path` param on `list` now scopes results to a folder:

```json
{ "action": "list", "path": "notes/" }
```

Returns only files under `notes/`. The output shows the filter context and count ("2 of 15 total"). Without a path, behavior is unchanged.

This lets the agent scope listings instead of dumping everything — important as workspaces grow.

## Tests

- Folder filtering: prefix matching, empty results for nonexistent folders, count context in output
- System prompt: verifies workspace conventions section with all folder names

All 307 context tests pass, no regressions.

Closes: n/a (partial progress on #178)
