### PR TITLE
fix(website): make landing page mobile responsive

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -606,6 +606,18 @@
 
     /* ── Responsive ── */
     @media (max-width: 640px) {
+      .page { padding: 0 16px; }
+      nav {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+      }
+      .nav-links {
+        width: 100%;
+        flex-wrap: wrap;
+        gap: 14px;
+      }
+
       .hero { padding: 56px 0 44px; }
       .card { padding: 18px; }
       .connect-option { padding: 18px; }


### PR DESCRIPTION
## Summary
- fix mobile overflow on the landing page header/nav
- keep desktop layout unchanged
- verify with iPhone viewport using agent-browser

## Changes
- `public/index.html`
  - in `@media (max-width: 640px)`:
    - reduce horizontal page padding (`24px` -> `16px`)
    - stack nav vertically (`nav` becomes column, left-aligned)
    - allow nav links to wrap and use full width

## Verification
- `npm run check`
- `npm run build`
- manual viewport check (iPhone 13):
  - before: `scrollWidth` > `innerWidth` due `.nav-links`
  - after: `scrollWidth === innerWidth` (no horizontal overflow)

Closes #189
