### PR TITLE
fix(landing): make mobile nav responsive and extract landing assets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,634 +9,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html { scroll-behavior: smooth; }
+    <link rel="stylesheet" href="/landing.css" />
 
-    :root {
-      --bg: oklch(0.985 0.002 90);
-      --fg: oklch(0.18 0 0);
-      --muted: oklch(0.50 0 0);
-      --faint: oklch(0.65 0 0);
-      --green: oklch(0.45 0.12 160);
-      --green-strong: oklch(0.40 0.12 160);
-      --green-light: oklch(0.45 0.12 160 / 0.08);
-      --green-lighter: oklch(0.45 0.12 160 / 0.04);
-      --green-border: oklch(0.45 0.12 160 / 0.14);
-      --border: oklch(0 0 0 / 0.08);
-      --border-light: oklch(0 0 0 / 0.05);
-      --card-bg: oklch(1 0 0 / 0.72);
-      --card-border: oklch(1 0 0 / 0.50);
-      --shadow: 0 2px 8px oklch(0 0 0 / 0.06), 0 0.5px 0 oklch(0 0 0 / 0.04);
-      --shadow-lg: 0 12px 40px oklch(0 0 0 / 0.08), 0 2px 6px oklch(0 0 0 / 0.05);
-      --glass-highlight: inset 0 1px 0 0 oklch(1 0 0 / 0.60), inset 1px 0 0 0 oklch(1 0 0 / 0.30);
-      --glass-inner: inset 0 -1px 0 0 oklch(0 0 0 / 0.04), inset -1px 0 0 0 oklch(0 0 0 / 0.02);
-      --radius: 16px;
-      --radius-sm: 10px;
-      --radius-xs: 6px;
-      --font: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
-      --font-display: 'Instrument Serif', Georgia, serif;
-      --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-      --terminal-bg: oklch(0.16 0.005 260);
-      --terminal-fg: oklch(0.88 0.01 110);
-      --terminal-muted: oklch(0.55 0.01 260);
-      --terminal-green: oklch(0.72 0.16 155);
-    }
-
-    body {
-      font-family: var(--font);
-      font-size: 15px;
-      line-height: 1.6;
-      color: var(--fg);
-      background-color: var(--bg);
-      background-image:
-        linear-gradient(oklch(0.45 0.08 160 / 0.04) 1px, transparent 1px),
-        linear-gradient(90deg, oklch(0.45 0.08 160 / 0.04) 1px, transparent 1px);
-      background-size: 80px 21px;
-      background-position: -1px -1px;
-      -webkit-font-smoothing: antialiased;
-    }
-
-    .page { max-width: 660px; margin: 0 auto; padding: 0 24px; }
-
-    /* ── Nav ── */
-    nav {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 20px 0 0;
-    }
-    .nav-mark {
-      font-family: var(--font);
-      font-size: 15px;
-      font-weight: 700;
-      color: var(--green);
-      text-decoration: none;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
-    .nav-mark span {
-      font-family: var(--font-display);
-      font-size: 20px;
-      line-height: 1;
-    }
-    .exp-badge {
-      display: inline-flex;
-      align-items: center;
-      font-family: var(--font-mono);
-      font-size: 10px;
-      font-weight: 500;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      padding: 3px 9px;
-      border-radius: 999px;
-      background: oklch(0.55 0.15 50 / 0.10);
-      color: oklch(0.48 0.12 50);
-      border: 1px solid oklch(0.55 0.15 50 / 0.18);
-      margin-left: 10px;
-    }
-    .nav-links { display: flex; align-items: center; gap: 20px; }
-    .nav-links a {
-      font-size: 13px;
-      color: var(--muted);
-      text-decoration: none;
-      transition: color 0.15s;
-    }
-    .nav-links a:hover { color: var(--fg); }
-    .gh-link { display: inline-flex; align-items: center; gap: 5px; }
-    .gh-link svg { width: 16px; height: 16px; fill: currentColor; }
-
-    /* ── Hero ── */
-    .hero {
-      padding: 72px 0 56px;
-      position: relative;
-    }
-    .hero h1 {
-      font-family: var(--font-display);
-      font-size: clamp(36px, 6.5vw, 50px);
-      font-weight: 400;
-      line-height: 1.12;
-      letter-spacing: -0.015em;
-      margin-bottom: 20px;
-      position: relative;
-    }
-    .hero h1 em {
-      font-style: italic;
-      color: var(--green);
-    }
-    .hero-sub {
-      font-size: 16px;
-      line-height: 1.7;
-      color: var(--muted);
-      max-width: 500px;
-      margin-bottom: 32px;
-    }
-    .hero-cta {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      background: var(--green);
-      color: white;
-      font-family: var(--font);
-      font-size: 14px;
-      font-weight: 600;
-      padding: 11px 22px;
-      border-radius: 999px;
-      border: none;
-      text-decoration: none;
-      cursor: pointer;
-      transition: background 0.15s, transform 0.15s;
-      box-shadow: 0 2px 12px oklch(0.45 0.12 160 / 0.25);
-    }
-    .hero-cta:hover { background: var(--green-strong); color: white; transform: translateY(-1px); }
-    .hero-cta svg {
-      width: 14px; height: 14px; fill: none;
-      stroke: currentColor; stroke-width: 2;
-      stroke-linecap: round; stroke-linejoin: round;
-    }
-    .hero-note {
-      margin-top: 14px;
-      font-size: 13px;
-      color: var(--faint);
-    }
-    .hero-note a { text-decoration: none; }
-    .hero-note a:hover { text-decoration: underline; }
-
-    /* ── Sections ── */
-    section { margin-bottom: 64px; }
-    .section-label {
-      font-family: var(--font-mono);
-      font-size: 11px;
-      font-weight: 500;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--green);
-      margin-bottom: 10px;
-    }
-    .section-title {
-      font-family: var(--font-display);
-      font-size: clamp(26px, 4.5vw, 34px);
-      font-weight: 400;
-      line-height: 1.2;
-      letter-spacing: -0.01em;
-      margin-bottom: 14px;
-    }
-    .section-desc {
-      font-size: 15px;
-      line-height: 1.7;
-      color: var(--muted);
-      max-width: 520px;
-      margin-bottom: 28px;
-    }
-
-    /* ── Glass card ── */
-    .card {
-      background: var(--card-bg);
-      border: 1px solid var(--card-border);
-      border-radius: var(--radius);
-      padding: 24px;
-      box-shadow: var(--shadow), var(--glass-highlight), var(--glass-inner);
-      backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
-      -webkit-backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
-    }
-    .card + .card { margin-top: 12px; }
-    .card h3 {
-      font-family: var(--font);
-      font-size: 15px;
-      font-weight: 600;
-      margin-bottom: 8px;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .card p, .card li {
-      font-size: 14px;
-      line-height: 1.65;
-      color: var(--muted);
-    }
-    .card p + p { margin-top: 8px; }
-    .card a { text-decoration: none; }
-    .card a:hover { text-decoration: underline; }
-
-    /* Step number */
-    .step-num {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 26px; height: 26px;
-      border-radius: 999px;
-      background: var(--green);
-      color: white;
-      font-family: var(--font-mono);
-      font-size: 12px;
-      font-weight: 500;
-      flex-shrink: 0;
-    }
-
-    /* ── Narrative block (the "why" sections) ── */
-    .narrative {
-      margin-bottom: 48px;
-    }
-    .narrative h3 {
-      font-family: var(--font-display);
-      font-size: clamp(22px, 4vw, 28px);
-      font-weight: 400;
-      line-height: 1.25;
-      margin-bottom: 12px;
-    }
-    .narrative p {
-      font-size: 15px;
-      line-height: 1.7;
-      color: var(--muted);
-      max-width: 540px;
-    }
-    .narrative p + p { margin-top: 10px; }
-
-    /* ── Convention demo ── */
-    .convention-demo {
-      margin-top: 20px;
-      background: var(--card-bg);
-      border: 1px solid var(--card-border);
-      border-radius: var(--radius);
-      overflow: hidden;
-      box-shadow: var(--shadow), var(--glass-highlight), var(--glass-inner);
-      backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
-      -webkit-backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
-    }
-    .convention-demo-header {
-      padding: 14px 20px;
-      border-bottom: 1px solid oklch(0 0 0 / 0.05);
-      font-family: var(--font);
-      font-size: 12px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--faint);
-    }
-    .convention-row {
-      display: flex;
-      align-items: baseline;
-      padding: 12px 20px;
-      border-bottom: 1px solid oklch(0 0 0 / 0.04);
-      gap: 16px;
-    }
-    .convention-row:last-child { border-bottom: none; }
-    .convention-label {
-      font-size: 13px;
-      color: var(--muted);
-      min-width: 120px;
-      flex-shrink: 0;
-    }
-    .convention-value {
-      font-family: var(--font-mono);
-      font-size: 13px;
-      color: var(--fg);
-      font-weight: 500;
-    }
-    .convention-value .green-swatch {
-      display: inline-block;
-      width: 12px; height: 12px;
-      border-radius: 3px;
-      background: rgb(0, 128, 0);
-      vertical-align: middle;
-      margin-right: 6px;
-      border: 1px solid oklch(0 0 0 / 0.1);
-    }
-
-    /* ── Prompt examples ── */
-    .prompts {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      margin-top: 20px;
-    }
-    .prompt-example {
-      padding: 12px 16px;
-      background: oklch(1 0 0 / 0.70);
-      border: 1px solid oklch(0 0 0 / 0.06);
-      border-radius: var(--radius-sm);
-      font-size: 14px;
-      color: var(--fg);
-      font-style: italic;
-      line-height: 1.5;
-      box-shadow: 0 1px 3px oklch(0 0 0 / 0.03);
-    }
-    .prompt-example::before {
-      content: '"';
-      color: var(--green);
-      font-family: var(--font-display);
-      font-size: 18px;
-      margin-right: 2px;
-    }
-    .prompt-example::after {
-      content: '"';
-      color: var(--green);
-      font-family: var(--font-display);
-      font-size: 18px;
-      margin-left: 1px;
-    }
-
-    /* ── Placeholder section ── */
-    .placeholder-card {
-      border: 1px dashed oklch(0 0 0 / 0.12);
-      border-radius: var(--radius);
-      padding: 28px 24px;
-      background: oklch(1 0 0 / 0.40);
-      text-align: center;
-    }
-    .placeholder-card p {
-      font-size: 14px;
-      color: var(--faint);
-      font-style: italic;
-    }
-
-    /* ── Download button ── */
-    .dl-btn {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      margin-top: 14px;
-      padding: 10px 18px;
-      background: var(--green-light);
-      border: 1px solid var(--green-border);
-      border-radius: var(--radius-sm);
-      color: var(--green);
-      font-family: var(--font);
-      font-size: 14px;
-      font-weight: 600;
-      text-decoration: none;
-      transition: background 0.15s, border-color 0.15s;
-    }
-    .dl-btn:hover {
-      background: oklch(0.45 0.12 160 / 0.14);
-      border-color: oklch(0.45 0.12 160 / 0.25);
-      text-decoration: none;
-    }
-    .dl-btn svg {
-      width: 16px; height: 16px; fill: none;
-      stroke: currentColor; stroke-width: 2;
-      stroke-linecap: round; stroke-linejoin: round;
-    }
-
-    /* ── Terminal block ── */
-    .terminal {
-      background: var(--terminal-bg);
-      border-radius: var(--radius-sm);
-      margin-top: 14px;
-      overflow: hidden;
-    }
-    .terminal-bar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 8px 14px;
-      background: oklch(0.20 0.005 260);
-      border-bottom: 1px solid oklch(1 0 0 / 0.06);
-    }
-    .terminal-dots { display: flex; gap: 6px; }
-    .terminal-dots span {
-      width: 10px; height: 10px; border-radius: 999px;
-      background: oklch(0.30 0 0);
-    }
-    .terminal-copy {
-      background: none;
-      border: 1px solid oklch(1 0 0 / 0.12);
-      border-radius: var(--radius-xs);
-      color: var(--terminal-muted);
-      font-family: var(--font);
-      font-size: 11px;
-      padding: 3px 10px;
-      cursor: pointer;
-      transition: color 0.15s, border-color 0.15s;
-    }
-    .terminal-copy:hover {
-      color: var(--terminal-fg);
-      border-color: oklch(1 0 0 / 0.25);
-    }
-    .terminal-copy.copied {
-      color: var(--terminal-green);
-      border-color: oklch(0.72 0.16 155 / 0.4);
-    }
-    .terminal pre {
-      padding: 16px;
-      overflow-x: auto;
-      font-family: var(--font-mono);
-      font-size: 13px;
-      line-height: 1.7;
-      color: var(--terminal-fg);
-    }
-    .terminal pre .comment { color: var(--terminal-muted); }
-    .terminal pre .prompt { color: var(--terminal-green); user-select: none; }
-
-    /* ── Callout ── */
-    .callout {
-      margin-top: 14px;
-      padding: 14px 16px;
-      background: var(--green-lighter);
-      border: 1px solid var(--green-border);
-      border-radius: var(--radius-sm);
-      font-size: 13px;
-      line-height: 1.6;
-      color: var(--muted);
-    }
-    .callout strong { color: var(--fg); font-weight: 600; }
-    .callout code {
-      font-family: var(--font-mono);
-      font-size: 12px;
-      background: oklch(0 0 0 / 0.05);
-      padding: 1px 5px;
-      border-radius: 4px;
-    }
-
-    /* ── OS toggle ── */
-    .os-toggle {
-      display: inline-flex;
-      background: oklch(0 0 0 / 0.04);
-      border-radius: 999px;
-      padding: 3px;
-      margin-bottom: 24px;
-      border: 1px solid var(--border-light);
-    }
-    .os-toggle button {
-      font-family: var(--font);
-      font-size: 13px;
-      font-weight: 500;
-      padding: 6px 16px;
-      border: none;
-      border-radius: 999px;
-      cursor: pointer;
-      background: transparent;
-      color: var(--muted);
-      transition: all 0.15s;
-    }
-    .os-toggle button.active {
-      background: white;
-      color: var(--fg);
-      box-shadow: 0 1px 4px oklch(0 0 0 / 0.08);
-    }
-    .os-panel { display: none; }
-    .os-panel.active { display: block; }
-
-    /* ── Connect options ── */
-    .connect-option {
-      padding: 20px 24px;
-      background: var(--card-bg);
-      border: 1px solid var(--card-border);
-      border-radius: var(--radius);
-      box-shadow: var(--shadow), var(--glass-highlight), var(--glass-inner);
-      backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
-      -webkit-backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
-    }
-    .connect-option + .connect-option { margin-top: 12px; }
-    .connect-option h3 {
-      font-family: var(--font);
-      font-size: 15px;
-      font-weight: 600;
-      margin-bottom: 6px;
-    }
-    .connect-option > p {
-      font-size: 14px;
-      color: var(--muted);
-      line-height: 1.65;
-    }
-    .connect-option > p.connect-step-intro { margin-top: 12px; }
-    .connect-option > p.connect-step-followup { margin-top: 16px; }
-    .connect-option > p.connect-helper-note {
-      margin-top: 12px;
-      font-size: 13px;
-      color: var(--faint);
-    }
-    .connect-option > p.connect-sidebar-note {
-      margin-top: 12px;
-      font-size: 14px;
-      color: var(--muted);
-    }
-    .badge {
-      display: inline-block;
-      font-family: var(--font);
-      font-size: 11px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      padding: 2px 8px;
-      border-radius: 999px;
-      background: var(--green-light);
-      color: var(--green);
-      vertical-align: middle;
-      margin-left: 8px;
-    }
-    .badge-simple {
-      background: oklch(0.45 0.08 90 / 0.10);
-      color: oklch(0.45 0.04 90);
-    }
-
-    /* ── Inline elements ── */
-    code {
-      font-family: var(--font-mono);
-      font-size: 0.9em;
-      background: oklch(0 0 0 / 0.05);
-      padding: 1px 5px;
-      border-radius: 4px;
-    }
-    kbd {
-      font-family: var(--font);
-      font-size: 12px;
-      font-weight: 500;
-      padding: 2px 7px;
-      background: oklch(0 0 0 / 0.06);
-      border: 1px solid oklch(0 0 0 / 0.10);
-      border-radius: 5px;
-      box-shadow: 0 1px 0 oklch(0 0 0 / 0.08);
-    }
-    .path {
-      font-family: var(--font-mono);
-      font-size: 13px;
-      color: var(--green);
-      font-weight: 500;
-    }
-    .card ol {
-      padding-left: 0;
-      list-style: none;
-      counter-reset: steps;
-    }
-    .card ol li {
-      counter-increment: steps;
-      padding-left: 24px;
-      position: relative;
-      margin-bottom: 6px;
-    }
-    .card ol li::before {
-      content: counter(steps) ".";
-      position: absolute;
-      left: 0;
-      font-family: var(--font-mono);
-      font-size: 12px;
-      font-weight: 500;
-      color: var(--green);
-    }
-
-    /* ── Footer ── */
-    footer {
-      padding: 48px 0;
-      border-top: 1px solid oklch(0 0 0 / 0.06);
-      margin-top: 24px;
-    }
-    .footer-pi {
-      font-family: var(--font-display);
-      font-size: 32px;
-      color: var(--green);
-      opacity: 0.15;
-      display: block;
-      margin-bottom: 12px;
-    }
-    footer p {
-      font-size: 13px;
-      color: var(--faint);
-      line-height: 1.7;
-    }
-    a { color: var(--green); }
-    a:hover { color: var(--green-strong); }
-    footer a { text-decoration: none; }
-    footer a:hover { text-decoration: underline; }
-
-    /* ── Animations ── */
-    @keyframes fadeUp {
-      from { opacity: 0; transform: translateY(16px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-    .hero h1 { animation: fadeUp 0.6s ease both; }
-    .hero-sub { animation: fadeUp 0.6s ease 0.08s both; }
-    .hero-cta { animation: fadeUp 0.6s ease 0.16s both; }
-    .hero-note { animation: fadeUp 0.6s ease 0.22s both; }
-    .reveal {
-      opacity: 0;
-      transform: translateY(12px);
-      transition: opacity 0.5s ease, transform 0.5s ease;
-    }
-    .reveal.visible { opacity: 1; transform: translateY(0); }
-
-    /* ── Responsive ── */
-    @media (max-width: 640px) {
-      .page { padding: 0 16px; }
-      nav {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 10px;
-      }
-      .nav-links {
-        width: 100%;
-        flex-wrap: wrap;
-        gap: 14px;
-      }
-
-      .hero { padding: 56px 0 44px; }
-      .card { padding: 18px; }
-      .connect-option { padding: 18px; }
-      .convention-row { flex-direction: column; gap: 4px; }
-      .convention-label { min-width: 0; }
-    }
-  </style>
 </head>
 <body>
 
@@ -644,7 +18,7 @@
 
   <!-- Nav -->
   <nav>
-    <a href="/" class="nav-mark"><span>π</span> Pi for Excel <span class="exp-badge">Experimental</span></a>
+    <a href="/" class="nav-mark"><span class="nav-mark__logo">π</span> <span class="nav-mark__text">Pi for Excel</span> <span class="exp-badge">Experimental</span></a>
     <div class="nav-links">
       <a href="#install">Install</a>
       <a href="#connect">Connect</a>
@@ -762,8 +136,8 @@
     </p>
 
     <div class="os-toggle">
-      <button class="active" onclick="switchOS('mac')">macOS</button>
-      <button onclick="switchOS('win')">Windows</button>
+      <button type="button" class="active" data-os="mac">macOS</button>
+      <button type="button" data-os="win">Windows</button>
     </div>
 
     <!-- macOS -->
@@ -783,7 +157,7 @@
         <div class="terminal">
           <div class="terminal-bar">
             <div class="terminal-dots"><span></span><span></span><span></span></div>
-            <button class="terminal-copy" onclick="copyCmd(this)">Copy</button>
+            <button type="button" class="terminal-copy">Copy</button>
           </div>
           <pre><span class="prompt">$ </span>mkdir -p ~/Library/Containers/com.microsoft.Excel/Data/Documents/wef && \
   cp ~/Downloads/manifest.prod.xml ~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/</pre>
@@ -805,7 +179,7 @@
 
     <!-- Windows -->
     <div id="panel-win" class="os-panel">
-      <div class="callout" style="margin-top: 0; margin-bottom: 16px;">
+      <div class="callout callout--windows-note">
         <strong>Heads up —</strong> Pi was built and tested on macOS. It <em>should</em> work on Windows (the underlying tech is cross-platform) but hasn't been extensively tested. Worth a try! If you hit issues, <a href="https://github.com/tmustier/pi-for-excel/issues" target="_blank" rel="noopener">open a GitHub issue</a>.
       </div>
 
@@ -849,36 +223,40 @@
         If you already pay for Claude, Copilot, or another provider, you can log in directly — no API key needed. You just need to run a small local helper first.
       </p>
 
-      <p class="connect-step-intro">
-        <strong>If you already have Node.js</strong>:
+      <p class="connect-option__intro">
+        <strong>One-time setup</strong> — open Terminal and run these, or just ask your agent to set it up:
       </p>
 
       <div class="terminal">
         <div class="terminal-bar">
           <div class="terminal-dots"><span></span><span></span><span></span></div>
-          <button class="terminal-copy" onclick="copyCmd(this)">Copy</button>
+          <button type="button" class="terminal-copy">Copy</button>
         </div>
-        <pre><span class="prompt">$ </span>npx pi-for-excel-proxy</pre>
+        <pre><span class="comment"># Install mkcert (creates local HTTPS certificates)</span>
+<span class="prompt">$ </span>brew install mkcert
+
+<span class="comment"># Download Pi for Excel and set up the login helper</span>
+<span class="prompt">$ </span>git clone https://github.com/tmustier/pi-for-excel.git ~/.pi-for-excel
+<span class="prompt">$ </span>cd ~/.pi-for-excel
+<span class="prompt">$ </span>npm install
+<span class="prompt">$ </span>mkcert -install && mkcert localhost
+<span class="prompt">$ </span>mv localhost-key.pem key.pem && mv localhost.pem cert.pem</pre>
       </div>
 
-      <p class="connect-step-followup">
-        <strong>If you don't have Node.js (or aren't sure)</strong>:
+      <p class="connect-option__start">
+        <strong>Then, whenever you use Pi</strong>, start the helper:
       </p>
 
       <div class="terminal">
         <div class="terminal-bar">
           <div class="terminal-dots"><span></span><span></span><span></span></div>
-          <button class="terminal-copy" onclick="copyCmd(this)">Copy</button>
+          <button type="button" class="terminal-copy">Copy</button>
         </div>
-        <pre><span class="prompt">$ </span>curl -fsSL https://piforexcel.com/proxy | sh</pre>
+        <pre><span class="prompt">$ </span>cd ~/.pi-for-excel && npm run proxy:https</pre>
       </div>
 
-      <p class="connect-helper-note">
-        First run sets up local HTTPS certs automatically. Keep the helper running while you use Pi.
-      </p>
-
-      <p class="connect-sidebar-note">
-        In the sidebar: <span class="path">/settings</span> → Proxy → enable, set URL to <code>https://localhost:3003</code>. Then <span class="path">/login</span> and sign in.
+      <p class="connect-option__note">
+        Keep it running while you use Pi. In the sidebar: <span class="path">/settings</span> → Proxy → enable, set URL to <code>https://localhost:3003</code>. Then <span class="path">/login</span> and sign in.
       </p>
 
       <div class="callout">
@@ -902,7 +280,7 @@
       Pi for Excel is free, open source, and <a href="https://github.com/tmustier/pi-for-excel/blob/main/LICENSE" target="_blank" rel="noopener">MIT licensed</a>.
       Updates are automatic — close and reopen the sidebar to get the latest version.
     </p>
-    <p style="margin-top: 8px;">
+    <p class="footer-note">
       Built by <a href="https://github.com/tmustier" target="_blank" rel="noopener">Thomas Mustier</a>.
       Powered by <a href="https://pi.dev" target="_blank" rel="noopener">Pi</a>, an extensible coding agent by <a href="https://github.com/badlogic" target="_blank" rel="noopener">Mario Zechner</a>.
     </p>
@@ -911,40 +289,7 @@
 </div>
 
 
-<script>
-  function switchOS(os) {
-    document.querySelectorAll('.os-toggle button').forEach(b => b.classList.remove('active'));
-    document.querySelectorAll('.os-panel').forEach(p => p.classList.remove('active'));
-    if (os === 'mac') {
-      document.querySelector('.os-toggle button:first-child').classList.add('active');
-      document.getElementById('panel-mac').classList.add('active');
-    } else {
-      document.querySelector('.os-toggle button:last-child').classList.add('active');
-      document.getElementById('panel-win').classList.add('active');
-    }
-  }
-
-  function copyCmd(btn) {
-    const pre = btn.closest('.terminal').querySelector('pre');
-    const text = pre.textContent
-      .split('\n')
-      .filter(line => !line.trim().startsWith('#'))
-      .map(line => line.replace(/^\$ /, ''))
-      .filter(line => line.trim())
-      .join('\n');
-    navigator.clipboard.writeText(text).then(() => {
-      btn.textContent = 'Copied!';
-      btn.classList.add('copied');
-      setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
-    });
-  }
-
-  const observer = new IntersectionObserver(
-    entries => entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); }),
-    { threshold: 0.1, rootMargin: '0px 0px -40px 0px' }
-  );
-  document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
-</script>
+<script src="/landing.js"></script>
 
 </body>
 </html>

--- a/public/landing.css
+++ b/public/landing.css
@@ -1,0 +1,643 @@
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+
+    :root {
+      --bg: oklch(0.985 0.002 90);
+      --fg: oklch(0.18 0 0);
+      --muted: oklch(0.50 0 0);
+      --faint: oklch(0.65 0 0);
+      --green: oklch(0.45 0.12 160);
+      --green-strong: oklch(0.40 0.12 160);
+      --green-light: oklch(0.45 0.12 160 / 0.08);
+      --green-lighter: oklch(0.45 0.12 160 / 0.04);
+      --green-border: oklch(0.45 0.12 160 / 0.14);
+      --border: oklch(0 0 0 / 0.08);
+      --border-light: oklch(0 0 0 / 0.05);
+      --card-bg: oklch(1 0 0 / 0.72);
+      --card-border: oklch(1 0 0 / 0.50);
+      --shadow: 0 2px 8px oklch(0 0 0 / 0.06), 0 0.5px 0 oklch(0 0 0 / 0.04);
+      --shadow-lg: 0 12px 40px oklch(0 0 0 / 0.08), 0 2px 6px oklch(0 0 0 / 0.05);
+      --glass-highlight: inset 0 1px 0 0 oklch(1 0 0 / 0.60), inset 1px 0 0 0 oklch(1 0 0 / 0.30);
+      --glass-inner: inset 0 -1px 0 0 oklch(0 0 0 / 0.04), inset -1px 0 0 0 oklch(0 0 0 / 0.02);
+      --radius: 16px;
+      --radius-sm: 10px;
+      --radius-xs: 6px;
+      --font: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
+      --font-display: 'Instrument Serif', Georgia, serif;
+      --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+      --terminal-bg: oklch(0.16 0.005 260);
+      --terminal-fg: oklch(0.88 0.01 110);
+      --terminal-muted: oklch(0.55 0.01 260);
+      --terminal-green: oklch(0.72 0.16 155);
+    }
+
+    body {
+      font-family: var(--font);
+      font-size: 15px;
+      line-height: 1.6;
+      color: var(--fg);
+      background-color: var(--bg);
+      background-image:
+        linear-gradient(oklch(0.45 0.08 160 / 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, oklch(0.45 0.08 160 / 0.04) 1px, transparent 1px);
+      background-size: 80px 21px;
+      background-position: -1px -1px;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .page { max-width: 660px; margin: 0 auto; padding: 0 24px; }
+
+    /* ── Nav ── */
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 0 0;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .nav-mark {
+      font-family: var(--font);
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--green);
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
+    }
+    .nav-mark__logo {
+      font-family: var(--font-display);
+      font-size: 20px;
+      line-height: 1;
+    }
+    .exp-badge {
+      display: inline-flex;
+      align-items: center;
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 3px 9px;
+      border-radius: 999px;
+      background: oklch(0.55 0.15 50 / 0.10);
+      color: oklch(0.48 0.12 50);
+      border: 1px solid oklch(0.55 0.15 50 / 0.18);
+      margin-left: 10px;
+    }
+    .nav-links { display: flex; align-items: center; gap: 20px; }
+    .nav-links a {
+      font-size: 13px;
+      color: var(--muted);
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .nav-links a:hover { color: var(--fg); }
+    .gh-link { display: inline-flex; align-items: center; gap: 5px; }
+    .gh-link svg { width: 16px; height: 16px; fill: currentColor; }
+
+    /* ── Hero ── */
+    .hero {
+      padding: 72px 0 56px;
+      position: relative;
+    }
+    .hero h1 {
+      font-family: var(--font-display);
+      font-size: clamp(36px, 6.5vw, 50px);
+      font-weight: 400;
+      line-height: 1.12;
+      letter-spacing: -0.015em;
+      margin-bottom: 20px;
+      position: relative;
+    }
+    .hero h1 em {
+      font-style: italic;
+      color: var(--green);
+    }
+    .hero-sub {
+      font-size: 16px;
+      line-height: 1.7;
+      color: var(--muted);
+      max-width: 500px;
+      margin-bottom: 32px;
+    }
+    .hero-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--green);
+      color: white;
+      font-family: var(--font);
+      font-size: 14px;
+      font-weight: 600;
+      padding: 11px 22px;
+      border-radius: 999px;
+      border: none;
+      text-decoration: none;
+      cursor: pointer;
+      transition: background 0.15s, transform 0.15s;
+      box-shadow: 0 2px 12px oklch(0.45 0.12 160 / 0.25);
+    }
+    .hero-cta:hover { background: var(--green-strong); color: white; transform: translateY(-1px); }
+    .hero-cta svg {
+      width: 14px; height: 14px; fill: none;
+      stroke: currentColor; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round;
+    }
+    .hero-note {
+      margin-top: 14px;
+      font-size: 13px;
+      color: var(--faint);
+    }
+    .hero-note a { text-decoration: none; }
+    .hero-note a:hover { text-decoration: underline; }
+
+    /* ── Sections ── */
+    section { margin-bottom: 64px; }
+    .section-label {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--green);
+      margin-bottom: 10px;
+    }
+    .section-title {
+      font-family: var(--font-display);
+      font-size: clamp(26px, 4.5vw, 34px);
+      font-weight: 400;
+      line-height: 1.2;
+      letter-spacing: -0.01em;
+      margin-bottom: 14px;
+    }
+    .section-desc {
+      font-size: 15px;
+      line-height: 1.7;
+      color: var(--muted);
+      max-width: 520px;
+      margin-bottom: 28px;
+    }
+
+    /* ── Glass card ── */
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: var(--radius);
+      padding: 24px;
+      box-shadow: var(--shadow), var(--glass-highlight), var(--glass-inner);
+      backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
+      -webkit-backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
+    }
+    .card + .card { margin-top: 12px; }
+    .card h3 {
+      font-family: var(--font);
+      font-size: 15px;
+      font-weight: 600;
+      margin-bottom: 8px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .card p, .card li {
+      font-size: 14px;
+      line-height: 1.65;
+      color: var(--muted);
+    }
+    .card p + p { margin-top: 8px; }
+    .card a { text-decoration: none; }
+    .card a:hover { text-decoration: underline; }
+
+    /* Step number */
+    .step-num {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px; height: 26px;
+      border-radius: 999px;
+      background: var(--green);
+      color: white;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 500;
+      flex-shrink: 0;
+    }
+
+    /* ── Narrative block (the "why" sections) ── */
+    .narrative {
+      margin-bottom: 48px;
+    }
+    .narrative h3 {
+      font-family: var(--font-display);
+      font-size: clamp(22px, 4vw, 28px);
+      font-weight: 400;
+      line-height: 1.25;
+      margin-bottom: 12px;
+    }
+    .narrative p {
+      font-size: 15px;
+      line-height: 1.7;
+      color: var(--muted);
+      max-width: 540px;
+    }
+    .narrative p + p { margin-top: 10px; }
+
+    /* ── Convention demo ── */
+    .convention-demo {
+      margin-top: 20px;
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      box-shadow: var(--shadow), var(--glass-highlight), var(--glass-inner);
+      backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
+      -webkit-backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
+    }
+    .convention-demo-header {
+      padding: 14px 20px;
+      border-bottom: 1px solid oklch(0 0 0 / 0.05);
+      font-family: var(--font);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--faint);
+    }
+    .convention-row {
+      display: flex;
+      align-items: baseline;
+      padding: 12px 20px;
+      border-bottom: 1px solid oklch(0 0 0 / 0.04);
+      gap: 16px;
+    }
+    .convention-row:last-child { border-bottom: none; }
+    .convention-label {
+      font-size: 13px;
+      color: var(--muted);
+      min-width: 120px;
+      flex-shrink: 0;
+    }
+    .convention-value {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--fg);
+      font-weight: 500;
+    }
+    .convention-value .green-swatch {
+      display: inline-block;
+      width: 12px; height: 12px;
+      border-radius: 3px;
+      background: rgb(0, 128, 0);
+      vertical-align: middle;
+      margin-right: 6px;
+      border: 1px solid oklch(0 0 0 / 0.1);
+    }
+
+    /* ── Prompt examples ── */
+    .prompts {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 20px;
+    }
+    .prompt-example {
+      padding: 12px 16px;
+      background: oklch(1 0 0 / 0.70);
+      border: 1px solid oklch(0 0 0 / 0.06);
+      border-radius: var(--radius-sm);
+      font-size: 14px;
+      color: var(--fg);
+      font-style: italic;
+      line-height: 1.5;
+      box-shadow: 0 1px 3px oklch(0 0 0 / 0.03);
+    }
+    .prompt-example::before {
+      content: '"';
+      color: var(--green);
+      font-family: var(--font-display);
+      font-size: 18px;
+      margin-right: 2px;
+    }
+    .prompt-example::after {
+      content: '"';
+      color: var(--green);
+      font-family: var(--font-display);
+      font-size: 18px;
+      margin-left: 1px;
+    }
+
+    /* ── Placeholder section ── */
+    .placeholder-card {
+      border: 1px dashed oklch(0 0 0 / 0.12);
+      border-radius: var(--radius);
+      padding: 28px 24px;
+      background: oklch(1 0 0 / 0.40);
+      text-align: center;
+    }
+    .placeholder-card p {
+      font-size: 14px;
+      color: var(--faint);
+      font-style: italic;
+    }
+
+    /* ── Download button ── */
+    .dl-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 14px;
+      padding: 10px 18px;
+      background: var(--green-light);
+      border: 1px solid var(--green-border);
+      border-radius: var(--radius-sm);
+      color: var(--green);
+      font-family: var(--font);
+      font-size: 14px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .dl-btn:hover {
+      background: oklch(0.45 0.12 160 / 0.14);
+      border-color: oklch(0.45 0.12 160 / 0.25);
+      text-decoration: none;
+    }
+    .dl-btn svg {
+      width: 16px; height: 16px; fill: none;
+      stroke: currentColor; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round;
+    }
+
+    /* ── Terminal block ── */
+    .terminal {
+      background: var(--terminal-bg);
+      border-radius: var(--radius-sm);
+      margin-top: 14px;
+      overflow: hidden;
+    }
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 14px;
+      background: oklch(0.20 0.005 260);
+      border-bottom: 1px solid oklch(1 0 0 / 0.06);
+    }
+    .terminal-dots { display: flex; gap: 6px; }
+    .terminal-dots span {
+      width: 10px; height: 10px; border-radius: 999px;
+      background: oklch(0.30 0 0);
+    }
+    .terminal-copy {
+      background: none;
+      border: 1px solid oklch(1 0 0 / 0.12);
+      border-radius: var(--radius-xs);
+      color: var(--terminal-muted);
+      font-family: var(--font);
+      font-size: 11px;
+      padding: 3px 10px;
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .terminal-copy:hover {
+      color: var(--terminal-fg);
+      border-color: oklch(1 0 0 / 0.25);
+    }
+    .terminal-copy.copied {
+      color: var(--terminal-green);
+      border-color: oklch(0.72 0.16 155 / 0.4);
+    }
+    .terminal pre {
+      padding: 16px;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.7;
+      color: var(--terminal-fg);
+    }
+    .terminal pre .comment { color: var(--terminal-muted); }
+    .terminal pre .prompt { color: var(--terminal-green); user-select: none; }
+
+    /* ── Callout ── */
+    .callout {
+      margin-top: 14px;
+      padding: 14px 16px;
+      background: var(--green-lighter);
+      border: 1px solid var(--green-border);
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      line-height: 1.6;
+      color: var(--muted);
+    }
+    .callout strong { color: var(--fg); font-weight: 600; }
+    .callout code {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      background: oklch(0 0 0 / 0.05);
+      padding: 1px 5px;
+      border-radius: 4px;
+    }
+    .callout--windows-note {
+      margin-top: 0;
+      margin-bottom: 16px;
+    }
+
+
+    /* ── OS toggle ── */
+    .os-toggle {
+      display: inline-flex;
+      background: oklch(0 0 0 / 0.04);
+      border-radius: 999px;
+      padding: 3px;
+      margin-bottom: 24px;
+      border: 1px solid var(--border-light);
+    }
+    .os-toggle button {
+      font-family: var(--font);
+      font-size: 13px;
+      font-weight: 500;
+      padding: 6px 16px;
+      border: none;
+      border-radius: 999px;
+      cursor: pointer;
+      background: transparent;
+      color: var(--muted);
+      transition: all 0.15s;
+    }
+    .os-toggle button.active {
+      background: white;
+      color: var(--fg);
+      box-shadow: 0 1px 4px oklch(0 0 0 / 0.08);
+    }
+    .os-panel { display: none; }
+    .os-panel.active { display: block; }
+
+    /* ── Connect options ── */
+    .connect-option {
+      padding: 20px 24px;
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow), var(--glass-highlight), var(--glass-inner);
+      backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
+      -webkit-backdrop-filter: blur(3px) saturate(1.6) brightness(1.04);
+    }
+    .connect-option + .connect-option { margin-top: 12px; }
+    .connect-option h3 {
+      font-family: var(--font);
+      font-size: 15px;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .connect-option > p {
+      font-size: 14px;
+      color: var(--muted);
+      line-height: 1.65;
+    }
+    .connect-option__intro {
+      margin-top: 12px;
+    }
+    .connect-option__start {
+      margin-top: 16px;
+    }
+    .connect-option__note {
+      margin-top: 12px;
+    }
+    .badge {
+      display: inline-block;
+      font-family: var(--font);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: var(--green-light);
+      color: var(--green);
+      vertical-align: middle;
+      margin-left: 8px;
+    }
+    .badge-simple {
+      background: oklch(0.45 0.08 90 / 0.10);
+      color: oklch(0.45 0.04 90);
+    }
+
+    /* ── Inline elements ── */
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.9em;
+      background: oklch(0 0 0 / 0.05);
+      padding: 1px 5px;
+      border-radius: 4px;
+    }
+    kbd {
+      font-family: var(--font);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 2px 7px;
+      background: oklch(0 0 0 / 0.06);
+      border: 1px solid oklch(0 0 0 / 0.10);
+      border-radius: 5px;
+      box-shadow: 0 1px 0 oklch(0 0 0 / 0.08);
+    }
+    .path {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--green);
+      font-weight: 500;
+    }
+    .card ol {
+      padding-left: 0;
+      list-style: none;
+      counter-reset: steps;
+    }
+    .card ol li {
+      counter-increment: steps;
+      padding-left: 24px;
+      position: relative;
+      margin-bottom: 6px;
+    }
+    .card ol li::before {
+      content: counter(steps) ".";
+      position: absolute;
+      left: 0;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--green);
+    }
+
+    /* ── Footer ── */
+    footer {
+      padding: 48px 0;
+      border-top: 1px solid oklch(0 0 0 / 0.06);
+      margin-top: 24px;
+    }
+    .footer-pi {
+      font-family: var(--font-display);
+      font-size: 32px;
+      color: var(--green);
+      opacity: 0.15;
+      display: block;
+      margin-bottom: 12px;
+    }
+    footer p {
+      font-size: 13px;
+      color: var(--faint);
+      line-height: 1.7;
+    }
+    .footer-note {
+      margin-top: 8px;
+    }
+    a { color: var(--green); }
+    a:hover { color: var(--green-strong); }
+    footer a { text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    /* ── Animations ── */
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(16px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .hero h1 { animation: fadeUp 0.6s ease both; }
+    .hero-sub { animation: fadeUp 0.6s ease 0.08s both; }
+    .hero-cta { animation: fadeUp 0.6s ease 0.16s both; }
+    .hero-note { animation: fadeUp 0.6s ease 0.22s both; }
+    .reveal {
+      opacity: 0;
+      transform: translateY(12px);
+      transition: opacity 0.5s ease, transform 0.5s ease;
+    }
+    .reveal.visible { opacity: 1; transform: translateY(0); }
+
+    /* ── Responsive ── */
+    @media (max-width: 640px) {
+      .hero { padding: 56px 0 44px; }
+      .card { padding: 18px; }
+      .connect-option { padding: 18px; }
+      .convention-row { flex-direction: column; gap: 4px; }
+      .convention-label { min-width: 0; }
+    }
+
+    @media (max-width: 480px) {
+      nav {
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .nav-mark {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .exp-badge {
+        font-size: 9px;
+        padding: 2px 7px;
+        margin-left: 6px;
+      }
+      .nav-links {
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+    }
+  

--- a/public/landing.js
+++ b/public/landing.js
@@ -1,0 +1,74 @@
+(() => {
+  function switchOS(os) {
+    if (os !== 'mac' && os !== 'win') {
+      return;
+    }
+
+    document.querySelectorAll('.os-toggle button[data-os]').forEach((button) => {
+      button.classList.toggle('active', button.dataset.os === os);
+    });
+
+    const macPanel = document.getElementById('panel-mac');
+    const winPanel = document.getElementById('panel-win');
+    if (macPanel) {
+      macPanel.classList.toggle('active', os === 'mac');
+    }
+    if (winPanel) {
+      winPanel.classList.toggle('active', os === 'win');
+    }
+  }
+
+  function copyCmd(button) {
+    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+      return;
+    }
+
+    const terminal = button.closest('.terminal');
+    const pre = terminal ? terminal.querySelector('pre') : null;
+    if (!pre || !pre.textContent) {
+      return;
+    }
+
+    const text = pre.textContent
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .map((line) => line.replace(/^\$ /, ''))
+      .filter((line) => line.trim())
+      .join('\n');
+
+    navigator.clipboard.writeText(text).then(() => {
+      button.textContent = 'Copied!';
+      button.classList.add('copied');
+      setTimeout(() => {
+        button.textContent = 'Copy';
+        button.classList.remove('copied');
+      }, 2000);
+    });
+  }
+
+  document.querySelectorAll('.os-toggle button[data-os]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const os = button.dataset.os;
+      if (os) {
+        switchOS(os);
+      }
+    });
+  });
+
+  document.querySelectorAll('.terminal-copy').forEach((button) => {
+    button.addEventListener('click', () => copyCmd(button));
+  });
+
+  const observer = new IntersectionObserver(
+    (entries) => entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+      }
+    }),
+    { threshold: 0.1, rootMargin: '0px 0px -40px 0px' },
+  );
+
+  document.querySelectorAll('.reveal').forEach((element) => {
+    observer.observe(element);
+  });
+})();


### PR DESCRIPTION
## Summary

Fixes mobile responsiveness issues in the landing page nav where **"Pi for Excel"** and the **"EXPERIMENTAL"** badge were getting smushed on narrow viewports.

### What changed

- Improve nav responsiveness for mobile:
  - allow wrapping in nav layout
  - keep brand text on one line
  - tighten badge/link spacing on small screens
- Scope nav logo styling to a specific class (`.nav-mark__logo`) instead of broad `span` styling.
- Remove inline styles from landing markup and replace with semantic classes.
- Remove inline `onclick` handlers and bind events in JS.
- Extract assets from inline blocks:
  - CSS moved to `public/landing.css`
  - JS moved to `public/landing.js`

## Files

- `public/index.html`
- `public/landing.css` (new)
- `public/landing.js` (new)

## Verification

- Manual browser checks at mobile widths (320px/375px) and tablet width.
- Confirmed nav/badge no longer overlap and links wrap cleanly.
- Confirmed OS toggle and terminal copy buttons still work after JS extraction.
