### PR TITLE
refactor(ui): unify overlay close controls and sizing tiers

### DIFF
--- a/src/commands/builtins/experimental-overlay.ts
+++ b/src/commands/builtins/experimental-overlay.ts
@@ -8,7 +8,11 @@ import {
   setExperimentalFeatureEnabled,
   type ExperimentalFeatureSnapshot,
 } from "../../experiments/flags.js";
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { EXPERIMENTAL_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 
@@ -137,6 +141,14 @@ export function showExperimentalDialog(): void {
     cardClassName: "pi-welcome-card pi-overlay-card pi-experimental-card",
   });
 
+  const closeOverlay = dialog.close;
+
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
   const title = document.createElement("h2");
   title.className = "pi-overlay-title";
   title.textContent = "Experimental Features";
@@ -146,6 +158,14 @@ export function showExperimentalDialog(): void {
   subtitle.textContent =
     "These toggles are local to this browser profile. Use carefully — some are security-sensitive. "
     + "Web Search and MCP are managed in /integrations.";
+
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close experimental features",
+  });
+
+  titleWrap.append(title, subtitle);
+  header.append(titleWrap, closeButton);
 
   const snapshots = getExperimentalFeatureSnapshots();
   const experimentalFeatures: ExperimentalFeatureSnapshot[] = [];
@@ -167,7 +187,7 @@ export function showExperimentalDialog(): void {
 
   const body = document.createElement("div");
   body.className = "pi-overlay-body";
-  body.append(title, subtitle);
+  body.append(header);
 
   if (experimentalFeatures.length > 0) {
     body.appendChild(buildFeatureSection({
@@ -194,12 +214,6 @@ export function showExperimentalDialog(): void {
 
   body.appendChild(footer);
 
-  const closeBtn = document.createElement("button");
-  closeBtn.type = "button";
-  closeBtn.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--full";
-  closeBtn.textContent = "Close";
-  closeBtn.addEventListener("click", dialog.close);
-
-  dialog.card.append(body, closeBtn);
+  dialog.card.append(body);
   dialog.mount();
 }

--- a/src/commands/builtins/extensions-overlay.ts
+++ b/src/commands/builtins/extensions-overlay.ts
@@ -15,7 +15,11 @@ import { validateOfficeProxyUrl } from "../../auth/proxy-validation.js";
 import { dispatchExperimentalToolConfigChanged } from "../../experiments/events.js";
 import { isExperimentalFeatureEnabled, setExperimentalFeatureEnabled } from "../../experiments/flags.js";
 import { PYTHON_BRIDGE_URL_SETTING_KEY } from "../../tools/experimental-tool-gates.js";
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { EXTENSIONS_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 
@@ -225,9 +229,9 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
 
   const closeOverlay = dialog.close;
 
-  const closeButton = createButton("Close");
-  closeButton.addEventListener("click", () => {
-    closeOverlay();
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close extensions manager",
   });
 
   header.append(titleWrap, closeButton);

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -38,7 +38,11 @@ import {
   type McpConfigStore,
   type McpServerConfig,
 } from "../../tools/mcp-config.js";
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { INTEGRATIONS_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 import { isRecord } from "../../utils/type-guards.js";
@@ -397,7 +401,12 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
 
   titleWrap.append(title, subtitle);
 
-  const closeButton = createButton("Close");
+  const closeOverlay = dialog.close;
+
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close integrations",
+  });
 
   header.append(titleWrap, closeButton);
 
@@ -504,10 +513,6 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
 
   body.append(externalSection, integrationsSection, webSearchSection, mcpSection);
   dialog.card.append(header, body);
-
-  const closeOverlay = dialog.close;
-
-  closeButton.addEventListener("click", closeOverlay);
 
   let busy = false;
   let snapshot: IntegrationsSnapshot | null = null;

--- a/src/commands/builtins/provider-overlay.ts
+++ b/src/commands/builtins/provider-overlay.ts
@@ -4,7 +4,11 @@
 
 import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.js";
 
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { PROVIDER_PICKER_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 
@@ -23,6 +27,14 @@ export async function showProviderPicker(): Promise<void> {
     cardClassName: "pi-welcome-card pi-overlay-card pi-provider-picker-card",
   });
 
+  const closeOverlay = dialog.close;
+
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
   const title = document.createElement("h2");
   title.className = "pi-overlay-title";
   title.textContent = "Providers";
@@ -31,10 +43,18 @@ export async function showProviderPicker(): Promise<void> {
   subtitle.className = "pi-overlay-subtitle";
   subtitle.textContent = "Connect providers to use their models.";
 
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close providers",
+  });
+
+  titleWrap.append(title, subtitle);
+  header.append(titleWrap, closeButton);
+
   const list = document.createElement("div");
   list.className = "pi-welcome-providers pi-provider-picker-list";
 
-  dialog.card.append(title, subtitle, list);
+  dialog.card.append(header, list);
 
   const expandedRef: { current: HTMLElement | null } = { current: null };
 

--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -3,7 +3,11 @@
  */
 
 import { formatRelativeDate } from "./overlay-relative-date.js";
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { RECOVERY_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 
@@ -65,6 +69,14 @@ export async function showRecoveryDialog(opts: {
     cardClassName: "pi-welcome-card pi-overlay-card pi-recovery-dialog",
   });
 
+  const closeOverlay = dialog.close;
+
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
   const title = document.createElement("h2");
   title.className = "pi-overlay-title";
   title.textContent = "Backups (Beta)";
@@ -72,6 +84,14 @@ export async function showRecoveryDialog(opts: {
   const subtitle = document.createElement("p");
   subtitle.className = "pi-overlay-subtitle";
   subtitle.textContent = "Saved before Pi edits, in between saves. Entries are sheet-specific in this workbook.";
+
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close backups",
+  });
+
+  titleWrap.append(title, subtitle);
+  header.append(titleWrap, closeButton);
 
   const workbookTag = document.createElement("p");
   workbookTag.className = "pi-overlay-workbook-tag";
@@ -102,16 +122,7 @@ export async function showRecoveryDialog(opts: {
   const list = document.createElement("div");
   list.className = "pi-recovery-list";
 
-  const footer = document.createElement("div");
-  footer.className = "pi-overlay-actions";
-
-  const closeButton = document.createElement("button");
-  closeButton.type = "button";
-  closeButton.className = "pi-overlay-btn pi-overlay-btn--ghost";
-  closeButton.textContent = "Close";
-
-  footer.append(closeButton);
-  dialog.card.append(title, subtitle, workbookTag, saveBoundaryHint, toolbar, list, footer);
+  dialog.card.append(header, workbookTag, saveBoundaryHint, toolbar, list);
 
   let checkpoints: RecoveryCheckpointSummary[] = [];
   let busy = false;
@@ -289,8 +300,6 @@ export async function showRecoveryDialog(opts: {
       }
     })();
   });
-
-  closeButton.addEventListener("click", dialog.close);
 
   dialog.mount();
 

--- a/src/commands/builtins/resume-overlay.ts
+++ b/src/commands/builtins/resume-overlay.ts
@@ -11,7 +11,11 @@ import {
   type ResumeDialogTarget,
 } from "./resume-target.js";
 import { formatRelativeDate } from "./overlay-relative-date.js";
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { RESUME_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 import { formatWorkbookLabel, getWorkbookContext } from "../../workbook/context.js";
@@ -104,9 +108,25 @@ export async function showResumeDialog(opts: {
     cardClassName: "pi-welcome-card pi-overlay-card pi-resume-dialog",
   });
 
+  const closeOverlay = dialog.close;
+
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
   const title = document.createElement("h2");
   title.className = "pi-overlay-title pi-resume-dialog__title";
   title.textContent = "Resume Session";
+
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close resume sessions",
+  });
+
+  titleWrap.append(title);
+  header.append(titleWrap, closeButton);
 
   const targetControls = document.createElement("div");
   targetControls.className = "pi-resume-target-controls";
@@ -150,7 +170,7 @@ export async function showResumeDialog(opts: {
   const list = document.createElement("div");
   list.className = "pi-resume-list";
 
-  dialog.card.append(title, targetControls, targetHint);
+  dialog.card.append(header, targetControls, targetHint);
   syncTargetButtons();
 
   if (workbookId) {
@@ -200,8 +220,6 @@ export async function showResumeDialog(opts: {
   };
 
   renderList();
-
-  const closeOverlay = dialog.close;
 
   dialog.overlay.addEventListener("click", (event) => {
     const target = event.target;

--- a/src/commands/builtins/rules-overlay.ts
+++ b/src/commands/builtins/rules-overlay.ts
@@ -20,7 +20,11 @@ import {
 } from "../../conventions/store.js";
 import { DEFAULT_CURRENCY_SYMBOL, PRESET_DEFAULT_DP } from "../../conventions/defaults.js";
 import type { StoredConventions, NumberPreset } from "../../conventions/types.js";
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { RULES_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 import { formatWorkbookLabel, getWorkbookContext } from "../../workbook/context.js";
@@ -309,9 +313,25 @@ export async function showRulesDialog(opts?: {
     cardClassName: "pi-welcome-card pi-overlay-card",
   });
 
+  const closeOverlay = dialog.close;
+
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
   const title = document.createElement("h2");
   title.className = "pi-overlay-title";
   title.textContent = "Rules";
+
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close rules",
+  });
+
+  titleWrap.append(title);
+  header.append(titleWrap, closeButton);
 
   const tabs = document.createElement("div");
   tabs.className = "pi-overlay-tabs";
@@ -352,7 +372,7 @@ export async function showRulesDialog(opts?: {
 
   const body = document.createElement("div");
   body.className = "pi-overlay-body";
-  body.append(title, tabs, workbookTag, hint, textarea, conventionsContainer);
+  body.append(header, tabs, workbookTag, hint, textarea, conventionsContainer);
 
   const footer = document.createElement("div");
   footer.className = "pi-overlay-footer";
@@ -376,8 +396,6 @@ export async function showRulesDialog(opts?: {
   actions.append(cancelBtn, saveBtn);
   footer.append(counter, actions);
   dialog.card.append(body, footer);
-
-  const closeOverlay = dialog.close;
 
   const tabButtons: Record<RulesTab, HTMLButtonElement> = {
     user: userTab,

--- a/src/commands/builtins/shortcuts-overlay.ts
+++ b/src/commands/builtins/shortcuts-overlay.ts
@@ -5,7 +5,11 @@
  * to the current platform (macOS symbols vs Windows/Linux labels).
  */
 
-import { closeOverlayById, createOverlayDialog } from "../../ui/overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "../../ui/overlay-dialog.js";
 import { SHORTCUTS_OVERLAY_ID } from "../../ui/overlay-ids.js";
 
 // ---------------------------------------------------------------------------
@@ -96,9 +100,25 @@ export function showShortcutsDialog(): void {
     cardClassName: "pi-welcome-card pi-overlay-card pi-shortcuts-dialog",
   });
 
+  const closeOverlay = dialog.close;
+
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
   const title = document.createElement("h2");
   title.className = "pi-overlay-title";
   title.textContent = "Keyboard Shortcuts";
+
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close keyboard shortcuts",
+  });
+
+  titleWrap.append(title);
+  header.append(titleWrap, closeButton);
 
   const list = document.createElement("div");
   list.className = "pi-shortcuts-list";
@@ -131,13 +151,6 @@ export function showShortcutsDialog(): void {
     list.appendChild(section);
   }
 
-  const closeButton = document.createElement("button");
-  closeButton.type = "button";
-  closeButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--full";
-  closeButton.textContent = "Close";
-
-  dialog.card.append(title, list, closeButton);
-  closeButton.addEventListener("click", dialog.close);
-
+  dialog.card.append(header, list);
   dialog.mount();
 }

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -87,7 +87,7 @@ pi-web-ui uses Light DOM (`createRenderRoot() { return this; }`), so styles leak
 | `theme-mode.ts` | — | Applies/removes `.dark` based on Office theme background (fallback: `prefers-color-scheme`) |
 | `loading.ts` | — | Splash screen shown during init |
 | `provider-login.ts` | — | API key entry rows for the welcome overlay |
-| `overlay-dialog.ts` | — | Shared overlay lifecycle helper (single-instance toggle, Escape/backdrop close, focus restore) |
+| `overlay-dialog.ts` | — | Shared overlay lifecycle helper (single-instance toggle, Escape/backdrop close, focus restore) + shared top-right close button factory (`createOverlayCloseButton`) |
 | `overlay-ids.ts` | — | Shared overlay id constants used across builtins/extensions/taskpane |
 
 ## Wiring (taskpane.ts)

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -12,7 +12,11 @@ import { type FilesWorkspaceAuditContext, getFilesWorkspace } from "../files/wor
 import { isExperimentalFeatureEnabled, setExperimentalFeatureEnabled } from "../experiments/flags.js";
 import { getErrorMessage } from "../utils/errors.js";
 import { formatWorkbookLabel, getWorkbookContext } from "../workbook/context.js";
-import { closeOverlayById, createOverlayDialog } from "./overlay-dialog.js";
+import {
+  closeOverlayById,
+  createOverlayCloseButton,
+  createOverlayDialog,
+} from "./overlay-dialog.js";
 import { FILES_WORKSPACE_OVERLAY_ID } from "./overlay-ids.js";
 import {
   buildFilesDialogFilterOptions,
@@ -75,24 +79,40 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
 
   const dialog = createOverlayDialog({
     overlayId: OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-files-dialog",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-files-dialog",
   });
 
+  const closeOverlay = dialog.close;
+
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
   const title = document.createElement("h2");
-  title.className = "pi-files-dialog__title";
+  title.className = "pi-overlay-title";
   title.textContent = "Files";
 
   const subtitle = document.createElement("p");
-  subtitle.className = "pi-files-dialog__subtitle";
+  subtitle.className = "pi-overlay-subtitle";
+
+  const closeButton = createOverlayCloseButton({
+    onClose: closeOverlay,
+    label: "Close files",
+  });
+
+  titleWrap.append(title, subtitle);
+  header.append(titleWrap, closeButton);
 
   const controls = document.createElement("div");
   controls.className = "pi-files-dialog__controls";
 
-  const enableButton = makeButton("Enable workspace write access", "pi-files-dialog__btn");
-  const uploadButton = makeButton("Upload", "pi-files-dialog__btn");
-  const newFileButton = makeButton("New text file", "pi-files-dialog__btn");
-  const nativeButton = makeButton("Select folder", "pi-files-dialog__btn");
-  const disconnectNativeButton = makeButton("Use sandbox workspace", "pi-files-dialog__btn");
+  const enableButton = makeButton("Enable workspace write access", "pi-overlay-btn pi-overlay-btn--ghost");
+  const uploadButton = makeButton("Upload", "pi-overlay-btn pi-overlay-btn--ghost");
+  const newFileButton = makeButton("New text file", "pi-overlay-btn pi-overlay-btn--ghost");
+  const nativeButton = makeButton("Select folder", "pi-overlay-btn pi-overlay-btn--ghost");
+  const disconnectNativeButton = makeButton("Use sandbox workspace", "pi-overlay-btn pi-overlay-btn--ghost");
 
   const hiddenInput = document.createElement("input");
   hiddenInput.type = "file";
@@ -147,8 +167,8 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
   const viewerActions = document.createElement("div");
   viewerActions.className = "pi-files-dialog__viewer-actions";
 
-  const saveButton = makeButton("Save", "pi-files-dialog__btn pi-files-dialog__btn--primary");
-  const closeViewerButton = makeButton("Close", "pi-files-dialog__btn");
+  const saveButton = makeButton("Save", "pi-overlay-btn pi-overlay-btn--primary");
+  const closeViewerButton = makeButton("Close", "pi-overlay-btn pi-overlay-btn--ghost");
 
   viewerActions.append(saveButton, closeViewerButton);
   viewerHeader.append(viewerTitle, viewerActions);
@@ -166,11 +186,6 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
 
   viewer.append(viewerHeader, viewerNote, viewerTextarea, viewerPreview);
 
-  const footer = document.createElement("div");
-  footer.className = "pi-files-dialog__footer";
-  const closeButton = makeButton("Close", "pi-files-dialog__btn");
-  footer.appendChild(closeButton);
-
   controls.append(
     enableButton,
     uploadButton,
@@ -180,8 +195,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
   );
 
   dialog.card.append(
-    title,
-    subtitle,
+    header,
     controls,
     hiddenInput,
     statusLine,
@@ -189,7 +203,6 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     filters,
     list,
     viewer,
-    footer,
   );
 
   let activeViewerPath: string | null = null;
@@ -214,8 +227,6 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     URL.revokeObjectURL(activeObjectUrl);
     activeObjectUrl = null;
   };
-
-  const closeOverlay = dialog.close;
 
   const setStatus = (message: string) => {
     statusLine.textContent = message;
@@ -699,8 +710,6 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
   closeViewerButton.addEventListener("click", () => {
     clearViewer();
   });
-
-  closeButton.addEventListener("click", closeOverlay);
 
   document.addEventListener(FILES_WORKSPACE_CHANGED_EVENT, onWorkspaceChanged);
 

--- a/src/ui/overlay-dialog.ts
+++ b/src/ui/overlay-dialog.ts
@@ -51,6 +51,26 @@ export interface OverlayDialogManager {
   getCurrent: () => OverlayDialogController | null;
 }
 
+export function createOverlayCloseButton(opts: {
+  onClose: () => void;
+  label?: string;
+}): HTMLButtonElement {
+  const button = document.createElement("button");
+  const label = opts.label ?? "Close dialog";
+
+  button.type = "button";
+  button.className = "pi-overlay-close";
+  button.textContent = "×";
+  button.setAttribute("aria-label", label);
+  button.title = label;
+
+  button.addEventListener("click", () => {
+    opts.onClose();
+  });
+
+  return button;
+}
+
 export function createOverlayDialog(options: OverlayDialogOptions): OverlayDialogController {
   const overlay = document.createElement("div");
   overlay.id = options.overlayId;

--- a/src/ui/theme/components/files.css
+++ b/src/ui/theme/components/files.css
@@ -1,55 +1,14 @@
 /* Files workspace dialog */
 .pi-files-dialog {
-  width: min(520px, 96vw);
-  max-height: min(760px, 90vh);
+  width: min(520px, 92vw);
+  max-height: min(80vh, 720px);
   gap: 10px;
-}
-
-.pi-files-dialog__title {
-  margin: 0;
-  font-family: var(--font-sans);
-  font-size: var(--text-lg);
-  font-weight: 700;
-  color: var(--foreground);
-}
-
-.pi-files-dialog__subtitle {
-  margin: 0;
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-  color: var(--muted-foreground);
 }
 
 .pi-files-dialog__controls {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-}
-
-.pi-files-dialog__btn {
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-sm);
-  background: var(--white-alpha-55);
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-  padding: 7px 10px;
-  cursor: pointer;
-}
-
-.pi-files-dialog__btn:hover:not(:disabled) {
-  background: var(--white-alpha-70);
-}
-
-.pi-files-dialog__btn:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.pi-files-dialog__btn--primary {
-  border-color: var(--green-alpha-25);
-  background: var(--pi-green);
-  color: white;
 }
 
 .pi-files-dialog__hidden-input {
@@ -331,7 +290,3 @@
   padding: 8px;
 }
 
-.pi-files-dialog__footer {
-  display: flex;
-  justify-content: flex-end;
-}

--- a/src/ui/theme/overlays/experimental.css
+++ b/src/ui/theme/overlays/experimental.css
@@ -1,8 +1,7 @@
 /* Experimental feature manager */
 
 .pi-experimental-card {
-  width: min(560px, 94vw);
-  max-height: 84vh;
+  width: min(520px, 92vw);
 }
 
 .pi-experimental-list {

--- a/src/ui/theme/overlays/extensions.css
+++ b/src/ui/theme/overlays/extensions.css
@@ -1,8 +1,8 @@
 /* Extensions manager */
 
 .pi-ext-card {
-  width: min(760px, 92vw);
-  max-height: 88vh;
+  width: min(720px, 92vw);
+  max-height: min(80vh, 720px);
   overflow: hidden;
   gap: 12px;
 }

--- a/src/ui/theme/overlays/integrations.css
+++ b/src/ui/theme/overlays/integrations.css
@@ -1,8 +1,8 @@
 /* Integrations manager */
 
 .pi-integrations-dialog {
-  width: min(760px, 92vw);
-  max-height: 88vh;
+  width: min(720px, 92vw);
+  max-height: min(80vh, 720px);
   overflow: hidden;
   gap: 12px;
 }

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -3,7 +3,7 @@
 .pi-overlay-card {
   text-align: left;
   width: min(520px, 92vw);
-  max-height: 82vh;
+  max-height: min(80vh, 720px);
   gap: 10px;
 }
 
@@ -131,6 +131,15 @@
   background: var(--alpha-6);
 }
 
+.pi-overlay-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pi-overlay-btn:disabled:hover {
+  background: var(--alpha-4);
+}
+
 .pi-overlay-btn--primary {
   border: none;
   background: var(--pi-green);
@@ -140,6 +149,10 @@
 
 .pi-overlay-btn--primary:hover {
   background: var(--pi-green-strong);
+}
+
+.pi-overlay-btn--primary:disabled:hover {
+  background: var(--pi-green);
 }
 
 .pi-overlay-btn--ghost {
@@ -170,6 +183,37 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
+}
+
+.pi-overlay-close {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border: 1px solid var(--alpha-10);
+  border-radius: var(--radius-sm);
+  background: var(--white-alpha-55);
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: var(--text-lg);
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
+}
+
+.pi-overlay-close:hover {
+  background: var(--white-alpha-70);
+  border-color: var(--alpha-14);
+  color: var(--foreground);
+}
+
+.pi-overlay-close:focus,
+.pi-overlay-close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--green-alpha-12);
 }
 
 .pi-overlay-body {

--- a/src/ui/theme/overlays/provider-resume-shortcuts.css
+++ b/src/ui/theme/overlays/provider-resume-shortcuts.css
@@ -1,8 +1,7 @@
 /* Provider / Resume / Shortcuts overlays */
 
 .pi-provider-picker-card {
-  width: min(340px, 92vw);
-  max-height: 82vh;
+  width: min(380px, 92vw);
 }
 
 .pi-provider-picker-list {
@@ -92,8 +91,7 @@
 }
 
 .pi-shortcuts-dialog {
-  width: min(420px, 92vw);
-  max-height: min(680px, 86vh);
+  width: min(520px, 92vw);
 }
 
 .pi-shortcuts-list {

--- a/src/ui/theme/overlays/recovery.css
+++ b/src/ui/theme/overlays/recovery.css
@@ -1,8 +1,7 @@
 /* Backups overlay */
 
 .pi-recovery-dialog {
-  width: min(560px, 92vw);
-  max-height: 82vh;
+  width: min(520px, 92vw);
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

Partial progress on #175 (overlay/menu consistency): standardize close affordances and baseline sizing tiers across overlays/dialogs.

### Included

- Added shared close-button helper in `src/ui/overlay-dialog.ts`:
  - `createOverlayCloseButton({ onClose, label })`
- Added shared close-button styling in overlay primitives:
  - `.pi-overlay-close`
- Migrated overlays to a consistent header pattern (`.pi-overlay-header` + top-right close control):
  - provider picker
  - resume dialog
  - rules dialog
  - shortcuts dialog
  - recovery dialog
  - experimental features dialog
  - extensions dialog
  - integrations dialog
  - files dialog
- Files dialog consistency improvements:
  - now uses `pi-overlay-card`
  - uses shared `pi-overlay-title` / `pi-overlay-subtitle`
  - switched primary/secondary action buttons to shared `pi-overlay-btn*` classes
  - removed footer close button in favor of top-right close control
- Overlay sizing tier alignment pass:
  - base `.pi-overlay-card` now uses `max-height: min(80vh, 720px)`
  - provider / medium overlays / large manager overlays moved closer to S/M/L widths in #175 spec

### Also included

- Added disabled-state styles for shared overlay buttons (`.pi-overlay-btn:disabled`) in `overlays/primitives.css`.
- Updated `src/ui/README.md` to mention shared close-button factory.

## Not included yet

- Full visual harmonization of every overlay footer/body pattern
- Remaining #175 follow-ups around deeper component-level polish

## Validation

- `npm run check`
- `npm run build`
