### PR TITLE
refactor(ui): extract shared overlay header builder

### DIFF
--- a/src/commands/builtins/experimental-overlay.ts
+++ b/src/commands/builtins/experimental-overlay.ts
@@ -10,8 +10,8 @@ import {
 } from "../../experiments/flags.js";
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { EXPERIMENTAL_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
@@ -141,31 +141,14 @@ export function showExperimentalDialog(): void {
     cardClassName: "pi-welcome-card pi-overlay-card pi-experimental-card",
   });
 
-  const closeOverlay = dialog.close;
-
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.className = "pi-overlay-title";
-  title.textContent = "Experimental Features";
-
-  const subtitle = document.createElement("p");
-  subtitle.className = "pi-overlay-subtitle";
-  subtitle.textContent =
-    "These toggles are local to this browser profile. Use carefully — some are security-sensitive. "
-    + "Web Search and MCP are managed in /integrations.";
-
-  const closeButton = createOverlayCloseButton({
-    onClose: closeOverlay,
-    label: "Close experimental features",
+  const { header } = createOverlayHeader({
+    onClose: dialog.close,
+    closeLabel: "Close experimental features",
+    title: "Experimental Features",
+    subtitle:
+      "These toggles are local to this browser profile. Use carefully — some are security-sensitive. "
+      + "Web Search and MCP are managed in /integrations.",
   });
-
-  titleWrap.append(title, subtitle);
-  header.append(titleWrap, closeButton);
 
   const snapshots = getExperimentalFeatureSnapshots();
   const experimentalFeatures: ExperimentalFeatureSnapshot[] = [];

--- a/src/commands/builtins/extensions-overlay.ts
+++ b/src/commands/builtins/extensions-overlay.ts
@@ -17,8 +17,8 @@ import { isExperimentalFeatureEnabled, setExperimentalFeatureEnabled } from "../
 import { PYTHON_BRIDGE_URL_SETTING_KEY } from "../../tools/experimental-tool-gates.js";
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { EXTENSIONS_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
@@ -211,30 +211,14 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
     cardClassName: "pi-welcome-card pi-overlay-card pi-ext-card",
   });
 
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.textContent = "Extensions Manager";
-  title.className = "pi-overlay-title";
-
-  const subtitle = document.createElement("p");
-  subtitle.textContent = "Extensions can read/write workbook data. Only enable code you trust.";
-  subtitle.className = "pi-overlay-subtitle";
-
-  titleWrap.append(title, subtitle);
-
   const closeOverlay = dialog.close;
 
-  const closeButton = createOverlayCloseButton({
+  const { header } = createOverlayHeader({
     onClose: closeOverlay,
-    label: "Close extensions manager",
+    closeLabel: "Close extensions manager",
+    title: "Extensions Manager",
+    subtitle: "Extensions can read/write workbook data. Only enable code you trust.",
   });
-
-  header.append(titleWrap, closeButton);
 
   const body = document.createElement("div");
   body.className = "pi-overlay-body";

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -40,8 +40,8 @@ import {
 } from "../../tools/mcp-config.js";
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { INTEGRATIONS_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
@@ -385,30 +385,14 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
     cardClassName: "pi-welcome-card pi-overlay-card pi-integrations-dialog",
   });
 
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.textContent = INTEGRATIONS_LABEL;
-  title.className = "pi-overlay-title";
-
-  const subtitle = document.createElement("p");
-  subtitle.textContent = "Add capabilities like web search and external integrations. External tools are off by default.";
-  subtitle.className = "pi-overlay-subtitle";
-
-  titleWrap.append(title, subtitle);
-
   const closeOverlay = dialog.close;
 
-  const closeButton = createOverlayCloseButton({
+  const { header } = createOverlayHeader({
     onClose: closeOverlay,
-    label: "Close integrations",
+    closeLabel: "Close integrations",
+    title: INTEGRATIONS_LABEL,
+    subtitle: "Add capabilities like web search and external integrations. External tools are off by default.",
   });
-
-  header.append(titleWrap, closeButton);
 
   const body = document.createElement("div");
   body.className = "pi-overlay-body";

--- a/src/commands/builtins/provider-overlay.ts
+++ b/src/commands/builtins/provider-overlay.ts
@@ -6,8 +6,8 @@ import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.
 
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { PROVIDER_PICKER_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
@@ -27,29 +27,12 @@ export async function showProviderPicker(): Promise<void> {
     cardClassName: "pi-welcome-card pi-overlay-card pi-provider-picker-card",
   });
 
-  const closeOverlay = dialog.close;
-
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.className = "pi-overlay-title";
-  title.textContent = "Providers";
-
-  const subtitle = document.createElement("p");
-  subtitle.className = "pi-overlay-subtitle";
-  subtitle.textContent = "Connect providers to use their models.";
-
-  const closeButton = createOverlayCloseButton({
-    onClose: closeOverlay,
-    label: "Close providers",
+  const { header } = createOverlayHeader({
+    onClose: dialog.close,
+    closeLabel: "Close providers",
+    title: "Providers",
+    subtitle: "Connect providers to use their models.",
   });
-
-  titleWrap.append(title, subtitle);
-  header.append(titleWrap, closeButton);
 
   const list = document.createElement("div");
   list.className = "pi-welcome-providers pi-provider-picker-list";

--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -5,8 +5,8 @@
 import { formatRelativeDate } from "./overlay-relative-date.js";
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { RECOVERY_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
@@ -69,29 +69,12 @@ export async function showRecoveryDialog(opts: {
     cardClassName: "pi-welcome-card pi-overlay-card pi-recovery-dialog",
   });
 
-  const closeOverlay = dialog.close;
-
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.className = "pi-overlay-title";
-  title.textContent = "Backups (Beta)";
-
-  const subtitle = document.createElement("p");
-  subtitle.className = "pi-overlay-subtitle";
-  subtitle.textContent = "Saved before Pi edits, in between saves. Entries are sheet-specific in this workbook.";
-
-  const closeButton = createOverlayCloseButton({
-    onClose: closeOverlay,
-    label: "Close backups",
+  const { header } = createOverlayHeader({
+    onClose: dialog.close,
+    closeLabel: "Close backups",
+    title: "Backups (Beta)",
+    subtitle: "Saved before Pi edits, in between saves. Entries are sheet-specific in this workbook.",
   });
-
-  titleWrap.append(title, subtitle);
-  header.append(titleWrap, closeButton);
 
   const workbookTag = document.createElement("p");
   workbookTag.className = "pi-overlay-workbook-tag";

--- a/src/commands/builtins/resume-overlay.ts
+++ b/src/commands/builtins/resume-overlay.ts
@@ -13,8 +13,8 @@ import {
 import { formatRelativeDate } from "./overlay-relative-date.js";
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { RESUME_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
@@ -110,23 +110,12 @@ export async function showResumeDialog(opts: {
 
   const closeOverlay = dialog.close;
 
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.className = "pi-overlay-title pi-resume-dialog__title";
-  title.textContent = "Resume Session";
-
-  const closeButton = createOverlayCloseButton({
+  const { header } = createOverlayHeader({
     onClose: closeOverlay,
-    label: "Close resume sessions",
+    closeLabel: "Close resume sessions",
+    title: "Resume Session",
+    titleClassName: "pi-resume-dialog__title",
   });
-
-  titleWrap.append(title);
-  header.append(titleWrap, closeButton);
 
   const targetControls = document.createElement("div");
   targetControls.className = "pi-resume-target-controls";

--- a/src/commands/builtins/rules-overlay.ts
+++ b/src/commands/builtins/rules-overlay.ts
@@ -22,8 +22,8 @@ import { DEFAULT_CURRENCY_SYMBOL, PRESET_DEFAULT_DP } from "../../conventions/de
 import type { StoredConventions, NumberPreset } from "../../conventions/types.js";
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { RULES_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
@@ -315,23 +315,11 @@ export async function showRulesDialog(opts?: {
 
   const closeOverlay = dialog.close;
 
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.className = "pi-overlay-title";
-  title.textContent = "Rules";
-
-  const closeButton = createOverlayCloseButton({
+  const { header } = createOverlayHeader({
     onClose: closeOverlay,
-    label: "Close rules",
+    closeLabel: "Close rules",
+    title: "Rules",
   });
-
-  titleWrap.append(title);
-  header.append(titleWrap, closeButton);
 
   const tabs = document.createElement("div");
   tabs.className = "pi-overlay-tabs";

--- a/src/commands/builtins/shortcuts-overlay.ts
+++ b/src/commands/builtins/shortcuts-overlay.ts
@@ -7,8 +7,8 @@
 
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
 import { SHORTCUTS_OVERLAY_ID } from "../../ui/overlay-ids.js";
 
@@ -100,25 +100,11 @@ export function showShortcutsDialog(): void {
     cardClassName: "pi-welcome-card pi-overlay-card pi-shortcuts-dialog",
   });
 
-  const closeOverlay = dialog.close;
-
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.className = "pi-overlay-title";
-  title.textContent = "Keyboard Shortcuts";
-
-  const closeButton = createOverlayCloseButton({
-    onClose: closeOverlay,
-    label: "Close keyboard shortcuts",
+  const { header } = createOverlayHeader({
+    onClose: dialog.close,
+    closeLabel: "Close keyboard shortcuts",
+    title: "Keyboard Shortcuts",
   });
-
-  titleWrap.append(title);
-  header.append(titleWrap, closeButton);
 
   const list = document.createElement("div");
   list.className = "pi-shortcuts-list";

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -87,7 +87,7 @@ pi-web-ui uses Light DOM (`createRenderRoot() { return this; }`), so styles leak
 | `theme-mode.ts` | — | Applies/removes `.dark` based on Office theme background (fallback: `prefers-color-scheme`) |
 | `loading.ts` | — | Splash screen shown during init |
 | `provider-login.ts` | — | API key entry rows for the welcome overlay |
-| `overlay-dialog.ts` | — | Shared overlay lifecycle helper (single-instance toggle, Escape/backdrop close, focus restore) + shared top-right close button factory (`createOverlayCloseButton`) |
+| `overlay-dialog.ts` | — | Shared overlay lifecycle helper (single-instance toggle, Escape/backdrop close, focus restore) + shared overlay chrome builders (`createOverlayCloseButton`, `createOverlayHeader`) |
 | `overlay-ids.ts` | — | Shared overlay id constants used across builtins/extensions/taskpane |
 
 ## Wiring (taskpane.ts)

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -14,8 +14,8 @@ import { getErrorMessage } from "../utils/errors.js";
 import { formatWorkbookLabel, getWorkbookContext } from "../workbook/context.js";
 import {
   closeOverlayById,
-  createOverlayCloseButton,
   createOverlayDialog,
+  createOverlayHeader,
 } from "./overlay-dialog.js";
 import { FILES_WORKSPACE_OVERLAY_ID } from "./overlay-ids.js";
 import {
@@ -84,26 +84,16 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
 
   const closeOverlay = dialog.close;
 
-  const header = document.createElement("div");
-  header.className = "pi-overlay-header";
-
-  const titleWrap = document.createElement("div");
-  titleWrap.className = "pi-overlay-title-wrap";
-
-  const title = document.createElement("h2");
-  title.className = "pi-overlay-title";
-  title.textContent = "Files";
-
-  const subtitle = document.createElement("p");
-  subtitle.className = "pi-overlay-subtitle";
-
-  const closeButton = createOverlayCloseButton({
+  const { header, subtitle } = createOverlayHeader({
     onClose: closeOverlay,
-    label: "Close files",
+    closeLabel: "Close files",
+    title: "Files",
+    subtitle: "",
   });
 
-  titleWrap.append(title, subtitle);
-  header.append(titleWrap, closeButton);
+  if (!subtitle) {
+    throw new Error("Files overlay subtitle is required.");
+  }
 
   const controls = document.createElement("div");
   controls.className = "pi-files-dialog__controls";

--- a/src/ui/overlay-dialog.ts
+++ b/src/ui/overlay-dialog.ts
@@ -71,6 +71,66 @@ export function createOverlayCloseButton(opts: {
   return button;
 }
 
+export interface OverlayHeaderOptions {
+  title: string;
+  subtitle?: string;
+  onClose: () => void;
+  closeLabel?: string;
+  titleClassName?: string;
+  subtitleClassName?: string;
+}
+
+export interface OverlayHeaderElements {
+  header: HTMLDivElement;
+  titleWrap: HTMLDivElement;
+  title: HTMLHeadingElement;
+  subtitle: HTMLParagraphElement | null;
+  closeButton: HTMLButtonElement;
+}
+
+function mergeClassName(baseClassName: string, className?: string): string {
+  return className && className.trim().length > 0
+    ? `${baseClassName} ${className}`
+    : baseClassName;
+}
+
+export function createOverlayHeader(options: OverlayHeaderOptions): OverlayHeaderElements {
+  const header = document.createElement("div");
+  header.className = "pi-overlay-header";
+
+  const titleWrap = document.createElement("div");
+  titleWrap.className = "pi-overlay-title-wrap";
+
+  const title = document.createElement("h2");
+  title.className = mergeClassName("pi-overlay-title", options.titleClassName);
+  title.textContent = options.title;
+
+  titleWrap.appendChild(title);
+
+  let subtitle: HTMLParagraphElement | null = null;
+  if (options.subtitle !== undefined) {
+    subtitle = document.createElement("p");
+    subtitle.className = mergeClassName("pi-overlay-subtitle", options.subtitleClassName);
+    subtitle.textContent = options.subtitle;
+    titleWrap.appendChild(subtitle);
+  }
+
+  const closeButton = createOverlayCloseButton({
+    onClose: options.onClose,
+    label: options.closeLabel,
+  });
+
+  header.append(titleWrap, closeButton);
+
+  return {
+    header,
+    titleWrap,
+    title,
+    subtitle,
+    closeButton,
+  };
+}
+
 export function createOverlayDialog(options: OverlayDialogOptions): OverlayDialogController {
   const overlay = document.createElement("div");
   overlay.id = options.overlayId;


### PR DESCRIPTION
## Summary

Refactor-only follow-up to the overlay consistency work: extract shared overlay header construction to remove repeated DOM boilerplate across overlay/dialog implementations.

### What changed

- Added `createOverlayHeader(...)` to `src/ui/overlay-dialog.ts`.
  - Builds `.pi-overlay-header` + `.pi-overlay-title-wrap` + title/subtitle + shared close button.
  - Keeps existing `createOverlayCloseButton(...)` as the underlying primitive.
- Migrated overlays/dialogs to use the new helper:
  - `provider-overlay.ts`
  - `resume-overlay.ts`
  - `rules-overlay.ts`
  - `shortcuts-overlay.ts`
  - `recovery-overlay.ts`
  - `experimental-overlay.ts`
  - `extensions-overlay.ts`
  - `integrations-overlay.ts`
  - `ui/files-dialog.ts`
- Updated `src/ui/README.md` to document the new shared overlay chrome helper.

## Why

- Removes duplicated header/close-button DOM setup in 9 places.
- Centralizes overlay chrome behavior and class wiring.
- Makes future overlay consistency changes lower-risk.

## Validation

- `npm run check`
- `npm run build`
