### PR TITLE
chore(release): bump version to 0.5.0-pre

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-for-excel",
-  "version": "0.3.0-pre",
+  "version": "0.5.0-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-for-excel",
-      "version": "0.3.0-pre",
+      "version": "0.5.0-pre",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel",
-  "version": "0.3.0-pre",
+  "version": "0.5.0-pre",
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump app version from `0.3.0-pre` to `0.5.0-pre`
- keep prerelease channel semantics (`-pre`)
- sync `package.json` and lockfile version metadata

## Validation
- `npm run check`
- `npm run build`
