### PR TITLE
fix(ui): remove duplicate Rules quick action

### DIFF
--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -1389,13 +1389,15 @@ export async function initTaskpane(opts: {
           return;
         }
 
+        const importedLabel = `${count} file${count === 1 ? "" : "s"}`;
+
         if (!isExperimentalFeatureEnabled("files_workspace")) {
           setExperimentalFeatureEnabled("files_workspace", true);
-          showToast(`Imported ${count} file${count === 1 ? "" : "s"} and enabled files-workspace.`);
+          showToast(`Imported ${importedLabel} into Files. The Files feature was enabled automatically.`);
           return;
         }
 
-        showToast(`Imported ${count} file${count === 1 ? "" : "s"}.`);
+        showToast(`Imported ${importedLabel} into Files.`);
       })
       .catch((error: unknown) => {
         showToast(`Import failed: ${error instanceof Error ? error.message : "Unknown error"}`);

--- a/src/ui/pi-input.ts
+++ b/src/ui/pi-input.ts
@@ -189,13 +189,13 @@ export class PiInput extends LitElement {
           class="pi-input-btn pi-input-btn--attach"
           type="button"
           @click=${this._openFilePicker}
-          aria-label="Attach files"
-          title="Attach files"
+          aria-label="Import files into Files"
+          title="Import files into Files"
         >
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21.44 11.05-8.49 8.49a5.5 5.5 0 0 1-7.78-7.78l9.2-9.19a3.5 3.5 0 0 1 4.95 4.95l-9.19 9.2a1.5 1.5 0 0 1-2.12-2.13l8.49-8.48"/></svg>
         </button>
         ${this._isDragOver
-          ? html`<div class="pi-input-drop-hint">Drop files to add them to workspace</div>`
+          ? html`<div class="pi-input-drop-hint">Drop files to import into Files</div>`
           : null}
         ${this.isStreaming
           ? html`

--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -12,7 +12,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { Agent, AgentEvent } from "@mariozechner/pi-agent-core";
 import type { ToolResultMessage } from "@mariozechner/pi-ai";
 import type { StreamingMessageContainer } from "@mariozechner/pi-web-ui/dist/components/StreamingMessageContainer.js";
-import { ArchiveRestore, ChevronRight, FileText, History, type IconNode } from "lucide";
+import { ArchiveRestore, ChevronRight, History, type IconNode } from "lucide";
 import "./pi-input.js";
 import "./working-indicator.js";
 import { initToolGrouping } from "./tool-grouping.js";
@@ -541,11 +541,10 @@ export class PiSidebar extends LitElement {
   }
 
   private _renderQuickActions() {
-    const showRules = Boolean(this.onOpenRules);
     const showResume = Boolean(this.onOpenResumePicker);
     const showBackups = Boolean(this.onOpenRecovery);
 
-    if (!showRules && !showResume && !showBackups) {
+    if (!showResume && !showBackups) {
       return nothing;
     }
 
@@ -556,14 +555,6 @@ export class PiSidebar extends LitElement {
 
     return html`
       <div class="pi-quick-actions">
-        ${showRules
-          ? this._renderQuickActionButton({
-            label: "Rules",
-            title: "Edit rules and conventions",
-            iconNode: FileText,
-            onClick: this.onOpenRules,
-          })
-          : nothing}
         ${showResume
           ? this._renderQuickActionButton({
             label: "Resume",


### PR DESCRIPTION
## Summary

Low-risk first slice for #174 input-controls cleanup:

- removes the duplicate **Rules** quick-action button from the row above the input
- keeps Rules accessible via the status bar badge and utilities menu
- clarifies the paperclip/drop import wording so users see files go into **Files** (not message-scoped attachments)

## Changes

### 1) Quick actions

- `src/ui/pi-sidebar.ts`
  - removed the `Rules` quick-action chip from `_renderQuickActions()`
  - quick actions now only render `Resume` and `Backups`

### 2) Files import copy

- `src/ui/pi-input.ts`
  - attach button `aria-label`/`title`: `Import files into Files`
  - drag-over hint: `Drop files to import into Files`
- `src/taskpane/init.ts`
  - import success toast now says `Imported N file(s) into Files`
  - auto-enable toast clarifies: `The Files feature was enabled automatically`

## Scope

- No behavior changes to file import plumbing (still imports via `onFilesDrop` into Files store).
- No `+` menu changes yet (kept for follow-up slice of #174).

## Validation

- `npm run check`
- `npm run build`

Related: #174
