### PR TITLE
refactor(tools): remove experimental gates for files and python bridge

### DIFF
--- a/src/commands/builtins/extensions-overlay.ts
+++ b/src/commands/builtins/extensions-overlay.ts
@@ -379,7 +379,6 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
   };
 
   const renderLocalBridgeState = async (): Promise<void> => {
-    const enabled = isExperimentalFeatureEnabled("python_bridge");
     const configuredUrl = await readSettingValue(PYTHON_BRIDGE_URL_SETTING_KEY);
 
     if (configuredUrl && localBridgeUrlInput.value.trim().length === 0) {
@@ -391,7 +390,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
       : "Bridge URL not set";
 
     localBridgeStatusBadgeSlot.replaceChildren(
-      createOverlayBadge(enabled ? "enabled" : "disabled", enabled ? "ok" : "muted"),
+      createOverlayBadge(configuredUrl ? "configured" : "not set", configuredUrl ? "ok" : "muted"),
     );
   };
 
@@ -656,10 +655,9 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
       const normalizedUrl = validateOfficeProxyUrl(candidateUrl);
       await writeSettingValue(PYTHON_BRIDGE_URL_SETTING_KEY, normalizedUrl);
       dispatchExperimentalToolConfigChanged({ configKey: PYTHON_BRIDGE_URL_SETTING_KEY });
-      setExperimentalFeatureEnabled("python_bridge", true);
 
       localBridgeUrlInput.value = normalizedUrl;
-      showToast(`Python bridge enabled at ${normalizedUrl}`);
+      showToast(`Python bridge configured at ${normalizedUrl}`);
     });
   });
 
@@ -683,9 +681,11 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
   });
 
   localBridgeDisableButton.addEventListener("click", () => {
-    void runAction(() => {
-      setExperimentalFeatureEnabled("python_bridge", false);
-      showToast("Python bridge disabled.");
+    void runAction(async () => {
+      await deleteSettingValue(PYTHON_BRIDGE_URL_SETTING_KEY);
+      dispatchExperimentalToolConfigChanged({ configKey: PYTHON_BRIDGE_URL_SETTING_KEY });
+      localBridgeUrlInput.value = "";
+      showToast("Python bridge URL cleared.");
     });
   });
 

--- a/src/experiments/flags.ts
+++ b/src/experiments/flags.ts
@@ -10,8 +10,6 @@ import { dispatchExperimentalFeatureChanged } from "./events.js";
 
 export type ExperimentalFeatureId =
   | "tmux_bridge"
-  | "python_bridge"
-  | "files_workspace"
   | "external_skills_discovery"
   | "remote_extension_urls"
   | "extension_permission_gates"
@@ -44,24 +42,6 @@ const EXPERIMENTAL_FEATURES = [
     description: "Allow local tmux bridge integration for interactive shell sessions.",
     wiring: "wired",
     storageKey: "pi.experimental.tmuxBridge",
-  },
-  {
-    id: "python_bridge",
-    slug: "python-bridge",
-    aliases: ["python", "libreoffice-bridge"],
-    title: "Python / LibreOffice bridge",
-    description: "Allow local Python and LibreOffice bridge integrations.",
-    wiring: "wired",
-    storageKey: "pi.experimental.pythonBridge",
-  },
-  {
-    id: "files_workspace",
-    slug: "files-workspace",
-    aliases: ["files", "workspace-files", "artifacts"],
-    title: "Files",
-    description: "Allow assistant write/delete access to files (list/read + built-in docs stay available).",
-    wiring: "wired",
-    storageKey: "pi.experimental.filesWorkspace",
   },
   {
     id: "external_skills_discovery",

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -27,7 +27,7 @@ import {
   PI_EXPERIMENTAL_FEATURE_CHANGED_EVENT,
   PI_EXPERIMENTAL_TOOL_CONFIG_CHANGED_EVENT,
 } from "../experiments/events.js";
-import { isExperimentalFeatureEnabled, setExperimentalFeatureEnabled } from "../experiments/flags.js";
+import { isExperimentalFeatureEnabled } from "../experiments/flags.js";
 import { convertToLlm } from "../messages/convert-to-llm.js";
 import { getFilesWorkspace } from "../files/workspace.js";
 import { createAllTools } from "../tools/index.js";
@@ -1390,13 +1390,6 @@ export async function initTaskpane(opts: {
         }
 
         const importedLabel = `${count} file${count === 1 ? "" : "s"}`;
-
-        if (!isExperimentalFeatureEnabled("files_workspace")) {
-          setExperimentalFeatureEnabled("files_workspace", true);
-          showToast(`Imported ${importedLabel} into Files. The Files feature was enabled automatically.`);
-          return;
-        }
-
         showToast(`Imported ${importedLabel} into Files.`);
       })
       .catch((error: unknown) => {

--- a/src/tools/experimental-tool-gates.ts
+++ b/src/tools/experimental-tool-gates.ts
@@ -10,9 +10,6 @@ export {
   PYTHON_BRIDGE_URL_SETTING_KEY,
   TMUX_BRIDGE_URL_SETTING_KEY,
   type ExperimentalToolGateDependencies,
-  type FilesWorkspaceGateDependencies,
-  type FilesWorkspaceGateReason,
-  type FilesWorkspaceGateResult,
   type OfficeJsExecuteApprovalRequest,
   type PythonBridgeApprovalRequest,
   type PythonBridgeGateDependencies,
@@ -24,10 +21,8 @@ export {
 } from "./experimental-tool-gates/types.js";
 
 export {
-  buildFilesWorkspaceGateErrorMessage,
   buildPythonBridgeGateErrorMessage,
   buildTmuxBridgeGateErrorMessage,
-  evaluateFilesWorkspaceGate,
   evaluatePythonBridgeGate,
   evaluateTmuxBridgeGate,
 } from "./experimental-tool-gates/evaluation.js";

--- a/src/tools/experimental-tool-gates/types.ts
+++ b/src/tools/experimental-tool-gates/types.ts
@@ -31,7 +31,6 @@ export interface TmuxBridgeGateDependencies {
 }
 
 export type PythonBridgeGateReason =
-  | "python_experiment_disabled"
   | "missing_bridge_url"
   | "invalid_bridge_url"
   | "bridge_unreachable";
@@ -43,21 +42,9 @@ export interface PythonBridgeGateResult {
 }
 
 export interface PythonBridgeGateDependencies {
-  isPythonExperimentEnabled?: () => boolean;
   getPythonBridgeUrl?: () => Promise<string | undefined>;
   validatePythonBridgeUrl?: (url: string) => string | null;
   probePythonBridge?: (bridgeUrl: string) => Promise<boolean>;
-}
-
-export type FilesWorkspaceGateReason = "files_experiment_disabled";
-
-export interface FilesWorkspaceGateResult {
-  allowed: boolean;
-  reason?: FilesWorkspaceGateReason;
-}
-
-export interface FilesWorkspaceGateDependencies {
-  isFilesWorkspaceExperimentEnabled?: () => boolean;
 }
 
 export interface PythonBridgeApprovalRequest {
@@ -73,8 +60,7 @@ export interface OfficeJsExecuteApprovalRequest {
 
 export interface ExperimentalToolGateDependencies extends
   TmuxBridgeGateDependencies,
-  PythonBridgeGateDependencies,
-  FilesWorkspaceGateDependencies {
+  PythonBridgeGateDependencies {
   requestPythonBridgeApproval?: (request: PythonBridgeApprovalRequest) => Promise<boolean>;
   getApprovedPythonBridgeUrl?: () => Promise<string | undefined>;
   setApprovedPythonBridgeUrl?: (bridgeUrl: string) => Promise<void>;

--- a/src/tools/libreoffice-convert.ts
+++ b/src/tools/libreoffice-convert.ts
@@ -1,11 +1,9 @@
 /**
  * libreoffice_convert — Experimental local LibreOffice bridge adapter.
  *
- * This tool stays registered for a stable tool list/prompt cache,
- * but execution is gated by:
- * - /experimental on python-bridge
- * - /experimental python-bridge-url https://localhost:<port>
- * - reachable bridge health endpoint
+ * This tool stays registered for a stable tool list/prompt cache.
+ * Execution requires a configured and reachable bridge URL
+ * (/experimental python-bridge-url https://localhost:<port>).
  */
 
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
@@ -384,7 +382,7 @@ function formatBridgeSuccessText(response: LibreOfficeConvertResponse): string {
 function buildMissingBridgeConfigurationMessage(): string {
   return (
     "Python/LibreOffice bridge URL is not configured. " +
-    "Run /experimental python-bridge-url https://localhost:3340 and enable /experimental on python-bridge."
+    "Run /experimental python-bridge-url https://localhost:3340 to set it up."
   );
 }
 

--- a/src/tools/python-run.ts
+++ b/src/tools/python-run.ts
@@ -1,11 +1,9 @@
 /**
  * python_run — Experimental local Python bridge adapter.
  *
- * This tool stays registered for a stable tool list/prompt cache,
- * but execution is gated by:
- * - /experimental on python-bridge
- * - /experimental python-bridge-url https://localhost:<port>
- * - reachable bridge health endpoint
+ * This tool stays registered for a stable tool list/prompt cache.
+ * Execution requires a configured and reachable bridge URL
+ * (/experimental python-bridge-url https://localhost:<port>).
  */
 
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
@@ -393,7 +391,7 @@ function buildOutputPreview(output: string | undefined): string | undefined {
 function buildMissingBridgeConfigurationMessage(): string {
   return (
     "Python bridge URL is not configured. " +
-    "Run /experimental python-bridge-url https://localhost:3340 and enable /experimental on python-bridge."
+    "Run /experimental python-bridge-url https://localhost:3340 to set it up."
   );
 }
 

--- a/src/tools/python-transform-range.ts
+++ b/src/tools/python-transform-range.ts
@@ -418,7 +418,7 @@ export function createPythonTransformRangeTool(
               type: "text",
               text:
                 "Python bridge URL is not configured. " +
-                "Run /experimental python-bridge-url https://localhost:3340 and enable /experimental on python-bridge.",
+                "Run /experimental python-bridge-url https://localhost:3340 to set it up.",
             }],
             details: {
               kind: "python_transform_range",

--- a/src/ui/files-dialog-status.ts
+++ b/src/ui/files-dialog-status.ts
@@ -1,7 +1,8 @@
 import type { FilesDialogFilterValue } from "./files-dialog-filtering.js";
 
 export function buildFilesDialogStatusMessage(args: {
-  filesExperimentEnabled: boolean;
+  /** @deprecated Files are always enabled. Kept for caller compatibility. */
+  filesExperimentEnabled?: boolean;
   totalCount: number;
   filteredCount: number;
   selectedFilter: FilesDialogFilterValue;
@@ -9,14 +10,6 @@ export function buildFilesDialogStatusMessage(args: {
   builtinDocsCount: number;
   workspaceFilesCount: number;
 }): string {
-  if (!args.filesExperimentEnabled) {
-    return (
-      `Built-in docs stay available (${args.builtinDocsCount}). `
-      + "Enable write access for assistant file management "
-      + `(${args.workspaceFilesCount} file${args.workspaceFilesCount === 1 ? "" : "s"}).`
-    );
-  }
-
   if (args.selectedFilter === "all") {
     return `${args.totalCount} file${args.totalCount === 1 ? "" : "s"} available to the assistant.`;
   }

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -9,7 +9,6 @@ import {
   type WorkspaceFileEntry,
 } from "../files/types.js";
 import { type FilesWorkspaceAuditContext, getFilesWorkspace } from "../files/workspace.js";
-import { isExperimentalFeatureEnabled, setExperimentalFeatureEnabled } from "../experiments/flags.js";
 import { getErrorMessage } from "../utils/errors.js";
 import { formatWorkbookLabel, getWorkbookContext } from "../workbook/context.js";
 import {
@@ -466,18 +465,17 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
       filterOptions.find((option) => option.value === selectedFilter)?.label
       ?? "All files";
 
-    const filesExperimentEnabled = isExperimentalFeatureEnabled("files_workspace");
     const workspaceFilesCount = files.length - builtinDocsCount;
 
-    enableButton.hidden = filesExperimentEnabled;
-    uploadButton.disabled = !filesExperimentEnabled;
-    newFileButton.disabled = !filesExperimentEnabled;
-    nativeButton.disabled = !filesExperimentEnabled || !backend.nativeSupported;
+    enableButton.hidden = true;
+    uploadButton.disabled = false;
+    newFileButton.disabled = false;
+    nativeButton.disabled = !backend.nativeSupported;
     nativeButton.hidden = !backend.nativeSupported;
     disconnectNativeButton.hidden = backend.kind !== "native-directory";
 
     setStatus(buildFilesDialogStatusMessage({
-      filesExperimentEnabled,
+      filesExperimentEnabled: true,
       totalCount: files.length,
       filteredCount: filteredFiles.length,
       selectedFilter,
@@ -600,12 +598,6 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
   };
 
   dialog.addCleanup(cleanup);
-
-  enableButton.addEventListener("click", () => {
-    setExperimentalFeatureEnabled("files_workspace", true);
-    void renderList();
-    showToast("Enabled file write/delete access.");
-  });
 
   uploadButton.addEventListener("click", () => {
     hiddenInput.click();

--- a/tests/files-dialog-status.test.ts
+++ b/tests/files-dialog-status.test.ts
@@ -3,24 +3,21 @@ import { test } from "node:test";
 
 import { buildFilesDialogStatusMessage } from "../src/ui/files-dialog-status.ts";
 
-void test("status message explains built-in docs when write/delete is gated", () => {
+void test("status message reports total count when showing all files", () => {
   const message = buildFilesDialogStatusMessage({
-    filesExperimentEnabled: false,
-    totalCount: 4,
-    filteredCount: 2,
-    selectedFilter: "builtin",
-    activeFilterLabel: "Built-in docs",
-    builtinDocsCount: 3,
-    workspaceFilesCount: 1,
+    totalCount: 10,
+    filteredCount: 10,
+    selectedFilter: "all",
+    activeFilterLabel: "All files",
+    builtinDocsCount: 4,
+    workspaceFilesCount: 6,
   });
 
-  assert.match(message, /Built-in docs stay available/i);
-  assert.match(message, /Enable write access/i);
+  assert.equal(message, "10 files available to the assistant.");
 });
 
-void test("status message reports active filtered count when enabled", () => {
+void test("status message reports active filtered count", () => {
   const message = buildFilesDialogStatusMessage({
-    filesExperimentEnabled: true,
     totalCount: 10,
     filteredCount: 3,
     selectedFilter: "builtin",

--- a/tests/libreoffice-convert-tool.test.ts
+++ b/tests/libreoffice-convert-tool.test.ts
@@ -30,7 +30,6 @@ void test("libreoffice_convert returns guidance when bridge URL is missing", asy
   });
 
   assert.match(firstText(result), /python-bridge-url/u);
-  assert.match(firstText(result), /\/experimental on python-bridge/u);
   assert.equal(result.details?.kind, "libreoffice_bridge");
   assert.equal(result.details?.ok, false);
   assert.equal(result.details?.error, "missing_bridge_url");

--- a/tests/python-run-tool.test.ts
+++ b/tests/python-run-tool.test.ts
@@ -27,7 +27,6 @@ void test("python_run returns guidance when bridge URL is not configured", async
   const result = await tool.execute("tc-missing", { code: "print('hello')" });
 
   assert.match(firstText(result), /python-bridge-url/u);
-  assert.match(firstText(result), /\/experimental on python-bridge/u);
   assert.equal(result.details?.kind, "python_bridge");
   assert.equal(result.details?.ok, false);
   assert.equal(result.details?.error, "missing_bridge_url");

--- a/tests/python-transform-range-tool.test.ts
+++ b/tests/python-transform-range-tool.test.ts
@@ -39,7 +39,6 @@ void test("python_transform_range returns bridge setup guidance when URL is miss
   });
 
   assert.match(firstText(result), /python-bridge-url/u);
-  assert.match(firstText(result), /\/experimental on python-bridge/u);
   assert.equal(result.details?.kind, "python_transform_range");
   assert.equal(result.details?.blocked, false);
   assert.equal(result.details?.error, "missing_bridge_url");


### PR DESCRIPTION
## Summary

Remove the `files_workspace` and `python_bridge` experimental feature flags. These gates added friction without proportional security benefit — the real security boundaries are the bridge URL validation, health probes, origin allowlists, and user approval dialogs (all kept).

### Files
- Write/delete actions no longer gated behind `/experimental on files-workspace`
- Files always available — removed enable button, experiment check in context injection, auto-enable on import
- Simplified `files-dialog-status` (removed disabled-experiment branch)

### Python / LibreOffice bridge
- No longer requires `/experimental on python-bridge`
- If a bridge URL is configured + reachable → tools work immediately
- User approval dialog remains (once per bridge URL per session)
- `/experimental python-bridge-url` and `python-bridge-token` commands stay (they configure the bridge)

### Kept as-is
- tmux bridge stays behind `/experimental on tmux-bridge` (shell access is genuinely dangerous)
- `execute_office_js` stays behind per-call user approval
- All bridge URL validation, health probes, and origin allowlists unchanged

### Verification
- `npm run check` ✅
- `npm run build` ✅  
- `npm run test:context` — 357/357 ✅
- `npm run test:security` — 32/32 ✅
- Net -204 lines

Toward #170