### PR TITLE
chore: remove dead code from gate removal

### DIFF
--- a/src/tools/experimental-tool-gates/types.ts
+++ b/src/tools/experimental-tool-gates/types.ts
@@ -1,5 +1,4 @@
 export const TMUX_TOOL_NAME = "tmux";
-export const FILES_TOOL_NAME = "files";
 export const EXECUTE_OFFICE_JS_TOOL_NAME = "execute_office_js";
 export const PYTHON_TOOL_NAMES = new Set<string>([
   "python_run",

--- a/src/ui/files-dialog-status.ts
+++ b/src/ui/files-dialog-status.ts
@@ -1,8 +1,6 @@
 import type { FilesDialogFilterValue } from "./files-dialog-filtering.js";
 
 export function buildFilesDialogStatusMessage(args: {
-  /** @deprecated Files are always enabled. Kept for caller compatibility. */
-  filesExperimentEnabled?: boolean;
   totalCount: number;
   filteredCount: number;
   selectedFilter: FilesDialogFilterValue;

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -97,7 +97,6 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
   const controls = document.createElement("div");
   controls.className = "pi-files-dialog__controls";
 
-  const enableButton = makeButton("Enable workspace write access", "pi-overlay-btn pi-overlay-btn--ghost");
   const uploadButton = makeButton("Upload", "pi-overlay-btn pi-overlay-btn--ghost");
   const newFileButton = makeButton("New text file", "pi-overlay-btn pi-overlay-btn--ghost");
   const nativeButton = makeButton("Select folder", "pi-overlay-btn pi-overlay-btn--ghost");
@@ -176,7 +175,6 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
   viewer.append(viewerHeader, viewerNote, viewerTextarea, viewerPreview);
 
   controls.append(
-    enableButton,
     uploadButton,
     newFileButton,
     nativeButton,
@@ -467,15 +465,12 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
 
     const workspaceFilesCount = files.length - builtinDocsCount;
 
-    enableButton.hidden = true;
-    uploadButton.disabled = false;
     newFileButton.disabled = false;
     nativeButton.disabled = !backend.nativeSupported;
     nativeButton.hidden = !backend.nativeSupported;
     disconnectNativeButton.hidden = backend.kind !== "native-directory";
 
     setStatus(buildFilesDialogStatusMessage({
-      filesExperimentEnabled: true,
       totalCount: files.length,
       filteredCount: filteredFiles.length,
       selectedFilter,


### PR DESCRIPTION
Small follow-up to #214 — removes dead code left behind by the files/python gate removal:

- `FILES_TOOL_NAME` constant (no longer referenced)
- `enableButton` in files dialog (always hidden, now fully removed)
- `filesExperimentEnabled` deprecated parameter from status builder

3 files, -8 lines. All tests pass.