### PR TITLE
refactor(ui): render slash menu with DOM-safe accessible items

### DIFF
--- a/src/commands/command-menu.ts
+++ b/src/commands/command-menu.ts
@@ -7,8 +7,6 @@
 
 import { commandRegistry, type SlashCommand } from "./types.js";
 
-import { escapeHtml } from "../utils/html.js";
-
 const SOURCE_BADGES: Record<string, string> = {
   builtin: "",
   extension: "ext",
@@ -16,9 +14,32 @@ const SOURCE_BADGES: Record<string, string> = {
   prompt: "prompt",
 };
 
-let menuEl: HTMLElement | null = null;
+let menuEl: HTMLDivElement | null = null;
 let selectedIndex = 0;
 let filteredCommands: SlashCommand[] = [];
+
+function getCommandTextarea(): HTMLTextAreaElement | null {
+  return document.querySelector("pi-input textarea");
+}
+
+function clearCommandTextarea(): void {
+  const textarea = getCommandTextarea();
+  if (!textarea) {
+    return;
+  }
+
+  textarea.value = "";
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function runCommand(command: SlashCommand): void {
+  hideCommandMenu();
+  clearCommandTextarea();
+
+  document.dispatchEvent(
+    new CustomEvent("pi:command-run", { detail: { name: command.name, args: "" } }),
+  );
+}
 
 export function showCommandMenu(filter: string, anchor: HTMLElement): void {
   filteredCommands = commandRegistry.list(filter);
@@ -26,12 +47,15 @@ export function showCommandMenu(filter: string, anchor: HTMLElement): void {
     hideCommandMenu();
     return;
   }
+
   selectedIndex = Math.min(selectedIndex, filteredCommands.length - 1);
 
   if (!menuEl) {
     menuEl = document.createElement("div");
     menuEl.id = "pi-command-menu";
     menuEl.className = "pi-cmd-menu";
+    menuEl.setAttribute("role", "listbox");
+    menuEl.setAttribute("aria-label", "Slash commands");
     document.body.appendChild(menuEl);
   }
 
@@ -65,94 +89,96 @@ export function handleCommandMenuKey(e: KeyboardEvent): boolean {
     renderMenu();
     return true;
   }
+
   if (e.key === "ArrowDown") {
     e.preventDefault();
     selectedIndex = Math.min(filteredCommands.length - 1, selectedIndex + 1);
     renderMenu();
     return true;
   }
+
   if (e.key === "Enter") {
     e.preventDefault();
-    const cmd = filteredCommands[selectedIndex];
-    if (cmd) {
-      hideCommandMenu();
-      // Clear the textarea
-      const textarea = document.querySelector("pi-input textarea") as HTMLTextAreaElement;
-      if (textarea) {
-        textarea.value = "";
-        textarea.dispatchEvent(new Event("input", { bubbles: true }));
-      }
-      document.dispatchEvent(
-        new CustomEvent("pi:command-run", { detail: { name: cmd.name, args: "" } }),
-      );
+    const command = filteredCommands[selectedIndex];
+    if (command) {
+      runCommand(command);
     }
     return true;
   }
+
   if (e.key === "Escape") {
     e.preventDefault();
     hideCommandMenu();
     return true;
   }
+
   if (e.key === "Tab") {
     // Tab-complete the command name
     e.preventDefault();
-    const cmd = filteredCommands[selectedIndex];
-    if (cmd) {
-      const textarea = document.querySelector("pi-input textarea") as HTMLTextAreaElement;
-      if (textarea) {
-        textarea.value = `/${cmd.name} `;
-        textarea.dispatchEvent(new Event("input", { bubbles: true }));
-        // Move cursor to end
-        textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
-      }
+    const command = filteredCommands[selectedIndex];
+    const textarea = getCommandTextarea();
+    if (command && textarea) {
+      textarea.value = `/${command.name} `;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      textarea.selectionStart = textarea.value.length;
+      textarea.selectionEnd = textarea.value.length;
     }
     return true;
   }
+
   return false;
 }
 
 function renderMenu(): void {
-  if (!menuEl) return;
+  if (!menuEl) {
+    return;
+  }
 
-  menuEl.innerHTML = filteredCommands.map((cmd, i) => {
-    const badge = SOURCE_BADGES[cmd.source];
-    const isSelected = i === selectedIndex;
-    return `
-      <div class="pi-cmd-item ${isSelected ? "selected" : ""}" data-index="${i}">
-        <span class="pi-cmd-name">/${escapeHtml(cmd.name)}</span>
-        ${badge ? `<span class="pi-cmd-badge">${escapeHtml(badge)}</span>` : ""}
-        <span class="pi-cmd-desc">${escapeHtml(cmd.description)}</span>
-      </div>
-    `;
-  }).join("");
+  menuEl.replaceChildren();
 
-  // Click handler
-  menuEl.querySelectorAll(".pi-cmd-item").forEach((item) => {
+  for (const [index, command] of filteredCommands.entries()) {
+    const badge = SOURCE_BADGES[command.source];
+    const isSelected = index === selectedIndex;
+
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = `pi-cmd-item${isSelected ? " selected" : ""}`;
+    item.dataset.index = String(index);
+    item.setAttribute("role", "option");
+    item.setAttribute("aria-selected", isSelected ? "true" : "false");
+
+    const name = document.createElement("span");
+    name.className = "pi-cmd-name";
+    name.textContent = `/${command.name}`;
+    item.appendChild(name);
+
+    if (badge.length > 0) {
+      const badgeEl = document.createElement("span");
+      badgeEl.className = "pi-cmd-badge";
+      badgeEl.textContent = badge;
+      item.appendChild(badgeEl);
+    }
+
+    const description = document.createElement("span");
+    description.className = "pi-cmd-desc";
+    description.textContent = command.description;
+    item.appendChild(description);
+
     item.addEventListener("click", () => {
-      const idx = parseInt((item as HTMLElement).dataset.index || "0");
-      const cmd = filteredCommands[idx];
-      if (cmd) {
-        hideCommandMenu();
-        const textarea = document.querySelector("pi-input textarea") as HTMLTextAreaElement;
-        if (textarea) {
-          textarea.value = "";
-          textarea.dispatchEvent(new Event("input", { bubbles: true }));
-        }
-
-        document.dispatchEvent(
-          new CustomEvent("pi:command-run", { detail: { name: cmd.name, args: "" } }),
-        );
-      }
+      runCommand(command);
     });
+
     item.addEventListener("mouseenter", () => {
-      selectedIndex = parseInt((item as HTMLElement).dataset.index || "0");
+      selectedIndex = index;
       renderMenu();
     });
-  });
 
-  // Scroll selected into view
-  const selectedEl = menuEl.querySelector(".selected");
-  if (selectedEl) selectedEl.scrollIntoView({ block: "nearest" });
+    menuEl.appendChild(item);
+
+    if (isSelected) {
+      item.scrollIntoView({ block: "nearest" });
+    }
+  }
 }
 
 /**
@@ -160,15 +186,19 @@ function renderMenu(): void {
  * Call once after the textarea is available.
  */
 export function wireCommandMenu(textarea: HTMLTextAreaElement): void {
-  const getAnchor = (): HTMLElement => textarea.closest<HTMLElement>(".pi-input-card") ?? textarea.closest<HTMLElement>(".bg-card") ?? textarea;
+  const getAnchor = (): HTMLElement =>
+    textarea.closest<HTMLElement>(".pi-input-card")
+    ?? textarea.closest<HTMLElement>(".bg-card")
+    ?? textarea;
 
   textarea.addEventListener("input", () => {
-    const val = textarea.value;
-    if (val.startsWith("/") && !val.includes("\n")) {
-      const filter = val.slice(1); // strip the `/`
+    const value = textarea.value;
+    if (value.startsWith("/") && !value.includes("\n")) {
+      const filter = value.slice(1); // strip the `/`
       showCommandMenu(filter, getAnchor());
-    } else {
-      hideCommandMenu();
+      return;
     }
+
+    hideCommandMenu();
   });
 }

--- a/src/ui/theme/components/menus.css
+++ b/src/ui/theme/components/menus.css
@@ -34,6 +34,8 @@
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   text-align: left;
+  -webkit-appearance: none;
+  appearance: none;
   transition: background var(--duration-fast), box-shadow var(--duration-fast);
 }
 
@@ -48,12 +50,12 @@
   box-shadow: var(--glass-highlight), var(--glass-inner-shadow);
 }
 
-.pi-utilities-menu__item {
+:is(.pi-cmd-item, .pi-utilities-menu__item) {
   cursor: pointer;
 }
 
-.pi-utilities-menu__item:focus,
-.pi-utilities-menu__item:focus-visible {
+:is(.pi-cmd-item, .pi-utilities-menu__item):focus,
+:is(.pi-cmd-item, .pi-utilities-menu__item):focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--green-alpha-12), var(--glass-highlight), var(--glass-inner-shadow);
 }


### PR DESCRIPTION
## Summary

Phase 2 (refactor follow-up) for #175: make slash-command menu rendering safer and more consistent with utilities-menu semantics.

## Changes

- Refactor slash command menu rendering from `innerHTML` string templates to DOM API construction.
- Remove HTML-escaping dependency in command-menu rendering path (`textContent` is now used throughout).
- Convert slash menu entries from generic `<div>` rows to interactive `<button type="button">` items.
- Add semantic roles/ARIA:
  - menu container uses `role="listbox"` + label
  - items use `role="option"` + `aria-selected`
- Centralize command execution/textarea clearing logic to avoid duplicated behavior paths.
- Harmonize focus styling between slash-menu and utilities-menu items.

## Files

- `src/commands/command-menu.ts`
- `src/ui/theme/components/menus.css`

## Validation

- `npm run check`
- `npm run build`
- Manual taskpane smoke:
  - type `/` in input and inspect slash menu rendering
  - arrow/enter/escape/tab behavior unchanged

Refs: #175
