### PR TITLE
refactor(ui): apply explicit overlay S/M/L sizing tiers

### DIFF
--- a/src/commands/builtins/experimental-overlay.ts
+++ b/src/commands/builtins/experimental-overlay.ts
@@ -138,7 +138,7 @@ export function showExperimentalDialog(): void {
 
   const dialog = createOverlayDialog({
     overlayId: EXPERIMENTAL_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-experimental-card",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--m pi-experimental-card",
   });
 
   const { header } = createOverlayHeader({

--- a/src/commands/builtins/extensions-overlay.ts
+++ b/src/commands/builtins/extensions-overlay.ts
@@ -182,7 +182,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
 
   const dialog = createOverlayDialog({
     overlayId: EXTENSIONS_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-ext-card",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--l pi-ext-card",
   });
 
   const closeOverlay = dialog.close;

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -373,7 +373,7 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
 
   const dialog = createOverlayDialog({
     overlayId: INTEGRATIONS_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-integrations-dialog",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--l pi-integrations-dialog",
   });
 
   const closeOverlay = dialog.close;

--- a/src/commands/builtins/provider-overlay.ts
+++ b/src/commands/builtins/provider-overlay.ts
@@ -24,7 +24,7 @@ export async function showProviderPicker(): Promise<void> {
 
   const dialog = createOverlayDialog({
     overlayId: PROVIDER_PICKER_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-provider-picker-card",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--s pi-provider-picker-card",
   });
 
   const { header } = createOverlayHeader({

--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -122,7 +122,7 @@ export async function showRecoveryDialog(opts: {
 
   const dialog = createOverlayDialog({
     overlayId: RECOVERY_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-recovery-dialog",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--m pi-recovery-dialog",
   });
 
   const { header } = createOverlayHeader({

--- a/src/commands/builtins/resume-overlay.ts
+++ b/src/commands/builtins/resume-overlay.ts
@@ -105,7 +105,7 @@ export async function showResumeDialog(opts: {
 
   const dialog = createOverlayDialog({
     overlayId: RESUME_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-resume-dialog",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--m pi-resume-dialog",
   });
 
   const closeOverlay = dialog.close;

--- a/src/commands/builtins/rules-overlay.ts
+++ b/src/commands/builtins/rules-overlay.ts
@@ -805,7 +805,7 @@ export async function showRulesDialog(opts?: {
 
   const dialog = createOverlayDialog({
     overlayId: RULES_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--m",
   });
 
   const closeOverlay = dialog.close;

--- a/src/commands/builtins/shortcuts-overlay.ts
+++ b/src/commands/builtins/shortcuts-overlay.ts
@@ -97,7 +97,7 @@ export function showShortcutsDialog(): void {
   const mac = isMacPlatform();
   const dialog = createOverlayDialog({
     overlayId: SHORTCUTS_OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-shortcuts-dialog",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--m pi-shortcuts-dialog",
   });
 
   const { header } = createOverlayHeader({

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -78,7 +78,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
 
   const dialog = createOverlayDialog({
     overlayId: OVERLAY_ID,
-    cardClassName: "pi-welcome-card pi-overlay-card pi-files-dialog",
+    cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--m pi-files-dialog",
   });
 
   const closeOverlay = dialog.close;

--- a/src/ui/theme/components/files.css
+++ b/src/ui/theme/components/files.css
@@ -1,7 +1,5 @@
 /* Files workspace dialog */
 .pi-files-dialog {
-  width: min(520px, 92vw);
-  max-height: min(80vh, 720px);
   gap: 10px;
 }
 

--- a/src/ui/theme/overlays/experimental.css
+++ b/src/ui/theme/overlays/experimental.css
@@ -1,9 +1,5 @@
 /* Experimental feature manager */
 
-.pi-experimental-card {
-  width: min(520px, 92vw);
-}
-
 .pi-experimental-list {
   display: flex;
   flex-direction: column;

--- a/src/ui/theme/overlays/extensions.css
+++ b/src/ui/theme/overlays/extensions.css
@@ -1,8 +1,6 @@
 /* Extensions manager */
 
 .pi-ext-card {
-  width: min(720px, 92vw);
-  max-height: min(80vh, 720px);
   overflow: hidden;
   gap: 12px;
 }

--- a/src/ui/theme/overlays/integrations.css
+++ b/src/ui/theme/overlays/integrations.css
@@ -1,8 +1,6 @@
 /* Integrations manager */
 
 .pi-integrations-dialog {
-  width: min(720px, 92vw);
-  max-height: min(80vh, 720px);
   overflow: hidden;
   gap: 12px;
 }

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -7,6 +7,18 @@
   gap: 10px;
 }
 
+.pi-overlay-card--s {
+  width: min(380px, 92vw);
+}
+
+.pi-overlay-card--m {
+  width: min(520px, 92vw);
+}
+
+.pi-overlay-card--l {
+  width: min(720px, 92vw);
+}
+
 .pi-overlay-title {
   margin: 0;
   font-family: var(--font-sans);

--- a/src/ui/theme/overlays/provider-resume-shortcuts.css
+++ b/src/ui/theme/overlays/provider-resume-shortcuts.css
@@ -1,9 +1,5 @@
 /* Provider / Resume / Shortcuts overlays */
 
-.pi-provider-picker-card {
-  width: min(380px, 92vw);
-}
-
 .pi-provider-picker-list {
   display: flex;
   flex: 1 1 auto;
@@ -88,10 +84,6 @@
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   color: var(--muted-foreground);
-}
-
-.pi-shortcuts-dialog {
-  width: min(520px, 92vw);
 }
 
 .pi-shortcuts-list {

--- a/src/ui/theme/overlays/recovery.css
+++ b/src/ui/theme/overlays/recovery.css
@@ -1,7 +1,6 @@
 /* Backups overlay */
 
 .pi-recovery-dialog {
-  width: min(520px, 92vw);
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

Phase 3 for #175: make overlay sizing tiers explicit and consistently applied at call sites.

## Changes

- Add explicit overlay tier utility classes in primitives:
  - `.pi-overlay-card--s`
  - `.pi-overlay-card--m`
  - `.pi-overlay-card--l`
- Apply explicit tier class in each overlay/dialog `cardClassName`:
  - S: provider picker
  - M: rules, resume, shortcuts, recovery, experimental, files
  - L: extensions, integrations
- Remove now-redundant per-overlay width/max-height declarations from specialized CSS modules where tier class now owns sizing.

## Why

This keeps sizing policy in one shared place and makes each overlay’s intended size obvious in code, reducing drift and making future consistency work safer.

## Files

- `src/ui/theme/overlays/primitives.css`
- `src/commands/builtins/{provider,resume,rules,shortcuts,recovery,experimental,extensions,integrations}-overlay.ts`
- `src/ui/files-dialog.ts`
- `src/ui/theme/overlays/{provider-resume-shortcuts,recovery,experimental,extensions,integrations}.css`
- `src/ui/theme/components/files.css`

## Validation

- `npm run check`
- `npm run build`
- Manual smoke:
  - Integrations overlay (L tier)
  - Provider overlay (S tier)

Refs: #175
