### PR TITLE
refactor(ui): modularize integrations overlay implementation

### DIFF
--- a/src/commands/builtins/integrations-overlay-card.ts
+++ b/src/commands/builtins/integrations-overlay-card.ts
@@ -1,0 +1,89 @@
+import { type IntegrationDefinition } from "../../integrations/catalog.js";
+import { createOverlayBadge } from "../../ui/overlay-dialog.js";
+import { type IntegrationsSnapshot } from "./integrations-overlay-types.js";
+
+function isEnabledInList(integrationIds: readonly string[], integrationId: string): boolean {
+  return integrationIds.includes(integrationId);
+}
+
+export function createIntegrationCard(args: {
+  integration: IntegrationDefinition;
+  snapshot: IntegrationsSnapshot;
+  onToggleSession: (integrationId: string, next: boolean) => Promise<void>;
+  onToggleWorkbook: (integrationId: string, next: boolean) => Promise<void>;
+}): HTMLElement {
+  const { integration, snapshot } = args;
+
+  const card = document.createElement("div");
+  card.className = "pi-overlay-surface pi-integrations-card";
+
+  const top = document.createElement("div");
+  top.className = "pi-integrations-card__top";
+
+  const textWrap = document.createElement("div");
+  textWrap.className = "pi-integrations-card__text-wrap";
+
+  const title = document.createElement("strong");
+  title.textContent = integration.title;
+  title.className = "pi-integrations-card__title";
+
+  const description = document.createElement("span");
+  description.textContent = integration.description;
+  description.className = "pi-integrations-card__description";
+
+  textWrap.append(title, description);
+
+  const badges = document.createElement("div");
+  badges.className = "pi-overlay-badges";
+
+  if (isEnabledInList(snapshot.activeIntegrationIds, integration.id) && snapshot.externalToolsEnabled) {
+    badges.appendChild(createOverlayBadge("active", "ok"));
+  } else if (isEnabledInList(snapshot.activeIntegrationIds, integration.id) && !snapshot.externalToolsEnabled) {
+    badges.appendChild(createOverlayBadge("configured (blocked)", "warn"));
+  } else {
+    badges.appendChild(createOverlayBadge("inactive", "muted"));
+  }
+
+  top.append(textWrap, badges);
+
+  const warning = document.createElement("div");
+  warning.className = "pi-integrations-card__warning";
+  warning.textContent = integration.warning ?? "";
+  warning.hidden = !integration.warning;
+
+  const toggles = document.createElement("div");
+  toggles.className = "pi-integrations-card__toggles";
+
+  const sessionLabel = document.createElement("label");
+  sessionLabel.className = "pi-integrations-card__toggle-label";
+
+  const sessionToggle = document.createElement("input");
+  sessionToggle.type = "checkbox";
+  sessionToggle.checked = isEnabledInList(snapshot.sessionIntegrationIds, integration.id);
+  sessionToggle.addEventListener("change", () => {
+    void args.onToggleSession(integration.id, sessionToggle.checked);
+  });
+  sessionLabel.append(sessionToggle, document.createTextNode("Enable for this session"));
+
+  const workbookLabel = document.createElement("label");
+  workbookLabel.className = "pi-integrations-card__toggle-label";
+
+  const workbookToggle = document.createElement("input");
+  workbookToggle.type = "checkbox";
+  workbookToggle.checked = isEnabledInList(snapshot.workbookIntegrationIds, integration.id);
+  workbookToggle.disabled = snapshot.workbookId === null;
+  workbookToggle.addEventListener("change", () => {
+    void args.onToggleWorkbook(integration.id, workbookToggle.checked);
+  });
+
+  const workbookText = snapshot.workbookId
+    ? `Enable for workbook (${snapshot.workbookLabel})`
+    : "Workbook scope unavailable";
+
+  workbookLabel.append(workbookToggle, document.createTextNode(workbookText));
+
+  toggles.append(sessionLabel, workbookLabel);
+
+  card.append(top, warning, toggles);
+  return card;
+}

--- a/src/commands/builtins/integrations-overlay-elements.ts
+++ b/src/commands/builtins/integrations-overlay-elements.ts
@@ -1,0 +1,195 @@
+import {
+  INTEGRATIONS_LABEL,
+} from "../../integrations/naming.js";
+import {
+  WEB_SEARCH_PROVIDERS,
+  WEB_SEARCH_PROVIDER_INFO,
+} from "../../tools/web-search-config.js";
+import {
+  createOverlayButton,
+  createOverlayInput,
+  createOverlaySectionTitle,
+} from "../../ui/overlay-dialog.js";
+
+export interface IntegrationsDialogElements {
+  body: HTMLDivElement;
+  externalToggle: HTMLInputElement;
+  activeSummary: HTMLDivElement;
+  integrationsList: HTMLDivElement;
+  webSearchStatus: HTMLDivElement;
+  webSearchProviderSelect: HTMLSelectElement;
+  webSearchProviderSignupLink: HTMLAnchorElement;
+  webSearchApiKeyInput: HTMLInputElement;
+  webSearchSaveButton: HTMLButtonElement;
+  webSearchValidateButton: HTMLButtonElement;
+  webSearchClearButton: HTMLButtonElement;
+  webSearchHint: HTMLParagraphElement;
+  webSearchValidationStatus: HTMLParagraphElement;
+  mcpList: HTMLDivElement;
+  mcpNameInput: HTMLInputElement;
+  mcpUrlInput: HTMLInputElement;
+  mcpTokenInput: HTMLInputElement;
+  mcpEnabledInput: HTMLInputElement;
+  mcpAddButton: HTMLButtonElement;
+}
+
+export function createIntegrationsDialogElements(): IntegrationsDialogElements {
+  const body = document.createElement("div");
+  body.className = "pi-overlay-body";
+
+  const externalSection = document.createElement("section");
+  externalSection.className = "pi-overlay-section";
+  externalSection.appendChild(createOverlaySectionTitle("External tools gate"));
+
+  const externalCard = document.createElement("div");
+  externalCard.className = "pi-overlay-surface";
+
+  const externalToggleLabel = document.createElement("label");
+  externalToggleLabel.className = "pi-integrations-toggle-label";
+
+  const externalToggle = document.createElement("input");
+  externalToggle.type = "checkbox";
+
+  const externalToggleText = document.createElement("span");
+  externalToggleText.textContent = "Allow external tools (web search / MCP)";
+
+  externalToggleLabel.append(externalToggle, externalToggleText);
+
+  const activeSummary = document.createElement("div");
+  activeSummary.className = "pi-integrations-active-summary";
+
+  externalCard.append(externalToggleLabel, activeSummary);
+  externalSection.appendChild(externalCard);
+
+  const integrationsSection = document.createElement("section");
+  integrationsSection.className = "pi-overlay-section";
+  integrationsSection.appendChild(createOverlaySectionTitle(`${INTEGRATIONS_LABEL} bundles`));
+
+  const integrationsList = document.createElement("div");
+  integrationsList.className = "pi-overlay-list";
+  integrationsSection.appendChild(integrationsList);
+
+  const webSearchSection = document.createElement("section");
+  webSearchSection.className = "pi-overlay-section";
+  webSearchSection.appendChild(createOverlaySectionTitle("Web search config"));
+
+  const webSearchCard = document.createElement("div");
+  webSearchCard.className = "pi-overlay-surface";
+
+  const webSearchStatus = document.createElement("div");
+  webSearchStatus.className = "pi-integrations-web-search-status";
+
+  const webSearchProviderRow = document.createElement("div");
+  webSearchProviderRow.className = "pi-integrations-web-search-provider-row";
+
+  const webSearchProviderSelect = document.createElement("select");
+  webSearchProviderSelect.className = "pi-overlay-input";
+
+  for (const providerId of WEB_SEARCH_PROVIDERS) {
+    const option = document.createElement("option");
+    option.value = providerId;
+    option.textContent = WEB_SEARCH_PROVIDER_INFO[providerId].title;
+    webSearchProviderSelect.appendChild(option);
+  }
+
+  const webSearchProviderSignupLink = document.createElement("a");
+  webSearchProviderSignupLink.className = "pi-overlay-link";
+  webSearchProviderSignupLink.target = "_blank";
+  webSearchProviderSignupLink.rel = "noopener noreferrer";
+
+  webSearchProviderRow.append(webSearchProviderSelect, webSearchProviderSignupLink);
+
+  const webSearchInputRow = document.createElement("div");
+  webSearchInputRow.className = "pi-integrations-web-search-row";
+
+  const webSearchApiKeyInput = createOverlayInput({ placeholder: "API key", type: "password" });
+  const webSearchSaveButton = createOverlayButton({ text: "Save key" });
+  const webSearchValidateButton = createOverlayButton({ text: "Validate" });
+  const webSearchClearButton = createOverlayButton({ text: "Clear" });
+
+  webSearchInputRow.append(
+    webSearchApiKeyInput,
+    webSearchSaveButton,
+    webSearchValidateButton,
+    webSearchClearButton,
+  );
+
+  const webSearchHint = document.createElement("p");
+  webSearchHint.className = "pi-overlay-hint";
+
+  const webSearchValidationStatus = document.createElement("p");
+  webSearchValidationStatus.className = "pi-overlay-hint";
+
+  webSearchCard.append(
+    webSearchStatus,
+    webSearchProviderRow,
+    webSearchInputRow,
+    webSearchHint,
+    webSearchValidationStatus,
+  );
+  webSearchSection.appendChild(webSearchCard);
+
+  const mcpSection = document.createElement("section");
+  mcpSection.className = "pi-overlay-section";
+  mcpSection.appendChild(createOverlaySectionTitle("MCP servers"));
+
+  const mcpList = document.createElement("div");
+  mcpList.className = "pi-overlay-list";
+
+  const mcpAddCard = document.createElement("div");
+  mcpAddCard.className = "pi-overlay-surface";
+
+  const mcpAddTitle = document.createElement("div");
+  mcpAddTitle.textContent = "Add server";
+  mcpAddTitle.className = "pi-integrations-mcp-add-title";
+
+  const mcpAddRow = document.createElement("div");
+  mcpAddRow.className = "pi-integrations-mcp-add-row";
+
+  const mcpNameInput = createOverlayInput({ placeholder: "Name" });
+  const mcpUrlInput = createOverlayInput({ placeholder: "https://example.com/mcp" });
+  const mcpTokenInput = createOverlayInput({ placeholder: "Bearer token (optional)", type: "password" });
+
+  const mcpEnabledLabel = document.createElement("label");
+  mcpEnabledLabel.className = "pi-integrations-toggle-label";
+  const mcpEnabledInput = document.createElement("input");
+  mcpEnabledInput.type = "checkbox";
+  mcpEnabledInput.checked = true;
+  mcpEnabledLabel.append(mcpEnabledInput, document.createTextNode("Enabled"));
+
+  const mcpAddButton = createOverlayButton({ text: "Add" });
+
+  mcpAddRow.append(mcpNameInput, mcpUrlInput, mcpTokenInput, mcpEnabledLabel, mcpAddButton);
+
+  const mcpHint = document.createElement("p");
+  mcpHint.className = "pi-overlay-hint";
+  mcpHint.textContent = "Server URL, optional bearer token, and one-click connection test.";
+
+  mcpAddCard.append(mcpAddTitle, mcpAddRow, mcpHint);
+
+  mcpSection.append(mcpList, mcpAddCard);
+
+  body.append(externalSection, integrationsSection, webSearchSection, mcpSection);
+
+  return {
+    body,
+    externalToggle,
+    activeSummary,
+    integrationsList,
+    webSearchStatus,
+    webSearchProviderSelect,
+    webSearchProviderSignupLink,
+    webSearchApiKeyInput,
+    webSearchSaveButton,
+    webSearchValidateButton,
+    webSearchClearButton,
+    webSearchHint,
+    webSearchValidationStatus,
+    mcpList,
+    mcpNameInput,
+    mcpUrlInput,
+    mcpTokenInput,
+    mcpEnabledInput,
+    mcpAddButton,
+  };
+}

--- a/src/commands/builtins/integrations-overlay-mcp-probe.ts
+++ b/src/commands/builtins/integrations-overlay-mcp-probe.ts
@@ -1,0 +1,137 @@
+import { APP_NAME, APP_VERSION } from "../../app/metadata.js";
+import { type IntegrationSettingsStore } from "../../integrations/store.js";
+import { getEnabledProxyBaseUrl, resolveOutboundRequestUrl } from "../../tools/external-fetch.js";
+import { type McpServerConfig } from "../../tools/mcp-config.js";
+import {
+  getHttpErrorReason,
+  runWithTimeoutAbort,
+} from "../../utils/network.js";
+import { isRecord } from "../../utils/type-guards.js";
+
+const MCP_PROBE_TIMEOUT_MS = 8_000;
+const MCP_PROTOCOL_VERSION = "2025-03-26";
+
+function parseToolCountFromListResponse(value: unknown): number {
+  if (!isRecord(value)) return 0;
+  if (!isRecord(value.result)) return 0;
+  const tools = value.result.tools;
+  return Array.isArray(tools) ? tools.length : 0;
+}
+
+async function postJsonRpc(args: {
+  server: McpServerConfig;
+  method: string;
+  params?: unknown;
+  settings: IntegrationSettingsStore;
+  expectResponse?: boolean;
+}): Promise<{ response: unknown; proxied: boolean; proxyBaseUrl?: string } | null> {
+  const { server, method, params, settings, expectResponse = true } = args;
+
+  const proxyBaseUrl = await getEnabledProxyBaseUrl(settings);
+  const resolved = resolveOutboundRequestUrl({
+    targetUrl: server.url,
+    proxyBaseUrl,
+  });
+
+  const body: Record<string, unknown> = {
+    jsonrpc: "2.0",
+    method,
+  };
+
+  if (params !== undefined) {
+    body.params = params;
+  }
+
+  if (expectResponse) {
+    body.id = crypto.randomUUID();
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+
+  if (server.token) {
+    headers.Authorization = `Bearer ${server.token}`;
+  }
+
+  return runWithTimeoutAbort({
+    signal: undefined,
+    timeoutMs: MCP_PROBE_TIMEOUT_MS,
+    timeoutErrorMessage: `MCP request timed out after ${MCP_PROBE_TIMEOUT_MS}ms.`,
+    run: async (requestSignal) => {
+      const response = await fetch(resolved.requestUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: requestSignal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        const reason = getHttpErrorReason(response.status, text);
+        throw new Error(`MCP request failed (${response.status}): ${reason}`);
+      }
+
+      if (!expectResponse) {
+        return {
+          response: null,
+          proxied: resolved.proxied,
+          proxyBaseUrl: resolved.proxyBaseUrl,
+        };
+      }
+
+      const text = await response.text();
+      const payload: unknown = text.trim().length > 0 ? JSON.parse(text) : null;
+
+      return {
+        response: payload,
+        proxied: resolved.proxied,
+        proxyBaseUrl: resolved.proxyBaseUrl,
+      };
+    },
+  });
+}
+
+export async function probeMcpServer(
+  server: McpServerConfig,
+  settings: IntegrationSettingsStore,
+): Promise<{ toolCount: number; proxied: boolean; proxyBaseUrl?: string }> {
+  await postJsonRpc({
+    server,
+    method: "initialize",
+    params: {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: {
+        name: APP_NAME,
+        version: APP_VERSION,
+      },
+    },
+    settings,
+  });
+
+  await postJsonRpc({
+    server,
+    method: "notifications/initialized",
+    settings,
+    expectResponse: false,
+  });
+
+  const list = await postJsonRpc({
+    server,
+    method: "tools/list",
+    params: {},
+    settings,
+  });
+
+  if (!list) {
+    throw new Error("MCP tools/list returned no response.");
+  }
+
+  return {
+    toolCount: parseToolCountFromListResponse(list.response),
+    proxied: list.proxied,
+    proxyBaseUrl: list.proxyBaseUrl,
+  };
+}

--- a/src/commands/builtins/integrations-overlay-state.ts
+++ b/src/commands/builtins/integrations-overlay-state.ts
@@ -1,0 +1,84 @@
+import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.js";
+
+import { INTEGRATION_IDS } from "../../integrations/catalog.js";
+import {
+  getExternalToolsEnabled,
+  getSessionIntegrationIds,
+  getWorkbookIntegrationIds,
+  resolveConfiguredIntegrationIds,
+  type IntegrationSettingsStore,
+} from "../../integrations/store.js";
+import {
+  loadWebSearchProviderConfig,
+  type WebSearchConfigStore,
+  type WebSearchProvider,
+} from "../../tools/web-search-config.js";
+import {
+  loadMcpServers,
+  type McpConfigStore,
+} from "../../tools/mcp-config.js";
+import type {
+  IntegrationsDialogDependencies,
+  IntegrationsSnapshot,
+} from "./integrations-overlay-types.js";
+
+export type IntegrationsSettingsStore = IntegrationSettingsStore & WebSearchConfigStore & McpConfigStore;
+
+export function normalizeWebSearchProvider(value: string): WebSearchProvider {
+  if (value === "serper" || value === "tavily" || value === "brave") {
+    return value;
+  }
+
+  return "serper";
+}
+
+export function getSettingsStore(): Promise<IntegrationsSettingsStore> {
+  return Promise.resolve(getAppStorage().settings);
+}
+
+export async function buildSnapshot(
+  dependencies: IntegrationsDialogDependencies,
+): Promise<IntegrationsSnapshot> {
+  const settings = await getSettingsStore();
+  const sessionId = dependencies.getActiveSessionId();
+  if (!sessionId) {
+    throw new Error("No active session.");
+  }
+
+  const workbookContext = await dependencies.resolveWorkbookContext();
+
+  const [
+    externalToolsEnabled,
+    sessionIntegrationIds,
+    workbookIntegrationIds,
+    activeIntegrationIds,
+    webSearchConfig,
+    mcpServers,
+  ] = await Promise.all([
+    getExternalToolsEnabled(settings),
+    getSessionIntegrationIds(settings, sessionId, INTEGRATION_IDS),
+    workbookContext.workbookId
+      ? getWorkbookIntegrationIds(settings, workbookContext.workbookId, INTEGRATION_IDS)
+      : Promise.resolve([]),
+    resolveConfiguredIntegrationIds({
+      settings,
+      sessionId,
+      workbookId: workbookContext.workbookId,
+      knownIntegrationIds: INTEGRATION_IDS,
+    }),
+    loadWebSearchProviderConfig(settings),
+    loadMcpServers(settings),
+  ]);
+
+  return {
+    sessionId,
+    workbookId: workbookContext.workbookId,
+    workbookLabel: workbookContext.workbookLabel,
+    externalToolsEnabled,
+    sessionIntegrationIds,
+    workbookIntegrationIds,
+    activeIntegrationIds,
+    webSearchConfig,
+    mcpServers,
+  };
+}

--- a/src/commands/builtins/integrations-overlay-types.ts
+++ b/src/commands/builtins/integrations-overlay-types.ts
@@ -1,0 +1,35 @@
+import type { WebSearchProviderConfig } from "../../tools/web-search-config.js";
+import type { McpServerConfig } from "../../tools/mcp-config.js";
+
+export interface WorkbookContextSnapshot {
+  workbookId: string | null;
+  workbookLabel: string;
+}
+
+export interface IntegrationsDialogDependencies {
+  getActiveSessionId: () => string | null;
+  resolveWorkbookContext: () => Promise<WorkbookContextSnapshot>;
+  onChanged?: () => Promise<void> | void;
+}
+
+export interface IntegrationsSnapshot {
+  sessionId: string;
+  workbookId: string | null;
+  workbookLabel: string;
+  externalToolsEnabled: boolean;
+  sessionIntegrationIds: string[];
+  workbookIntegrationIds: string[];
+  activeIntegrationIds: string[];
+  webSearchConfig: WebSearchProviderConfig;
+  mcpServers: McpServerConfig[];
+}
+
+export type IntegrationMutationReason = "toggle" | "scope" | "external-toggle" | "config";
+
+export function getIntegrationsErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return String(error);
+}


### PR DESCRIPTION
## Summary
Refactors the `/integrations` overlay implementation into focused modules without changing behavior.

### What changed
- split the former large `src/commands/builtins/integrations-overlay.ts` into:
  - `src/commands/builtins/integrations-overlay.ts` (orchestration + event wiring)
  - `src/commands/builtins/integrations-overlay-elements.ts` (DOM section construction)
  - `src/commands/builtins/integrations-overlay-card.ts` (integration card rendering)
  - `src/commands/builtins/integrations-overlay-state.ts` (snapshot/settings helpers)
  - `src/commands/builtins/integrations-overlay-mcp-probe.ts` (MCP probe transport)
  - `src/commands/builtins/integrations-overlay-types.ts` (shared types + error helper)

### Why
- reduce cognitive load in one oversized file
- isolate state/network/UI concerns for easier future edits
- keep the main overlay module under ~500 LOC

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
