### PR TITLE
refactor(ui): normalize overlay header subtitle patterns

### DIFF
--- a/src/commands/builtins/resume-overlay.ts
+++ b/src/commands/builtins/resume-overlay.ts
@@ -114,7 +114,7 @@ export async function showResumeDialog(opts: {
     onClose: closeOverlay,
     closeLabel: "Close resume sessions",
     title: "Resume Session",
-    titleClassName: "pi-resume-dialog__title",
+    subtitle: "Pick a previous session and choose whether to open it in a new tab or replace the current tab.",
   });
 
   const targetControls = document.createElement("div");

--- a/src/commands/builtins/rules-overlay.ts
+++ b/src/commands/builtins/rules-overlay.ts
@@ -814,6 +814,7 @@ export async function showRulesDialog(opts?: {
     onClose: closeOverlay,
     closeLabel: "Close rules",
     title: "Rules",
+    subtitle: "Set guidance for all files, this workbook, and formatting conventions.",
   });
 
   const tabs = document.createElement("div");

--- a/src/commands/builtins/shortcuts-overlay.ts
+++ b/src/commands/builtins/shortcuts-overlay.ts
@@ -104,6 +104,7 @@ export function showShortcutsDialog(): void {
     onClose: dialog.close,
     closeLabel: "Close keyboard shortcuts",
     title: "Keyboard Shortcuts",
+    subtitle: "Quick reference for chat, tabs, navigation, and system shortcuts.",
   });
 
   const list = document.createElement("div");

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -87,7 +87,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     onClose: closeOverlay,
     closeLabel: "Close files",
     title: "Files",
-    subtitle: "",
+    subtitle: "Storage: loading…",
   });
 
   if (!subtitle) {

--- a/src/ui/theme/overlays/provider-resume-shortcuts.css
+++ b/src/ui/theme/overlays/provider-resume-shortcuts.css
@@ -14,11 +14,6 @@
   overflow: hidden;
 }
 
-.pi-resume-dialog__title {
-  margin-bottom: 12px;
-  flex-shrink: 0;
-}
-
 .pi-resume-target-controls {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## Summary

Phase 4 follow-up for #175: finish header consistency by removing the last per-overlay title override and standardizing subtitle usage across remaining overlays.

## Changes

- Removed the remaining title-specific override in Resume overlay (`titleClassName` usage removed).
- Added shared-style subtitles to overlays that previously had none:
  - Rules
  - Keyboard Shortcuts
  - Resume Session
- Updated Files overlay initial subtitle to a meaningful loading state (`Storage: loading…`) before backend status is resolved.
- Removed now-unused `.pi-resume-dialog__title` CSS rule.

## Why

This keeps header typography/spacing behavior on shared overlay primitives (`pi-overlay-title` + `pi-overlay-subtitle`) and avoids one-off title spacing exceptions.

## Files

- `src/commands/builtins/resume-overlay.ts`
- `src/commands/builtins/rules-overlay.ts`
- `src/commands/builtins/shortcuts-overlay.ts`
- `src/ui/files-dialog.ts`
- `src/ui/theme/overlays/provider-resume-shortcuts.css`

## Validation

- `npm run check`
- `npm run build`
- Manual taskpane smoke via `agent-browser`:
  - `/shortcuts`
  - `/rules`
  - `/files`

Refs: #175
