### PR TITLE
fix(ui): gate dark mode behind /experimental

### DIFF
--- a/src/experiments/flags.ts
+++ b/src/experiments/flags.ts
@@ -11,6 +11,7 @@ import { dispatchExperimentalFeatureChanged } from "./events.js";
 export type ExperimentalFeatureId =
   | "tmux_bridge"
   | "external_skills_discovery"
+  | "ui_dark_mode"
   | "remote_extension_urls"
   | "extension_permission_gates"
   | "extension_sandbox_runtime"
@@ -52,6 +53,15 @@ const EXPERIMENTAL_FEATURES = [
     warning: "Security: external skills can contain untrusted instructions and executable references.",
     wiring: "wired",
     storageKey: "pi.experimental.externalSkillsDiscovery",
+  },
+  {
+    id: "ui_dark_mode",
+    slug: "dark-mode",
+    aliases: ["theme-dark", "ui-dark-mode"],
+    title: "Dark mode",
+    description: "Enable Office/theme-driven dark mode for the task pane UI.",
+    wiring: "wired",
+    storageKey: "pi.experimental.uiDarkMode",
   },
   {
     id: "remote_extension_urls",

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -84,7 +84,7 @@ pi-web-ui uses Light DOM (`createRenderRoot() { return this; }`), so styles leak
 | `message-style-hooks.ts` | — | Stamps semantic classes on pi-web-ui message internals (`pi-assistant-body`, `pi-tool-card-fallback`, etc.) to avoid brittle utility selectors |
 | `dialog-style-hooks.ts` | — | Stamps semantic classes on dialog internals (`pi-dialog-card`, `pi-model-selector-item-*`) so dialog CSS avoids utility selectors |
 | `toast.ts` | — | `showToast(msg, duration \| { duration, variant })` + `showActionToast(...)` — fixed notifications with destructive styling for errors |
-| `theme-mode.ts` | — | Applies/removes `.dark` based on Office theme background (fallback: `prefers-color-scheme`) |
+| `theme-mode.ts` | — | Keeps light mode by default; `/experimental on dark-mode` enables Office/theme-driven `.dark` (fallback: `prefers-color-scheme`) |
 | `loading.ts` | — | Splash screen shown during init |
 | `provider-login.ts` | — | API key entry rows for the welcome overlay |
 | `overlay-dialog.ts` | — | Shared overlay lifecycle helper (single-instance toggle, Escape/backdrop close, focus restore) + shared overlay chrome/DOM builders (`createOverlayCloseButton`, `createOverlayHeader`, `createOverlayButton`, `createOverlayInput`, `createOverlaySectionTitle`, `createOverlayBadge`) |

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -104,6 +104,8 @@ void test("builtins registry wires /experimental, /extensions, and /integrations
   assert.match(experimentalFlagsSource, /extension-widget-v2/);
   assert.match(experimentalFlagsSource, /external_skills_discovery/);
   assert.match(experimentalFlagsSource, /external-skills-discovery/);
+  assert.match(experimentalFlagsSource, /ui_dark_mode/);
+  assert.match(experimentalFlagsSource, /dark-mode/);
   assert.match(
     experimentalFlagsSource,
     /id:\s*"external_skills_discovery"[\s\S]*?wiring:\s*"wired"/,


### PR DESCRIPTION
## Summary
- add a new experimental feature flag `ui_dark_mode` exposed as `/experimental on dark-mode`
- keep the task pane in light mode by default unless the dark-mode experiment is enabled
- update theme sync to re-apply immediately when the experimental flag is toggled
- update `src/ui/README.md` to document light-by-default + experimental dark mode
- extend builtins registry coverage to assert the new experimental flag is registered

## Testing
- pre-commit hooks on commit (`npm run lint`, `npm run typecheck`)
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/builtins-registry.test.ts tests/experimental-command.test.ts`
