### PR TITLE
refactor(ui): use shared overlay button variants in files rows

### DIFF
--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -531,19 +531,21 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
         const actions = document.createElement("div");
         actions.className = "pi-files-dialog__actions";
 
-        const openButton = makeButton("Open", "pi-files-dialog__row-btn");
+        const rowActionClassName = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--compact";
+
+        const openButton = makeButton("Open", rowActionClassName);
         openButton.addEventListener("click", () => {
           void openViewer(file);
         });
 
-        const downloadButton = makeButton("Download", "pi-files-dialog__row-btn");
+        const downloadButton = makeButton("Download", rowActionClassName);
         downloadButton.addEventListener("click", () => {
           void workspace.downloadFile(file.path).catch((error: unknown) => {
             showToast(`Download failed: ${getErrorMessage(error)}`);
           });
         });
 
-        const renameButton = makeButton("Rename", "pi-files-dialog__row-btn");
+        const renameButton = makeButton("Rename", rowActionClassName);
         renameButton.disabled = file.readOnly;
         if (file.readOnly) {
           renameButton.title = "Built-in docs are read-only.";
@@ -559,7 +561,10 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
           });
         });
 
-        const deleteButton = makeButton("Delete", "pi-files-dialog__row-btn pi-files-dialog__row-btn--danger");
+        const deleteButton = makeButton(
+          "Delete",
+          `${rowActionClassName} pi-overlay-btn--danger`,
+        );
         deleteButton.disabled = file.readOnly;
         if (file.readOnly) {
           deleteButton.title = "Built-in docs are read-only.";

--- a/src/ui/theme/components/files.css
+++ b/src/ui/theme/components/files.css
@@ -171,30 +171,6 @@
   flex-shrink: 0;
 }
 
-.pi-files-dialog__row-btn {
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-xs);
-  background: var(--white-alpha-65);
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: var(--text-xs);
-  padding: 4px 7px;
-  cursor: pointer;
-}
-
-.pi-files-dialog__row-btn:hover {
-  background: var(--white-alpha-80);
-}
-
-.pi-files-dialog__row-btn:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-.pi-files-dialog__row-btn--danger {
-  color: oklch(0.56 0.2 24);
-}
-
 .pi-files-dialog__viewer {
   border: var(--pi-divider);
   border-radius: var(--radius-md);

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -172,6 +172,23 @@
   background: var(--alpha-4);
 }
 
+.pi-overlay-btn--compact {
+  border-radius: var(--radius-xs);
+  font-size: var(--text-xs);
+  padding: 4px 7px;
+}
+
+.pi-overlay-btn--danger {
+  color: var(--destructive);
+  border-color: color-mix(in oklch, var(--destructive) 22%, var(--alpha-12));
+  background: color-mix(in oklch, var(--destructive) 7%, transparent);
+}
+
+.pi-overlay-btn--danger:hover {
+  border-color: color-mix(in oklch, var(--destructive) 30%, var(--alpha-12));
+  background: color-mix(in oklch, var(--destructive) 12%, transparent);
+}
+
 .pi-overlay-btn--full {
   width: 100%;
 }


### PR DESCRIPTION
## Summary

Phase 5 for #175: continue button-system consistency by moving Files row actions onto shared overlay button primitives.

## Changes

- Added reusable overlay button variants:
  - `pi-overlay-btn--compact` for dense row/tool actions
  - `pi-overlay-btn--danger` for destructive actions
- Updated Files dialog row actions (`Open`, `Download`, `Rename`, `Delete`) to use shared overlay button classes instead of files-specific row-button classes.
- Removed now-redundant files-specific row button CSS.

## Why

Issue #175 calls out inconsistent button systems across overlays. This slice removes one remaining local button style island and reuses shared primitives for consistent spacing, focus, and visual language.

## Files

- `src/ui/theme/overlays/primitives.css`
- `src/ui/files-dialog.ts`
- `src/ui/theme/components/files.css`

## Validation

- `npm run check`
- `npm run build`
- Manual taskpane smoke via `agent-browser`:
  - `/files` (row actions + delete styling)

Refs: #175
