### PR TITLE
fix(ui): truncate sidebar input placeholder in narrow widths

### DIFF
--- a/src/ui/pi-input.ts
+++ b/src/ui/pi-input.ts
@@ -17,10 +17,10 @@ import { customElement, property, state, query } from "lit/decorators.js";
 import { doesOverlayClaimEscape } from "../utils/escape-guard.js";
 
 const PLACEHOLDER_HINTS = [
-  "Ask Pi anything about your workbook…",
+  "Ask Pi about your workbook…",
   "Type / for commands…",
-  "Ask Pi anything about your workbook…",
-  "Tell Pi what to change…",
+  "Ask Pi what to change…",
+  "Summarize this workbook…",
 ];
 
 export type PiInputAction = "open-files" | "open-rules" | "open-resume" | "open-backups";

--- a/src/ui/theme/components/input.css
+++ b/src/ui/theme/components/input.css
@@ -53,10 +53,17 @@
   font-family: var(--font-sans);
   font-size: var(--text-base);
   line-height: 1.5;
+  white-space: pre-wrap;
   resize: none;
   outline: none;
   overflow-y: auto;
   field-sizing: content;
+}
+
+.pi-input-textarea:placeholder-shown {
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .pi-input-textarea::placeholder {


### PR DESCRIPTION
## Summary
- shorten default input hint copy from "Ask Pi anything about your workbook…" to "Ask Pi about your workbook…"
- adjust the rotating placeholder hints to shorter variants better suited for narrow Excel taskpane widths
- prevent placeholder wrapping in the sidebar input by forcing single-line + ellipsis while the field is empty

## Why
In narrow taskpane layouts, the placeholder wrapped to a second line and became visually noisy/clipped around the input controls.

## Changes
- `src/ui/pi-input.ts`
  - updated `PLACEHOLDER_HINTS` strings to shorter copy
- `src/ui/theme/components/input.css`
  - keep normal typed content multiline (`white-space: pre-wrap`)
  - when placeholder is shown, force single-line truncation:
    - `white-space: nowrap`
    - `overflow-x: hidden`
    - `text-overflow: ellipsis`

## Validation
- `npm run lint`
- `npm run typecheck`
