### PR TITLE
refactor(ui): share inline control styles across overlays

### DIFF
--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -175,10 +175,10 @@ export async function showRecoveryDialog(opts: {
   const searchInput = document.createElement("input");
   searchInput.type = "text";
   searchInput.placeholder = "Search by id, tool, or range…";
-  searchInput.className = "pi-recovery-search";
+  searchInput.className = "pi-recovery-search pi-overlay-inline-control";
 
   const toolFilterSelect = document.createElement("select");
-  toolFilterSelect.className = "pi-recovery-filter-select";
+  toolFilterSelect.className = "pi-recovery-filter-select pi-overlay-inline-control";
 
   const sortButton = document.createElement("button");
   sortButton.type = "button";
@@ -231,7 +231,7 @@ export async function showRecoveryDialog(opts: {
   retentionInput.type = "number";
   retentionInput.min = "5";
   retentionInput.max = "120";
-  retentionInput.className = "pi-recovery-retention__input";
+  retentionInput.className = "pi-recovery-retention__input pi-overlay-inline-control";
 
   const retentionSuffix = document.createElement("span");
   retentionSuffix.className = "pi-recovery-retention__suffix";

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -122,7 +122,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
   filterLabel.textContent = "Filter";
 
   const filterSelect = document.createElement("select");
-  filterSelect.className = "pi-files-dialog__filter-select";
+  filterSelect.className = "pi-files-dialog__filter-select pi-overlay-inline-control";
   filterLabel.appendChild(filterSelect);
 
   const quickFilters = document.createElement("div");

--- a/src/ui/theme/components/files.css
+++ b/src/ui/theme/components/files.css
@@ -45,17 +45,6 @@
 .pi-files-dialog__filter-select {
   min-width: 240px;
   max-width: min(100%, 320px);
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-sm);
-  background: var(--white-alpha-65);
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-  padding: 5px 8px;
-}
-
-.pi-files-dialog__filter-select:disabled {
-  opacity: 0.6;
 }
 
 .pi-files-dialog__quick-filters {

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -77,6 +77,17 @@
   outline: none;
 }
 
+.pi-overlay-inline-control {
+  border: 1px solid var(--alpha-10);
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  background: var(--white-alpha-65);
+  color: var(--foreground);
+  outline: none;
+}
+
 .pi-overlay-textarea {
   min-height: 220px;
   max-height: 42vh;
@@ -87,10 +98,16 @@
 .pi-overlay-textarea:focus-visible,
 .pi-overlay-input:focus,
 .pi-overlay-input:focus-visible,
+.pi-overlay-inline-control:focus,
+.pi-overlay-inline-control:focus-visible,
 .pi-overlay-btn:focus-visible,
 .pi-overlay-tab:focus-visible {
   border-color: var(--green-alpha-25);
   box-shadow: 0 0 0 2px var(--pi-green-lighter);
+}
+
+.pi-overlay-inline-control:disabled {
+  opacity: 0.6;
 }
 
 .pi-overlay-footer {

--- a/src/ui/theme/overlays/recovery.css
+++ b/src/ui/theme/overlays/recovery.css
@@ -16,38 +16,11 @@
 .pi-recovery-search {
   flex: 1;
   min-width: 120px;
-  padding: 5px 8px;
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-sm);
-  background: var(--white-alpha-65);
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-  outline: none;
-}
-
-.pi-recovery-search:focus {
-  border-color: var(--green-alpha-25);
-}
-
-.pi-recovery-search:disabled {
-  opacity: 0.6;
 }
 
 .pi-recovery-filter-select {
   min-width: 110px;
   max-width: 170px;
-  padding: 5px 8px;
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-sm);
-  background: var(--white-alpha-65);
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-}
-
-.pi-recovery-filter-select:disabled {
-  opacity: 0.6;
 }
 
 .pi-recovery-sort-btn {
@@ -77,17 +50,8 @@
 .pi-recovery-retention__input {
   width: 60px;
   padding: 4px 6px;
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-sm);
-  background: var(--white-alpha-65);
-  color: var(--foreground);
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
   text-align: center;
-}
-
-.pi-recovery-retention__input:disabled {
-  opacity: 0.6;
 }
 
 .pi-recovery-status {


### PR DESCRIPTION
## Summary

Phase 6 for #175: unify compact inline control styling (search/select/retention/filter controls) on shared overlay primitives.

## Changes

- Added shared compact control class in overlay primitives:
  - `pi-overlay-inline-control`
  - Includes common border/background/font/padding/focus/disabled treatment.
- Applied shared class to existing controls:
  - Recovery overlay search input
  - Recovery overlay tool-filter select
  - Recovery overlay retention input
  - Files dialog filter select
- Removed duplicated style declarations now owned by the shared primitive from:
  - `recovery.css`
  - `files.css`

## Why

This continues #175 consistency work by reducing per-overlay control styling drift and centralizing common input/select treatment in the shared overlay layer.

## Files

- `src/ui/theme/overlays/primitives.css`
- `src/commands/builtins/recovery-overlay.ts`
- `src/ui/files-dialog.ts`
- `src/ui/theme/overlays/recovery.css`
- `src/ui/theme/components/files.css`

## Validation

- `npm run check`
- `npm run build`
- Manual taskpane smoke via `agent-browser`:
  - `/files`
  - `/backups`

Refs: #175
