### PR TITLE
refactor(taskpane): centralize busy slash-command policy

### DIFF
--- a/src/commands/busy-command-policy.ts
+++ b/src/commands/busy-command-policy.ts
@@ -1,0 +1,24 @@
+/**
+ * Slash-command policy for command execution while a runtime is busy.
+ *
+ * Keep this list centralized so keyboard-enter execution and command-menu
+ * execution cannot drift.
+ */
+
+import { INTEGRATIONS_COMMAND_NAME } from "../integrations/naming.js";
+
+const BUSY_ALLOWED_COMMANDS = new Set<string>([
+  "compact",
+  "new",
+  "rules",
+  "resume",
+  "history",
+  "reopen",
+  "yolo",
+  "extensions",
+  INTEGRATIONS_COMMAND_NAME,
+]);
+
+export function isBusyAllowedCommand(commandName: string): boolean {
+  return BUSY_ALLOWED_COMMANDS.has(commandName);
+}

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -46,6 +46,7 @@ import {
   type RecoveryCheckpointSummary,
 } from "../commands/builtins/overlays.js";
 import { wireCommandMenu } from "../commands/command-menu.js";
+import { isBusyAllowedCommand } from "../commands/busy-command-policy.js";
 import { commandRegistry } from "../commands/types.js";
 import {
   getUserRules,
@@ -65,7 +66,6 @@ import {
   INTEGRATION_IDS,
 } from "../integrations/catalog.js";
 import { PI_INTEGRATIONS_CHANGED_EVENT } from "../integrations/events.js";
-import { INTEGRATIONS_COMMAND_NAME } from "../integrations/naming.js";
 import { getExternalToolsEnabled, resolveConfiguredIntegrationIds } from "../integrations/store.js";
 import { buildSystemPrompt } from "../prompt/system-prompt.js";
 import {
@@ -123,18 +123,6 @@ import {
 } from "./session-runtime-manager.js";
 import { doesOverlayClaimEscape } from "../utils/escape-guard.js";
 import { isRecord } from "../utils/type-guards.js";
-
-const BUSY_ALLOWED_COMMANDS = new Set([
-  "compact",
-  "new",
-  "rules",
-  "resume",
-  "history",
-  "reopen",
-  "yolo",
-  "extensions",
-  INTEGRATIONS_COMMAND_NAME,
-]);
 
 function showErrorBanner(errorRoot: HTMLElement, message: string): void {
   render(renderError(message), errorRoot);
@@ -1368,7 +1356,7 @@ export async function initTaskpane(opts: {
     }
 
     const busy = activeRuntime.agent.state.isStreaming || activeRuntime.actionQueue.isBusy();
-    if (busy && !BUSY_ALLOWED_COMMANDS.has(name)) {
+    if (busy && !isBusyAllowedCommand(name)) {
       showToast(`Can't run /${name} while Pi is busy`);
       return;
     }

--- a/src/taskpane/keyboard-shortcuts/editor-actions.ts
+++ b/src/taskpane/keyboard-shortcuts/editor-actions.ts
@@ -6,8 +6,9 @@ import type { Agent, AgentMessage } from "@mariozechner/pi-agent-core";
 
 import type { PiSidebar } from "../../ui/pi-sidebar.js";
 import { showToast } from "../../ui/toast.js";
-import { commandRegistry } from "../../commands/types.js";
 import { hideCommandMenu } from "../../commands/command-menu.js";
+import { isBusyAllowedCommand } from "../../commands/busy-command-policy.js";
+import { commandRegistry } from "../../commands/types.js";
 
 export type QueueDisplay = {
   add: (type: "steer" | "follow-up", text: string) => void;
@@ -17,8 +18,6 @@ export type ActionQueue = {
   enqueueCommand: (name: string, args: string) => void;
   isBusy: () => boolean;
 };
-
-const BUSY_ALLOWED_COMMANDS = new Set(["compact", "new", "resume", "reopen", "yolo"]);
 
 export function handleSlashCommandExecution(args: {
   event: KeyboardEvent;
@@ -57,7 +56,7 @@ export function handleSlashCommandExecution(args: {
   const actionQueue = getActiveActionQueue();
   const busy = isStreaming || actionQueue?.isBusy() === true;
 
-  if (busy && !BUSY_ALLOWED_COMMANDS.has(cmdName)) {
+  if (busy && !isBusyAllowedCommand(cmdName)) {
     event.preventDefault();
     event.stopImmediatePropagation();
     showToast(`Can't run /${cmdName} while Pi is busy`);

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -157,14 +157,20 @@ void test("settings builtins include yolo execution-mode command", async () => {
   assert.match(settingsSource, /Usage:\s*\/yolo/);
 });
 
-void test("keyboard slash-command busy allowlist includes /yolo", async () => {
+void test("slash-command busy policy is centralized and includes /yolo", async () => {
   const keyboardActionsSource = await readFile(
     new URL("../src/taskpane/keyboard-shortcuts/editor-actions.ts", import.meta.url),
     "utf8",
   );
+  const initSource = await readFile(new URL("../src/taskpane/init.ts", import.meta.url), "utf8");
+  const busyPolicySource = await readFile(new URL("../src/commands/busy-command-policy.ts", import.meta.url), "utf8");
 
-  assert.match(keyboardActionsSource, /BUSY_ALLOWED_COMMANDS/);
-  assert.match(keyboardActionsSource, /"yolo"/);
+  assert.match(keyboardActionsSource, /isBusyAllowedCommand/);
+  assert.match(initSource, /isBusyAllowedCommand/);
+
+  assert.match(busyPolicySource, /"yolo"/);
+  assert.match(busyPolicySource, /"rules"/);
+  assert.match(busyPolicySource, /INTEGRATIONS_COMMAND_NAME/);
 });
 
 void test("taskpane init wires recovery overlay opener", async () => {


### PR DESCRIPTION
## Summary
- add a shared busy-command policy module: `src/commands/busy-command-policy.ts`
- remove duplicated busy allowlists from:
  - `src/taskpane/init.ts`
  - `src/taskpane/keyboard-shortcuts/editor-actions.ts`
- route both command execution paths through `isBusyAllowedCommand(...)` to prevent drift
- update registry coverage test to assert centralization and key command coverage (`/yolo`, `rules`, integrations command)

## Why
- this is the first post-#191/#212 cleanup slice from #179 prep
- keeps keyboard-enter slash command behavior aligned with command-menu dispatch behavior

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
- `npm run test:models`

Part of #179
