### PR TITLE
chore(deploy): skip non-PR branch vercel builds

### DIFF
--- a/docs/deploy-vercel.md
+++ b/docs/deploy-vercel.md
@@ -15,6 +15,7 @@ Vercel is a good default host because it’s free for OSS/hobby usage and handle
 
 This repo includes `vercel.json` with:
 - `outputDirectory: dist`
+- an `ignoreCommand` that skips non-PR branch deployments (builds still run for `main` and pull requests)
 - `/proxy` rewrite to `/proxy.sh` (bootstrap script for `npx pi-for-excel-proxy`)
 - a header rule to disable caching for `/src/taskpane.html` to make updates propagate reliably
 - an enforced `Content-Security-Policy` on `/src/taskpane.html` (Office.js + provider/auth endpoints + localhost proxy).

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "npm run build",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; if [ -n \"$VERCEL_GIT_PULL_REQUEST_ID\" ]; then exit 1; fi; if [ -z \"$VERCEL_GIT_COMMIT_REF\" ]; then exit 1; fi; echo \"Skipping non-PR branch deploy for $VERCEL_GIT_COMMIT_REF\"; exit 0",
   "outputDirectory": "dist",
   "rewrites": [
     {


### PR DESCRIPTION
## Summary
- add `ignoreCommand` to `vercel.json` to reduce hobby deployment churn
- keep deployments enabled for:
  - `main`
  - pull requests
- skip deployments for non-PR branch pushes
- document the behavior in `docs/deploy-vercel.md`

## Why
Vercel Hobby has daily deployment limits; this preserves production + PR previews while preventing branch-push spam from consuming quota.

## Validation
- pre-commit hooks passed (`npm run lint`, `npm run typecheck`)
- JSON parse check for `vercel.json`
