### PR TITLE
feat(ui): improve utilities menu discoverability and grouping

### DIFF
--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -1242,6 +1242,10 @@ export async function initTaskpane(opts: {
     });
   };
 
+  const openExtensionsManager = () => {
+    showExtensionsDialog(extensionManager);
+  };
+
   const openRecoveryDialog = async (): Promise<void> => {
     const workbookContext = await resolveWorkbookContext();
 
@@ -1334,9 +1338,7 @@ export async function initTaskpane(opts: {
     },
     getExecutionMode: () => Promise.resolve(getExecutionMode()),
     setExecutionMode,
-    openExtensionsManager: () => {
-      showExtensionsDialog(extensionManager);
-    },
+    openExtensionsManager,
     openIntegrationsManager,
   });
 
@@ -1423,6 +1425,9 @@ export async function initTaskpane(opts: {
   };
   sidebar.onOpenIntegrations = () => {
     openIntegrationsManager();
+  };
+  sidebar.onOpenExtensions = () => {
+    openExtensionsManager();
   };
   sidebar.onOpenFiles = () => {
     void showFilesWorkspaceDialog();

--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -110,6 +110,7 @@ export class PiSidebar extends LitElement {
   @property({ attribute: false }) onCloseOtherTabs?: (runtimeId: string) => void;
   @property({ attribute: false }) onOpenRules?: () => void;
   @property({ attribute: false }) onOpenIntegrations?: () => void;
+  @property({ attribute: false }) onOpenExtensions?: () => void;
   @property({ attribute: false }) onOpenSettings?: () => void;
   @property({ attribute: false }) onOpenFiles?: () => void;
   @property({ attribute: false }) onFilesDrop?: (files: File[]) => void;
@@ -687,12 +688,12 @@ export class PiSidebar extends LitElement {
           <button
             class="pi-utilities-btn"
             @click=${() => this._toggleUtilitiesMenu()}
-            aria-label="Menu"
-            title="Menu"
+            aria-label="Settings and tools"
+            title="Settings and tools"
             aria-haspopup="menu"
             aria-controls=${this._utilitiesMenuId}
             aria-expanded=${this._utilitiesMenuOpen ? "true" : "false"}
-          >⋯</button>
+          >⚙</button>
           ${this._utilitiesMenuOpen ? this._renderUtilitiesMenu() : nothing}
         </div>
       </div>
@@ -847,15 +848,25 @@ export class PiSidebar extends LitElement {
 
   private _renderUtilitiesMenu() {
     return html`
-      <div class="pi-utilities-menu" id=${this._utilitiesMenuId} role="menu" aria-label="Utilities menu">
+      <div class="pi-utilities-menu" id=${this._utilitiesMenuId} role="menu" aria-label="Settings and tools">
+        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenSettings?.(); }}>
+          Settings…
+        </button>
         <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenRules?.(); }}>
           Rules & conventions…
         </button>
         <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenIntegrations?.(); }}>
           ${INTEGRATIONS_LABEL}…
         </button>
-        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenSettings?.(); }}>
-          Settings…
+        ${this.onOpenExtensions
+          ? html`
+            <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenExtensions?.(); }}>
+              Extensions…
+            </button>
+          `
+          : nothing}
+        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenFiles?.(); }}>
+          Files…
         </button>
 
         <div class="pi-utilities-menu__divider" role="separator"></div>
@@ -870,17 +881,14 @@ export class PiSidebar extends LitElement {
             </button>
           `
           : nothing}
-        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenShortcuts?.(); }}>
-          Keyboard shortcuts…
+        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenRecovery?.(); }}>
+          Backups…
         </button>
 
         <div class="pi-utilities-menu__divider" role="separator"></div>
 
-        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenRecovery?.(); }}>
-          Backups…
-        </button>
-        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenFiles?.(); }}>
-          Files workspace (Beta)…
+        <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenShortcuts?.(); }}>
+          Keyboard shortcuts…
         </button>
       </div>
     `;

--- a/src/ui/theme/components/tabs.css
+++ b/src/ui/theme/components/tabs.css
@@ -304,7 +304,7 @@
   );
 }
 
-/* ── Utilities menu (⋯ in tab strip) ── */
+/* ── Utilities menu trigger (gear in tab strip) ── */
 
 .pi-utilities-anchor {
   position: relative;
@@ -312,26 +312,33 @@
 }
 
 .pi-utilities-btn {
-  border: none;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: var(--text-md);
-  width: 20px;
-  height: 20px;
-  border-radius: var(--radius-xs);
+  border: 1px solid var(--alpha-10);
+  background: var(--white-alpha-35);
+  color: var(--foreground);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  letter-spacing: 1px;
+  line-height: 1;
   flex-shrink: 0;
-  transition: background var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-fast);
+  box-shadow: var(--glass-highlight), var(--glass-inner-shadow);
+  transition: background var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-fast), border-color var(--duration-fast);
 }
 
 .pi-utilities-btn:hover {
-  background: var(--white-alpha-45);
+  background: var(--white-alpha-55);
   color: var(--foreground);
-  box-shadow: var(--glass-highlight), var(--glass-inner-shadow);
+  box-shadow: var(--glass-shadow), var(--glass-highlight), var(--glass-inner-shadow);
+}
+
+.pi-utilities-btn[aria-expanded="true"] {
+  background: var(--white-alpha-55);
+  border-color: var(--green-alpha-25);
 }
 
 

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -138,6 +138,22 @@ void test("taskpane init wires Files workspace opener when sidebar callback is p
   );
 });
 
+void test("taskpane init wires extensions menu opener", async () => {
+  const initSource = await readFile(new URL("../src/taskpane/init.ts", import.meta.url), "utf8");
+
+  assert.match(initSource, /const openExtensionsManager = \(\) =>/);
+  assert.match(initSource, /sidebar\.onOpenExtensions\s*=\s*\(\)\s*=>\s*\{\s*openExtensionsManager\(\);\s*\};/);
+});
+
+void test("sidebar utilities menu includes extensions and files labels", async () => {
+  const sidebarSource = await readFile(new URL("../src/ui/pi-sidebar.ts", import.meta.url), "utf8");
+
+  assert.match(sidebarSource, /aria-label="Settings and tools"/);
+  assert.match(sidebarSource, /Extensions…/);
+  assert.match(sidebarSource, /Files…/);
+  assert.doesNotMatch(sidebarSource, /Files workspace \(Beta\)…/);
+});
+
 void test("session builtins include recovery and manual-backup commands", async () => {
   const sessionSource = await readFile(new URL("../src/commands/builtins/session.ts", import.meta.url), "utf8");
 


### PR DESCRIPTION
## Summary
- make the utilities trigger more discoverable by switching from subtle `⋯` to a clearer gear-style control with stronger visual affordance
- regroup utilities menu items into clearer sections:
  - config/discovery: Settings, Rules & conventions, Integrations, Extensions, Files
  - session/recovery: Resume, Reopen last closed, Backups
  - help: Keyboard shortcuts
- rename `Files workspace (Beta)…` to `Files…` in the utilities menu
- wire a new sidebar callback for opening Extensions from the utilities menu

## Why
- addresses #173 by improving menu discoverability, reducing grouping ambiguity, and exposing Extensions directly for non-slash users

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
- `npm run test:models`

Closes #173
