### PR TITLE
docs(release): add host smoke-run templates

### DIFF
--- a/docs/release-smoke-runs/README.md
+++ b/docs/release-smoke-runs/README.md
@@ -18,3 +18,15 @@ Examples:
 - pass/fail/blocked with short rationale and evidence pointers
 
 Keep each run append-only; create a new file for each run instead of rewriting older runs.
+
+## Templates
+
+- macOS host run: `docs/release-smoke-runs/templates/macos-host-smoke-template.md`
+- Windows host run: `docs/release-smoke-runs/templates/windows-host-smoke-template.md`
+
+Recommended workflow:
+
+1. Copy the matching template into a dated file in this folder.
+2. Fill each covered checklist row with `Pass` / `Fail` / `Blocked`.
+3. Link screenshots/logs directly in the evidence column.
+4. Leave unresolved failures with an owner and next action.

--- a/docs/release-smoke-runs/templates/macos-host-smoke-template.md
+++ b/docs/release-smoke-runs/templates/macos-host-smoke-template.md
@@ -1,0 +1,45 @@
+# Smoke Run — macOS host (template)
+
+- Date: YYYY-MM-DD
+- Commit: `git rev-parse --short HEAD`
+- Environment: macOS version + Excel version/build + provider used
+- Checklist source: `docs/release-smoke-test-checklist.md`
+
+## Setup notes
+
+- Manifest used: `manifest.prod.xml` or `manifest.xml`
+- Proxy mode: enabled/disabled (+ URL if enabled)
+- Bridges enabled: tmux/python/none
+
+## Checklist coverage
+
+| ID | Status (Pass/Fail/Blocked) | Evidence (screenshot/log) | Notes |
+|---|---|---|---|
+| C-1 |  |  |  |
+| C-2 |  |  |  |
+| C-3 |  |  |  |
+| C-4 |  |  |  |
+| C-5 |  |  |  |
+| P-1 |  |  |  |
+| P-2 |  |  |  |
+| P-3 |  |  |  |
+| P-4 |  |  |  |
+| I-1 |  |  |  |
+| I-3 (macOS leg) |  |  |  |
+| I-4 (macOS leg) |  |  |  |
+| H-1 |  |  |  |
+| H-2 |  |  |  |
+| H-4 |  |  |  |
+
+## Failure details (if any)
+
+### <ID>
+- Symptom:
+- Repro steps:
+- Expected vs actual:
+- Follow-up issue/PR:
+
+## Exit criteria
+
+- [ ] No unresolved `Fail` rows for macOS-required IDs
+- [ ] Any `Blocked` rows have explicit blocker + owner + next step

--- a/docs/release-smoke-runs/templates/windows-host-smoke-template.md
+++ b/docs/release-smoke-runs/templates/windows-host-smoke-template.md
@@ -1,0 +1,40 @@
+# Smoke Run — Windows host (template)
+
+- Date: YYYY-MM-DD
+- Commit: `git rev-parse --short HEAD`
+- Environment: Windows version + Excel version/build + provider used
+- Checklist source: `docs/release-smoke-test-checklist.md`
+
+## Setup notes
+
+- Manifest used: `manifest.prod.xml` or `manifest.xml`
+- Install path followed: `docs/install.md` Windows flow
+- Proxy mode: enabled/disabled (+ URL if enabled)
+
+## Checklist coverage
+
+| ID | Status (Pass/Fail/Blocked) | Evidence (screenshot/log) | Notes |
+|---|---|---|---|
+| I-2 |  |  |  |
+| I-3 (Windows leg) |  |  |  |
+| I-4 (Windows leg) |  |  |  |
+
+## Optional Windows sanity checks
+
+| ID | Status (Pass/Fail/Blocked) | Evidence (screenshot/log) | Notes |
+|---|---|---|---|
+| C-1 |  |  |  |
+| P-1 |  |  |  |
+
+## Failure details (if any)
+
+### <ID>
+- Symptom:
+- Repro steps:
+- Expected vs actual:
+- Follow-up issue/PR:
+
+## Exit criteria
+
+- [ ] Required Windows rows covered (`I-2`, `I-3`, `I-4`)
+- [ ] Any `Blocked` rows have explicit blocker + owner + next step

--- a/docs/release-smoke-test-checklist.md
+++ b/docs/release-smoke-test-checklist.md
@@ -16,6 +16,7 @@ This checklist maps directly to issue [#179](https://github.com/tmustier/pi-for-
 ## Run logs
 
 - Store run evidence in `docs/release-smoke-runs/`.
+- Host run templates live in `docs/release-smoke-runs/templates/`.
 - Latest preflight run: `docs/release-smoke-runs/2026-02-14-macos-preflight.md`.
 - Latest CLI validation run: `docs/release-smoke-runs/2026-02-14-cli-validation.md`.
 


### PR DESCRIPTION
## Summary
- add reusable host smoke-run templates for #179 execution:
  - `docs/release-smoke-runs/templates/macos-host-smoke-template.md`
  - `docs/release-smoke-runs/templates/windows-host-smoke-template.md`
- update smoke-run README with template usage workflow
- update release smoke checklist to point to the new host templates

## Validation
- npm run check

Refs #179