### PR TITLE
refactor(ui): apply danger variant to destructive overlay actions

### DIFF
--- a/src/commands/builtins/extensions-overlay.ts
+++ b/src/commands/builtins/extensions-overlay.ts
@@ -608,7 +608,10 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
       });
     });
 
-    const uninstallButton = createOverlayButton({ text: "Uninstall" });
+    const uninstallButton = createOverlayButton({
+      text: "Uninstall",
+      className: "pi-overlay-btn--danger",
+    });
     uninstallButton.addEventListener("click", () => {
       const confirmed = window.confirm(`Uninstall extension "${status.name}"?`);
       if (!confirmed) {

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -184,7 +184,10 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
     actions.className = "pi-overlay-actions pi-overlay-actions--wrap";
 
     const testButton = createOverlayButton({ text: "Test" });
-    const removeButton = createOverlayButton({ text: "Remove" });
+    const removeButton = createOverlayButton({
+      text: "Remove",
+      className: "pi-overlay-btn--danger",
+    });
 
     testButton.addEventListener("click", () => {
       void runAction(async () => {

--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -210,7 +210,7 @@ export async function showRecoveryDialog(opts: {
 
   const clearButton = document.createElement("button");
   clearButton.type = "button";
-  clearButton.className = "pi-overlay-btn pi-overlay-btn--ghost";
+  clearButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--danger";
   clearButton.textContent = "Clear all";
 
   const statusText = document.createElement("span");
@@ -357,7 +357,7 @@ export async function showRecoveryDialog(opts: {
 
       const deleteButton = document.createElement("button");
       deleteButton.type = "button";
-      deleteButton.className = "pi-overlay-btn pi-overlay-btn--ghost";
+      deleteButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--danger";
       deleteButton.textContent = "Delete";
 
       restoreButton.addEventListener("click", () => {


### PR DESCRIPTION
## Summary

Phase 7 for #175: make destructive overlay actions visually consistent by using the shared danger button variant.

## Changes

Applied `pi-overlay-btn--danger` to destructive actions that previously looked like neutral ghost buttons:

- Recovery overlay
  - `Clear all`
  - per-item `Delete`
- Extensions overlay
  - `Uninstall`
- Integrations overlay
  - MCP server `Remove`

## Why

Issue #175 calls out button-pattern inconsistency. This slice makes destructive actions consistently recognizable across overlays and aligns with the shared button system introduced in earlier phases.

## Files

- `src/commands/builtins/recovery-overlay.ts`
- `src/commands/builtins/extensions-overlay.ts`
- `src/commands/builtins/integrations-overlay.ts`

## Validation

- `npm run check`
- `npm run build`
- Manual taskpane smoke via `agent-browser`:
  - `/backups`
  - `/extensions`
  - `/integrations`

Refs: #175
