### PR TITLE
fix(ui): constrain heading sizes in tool card markdown & strip YAML frontmatter

### DIFF
--- a/src/ui/theme/content/tool-card-markdown.css
+++ b/src/ui/theme/content/tool-card-markdown.css
@@ -10,6 +10,17 @@
 .pi-tool-card__markdown markdown-block { font-size: var(--text-sm); line-height: 1.5; }
 .pi-tool-card__markdown markdown-block p { font-size: var(--text-sm); margin: 0 0 6px; }
 
+/* Heading scale — compact for sidebar tool cards */
+.pi-tool-card__markdown h1 { font-size: var(--text-sm); font-weight: 700; line-height: 1.3; margin: 10px 0 4px; }
+.pi-tool-card__markdown h2 { font-size: var(--text-sm); font-weight: 700; line-height: 1.35; margin: 8px 0 4px; }
+.pi-tool-card__markdown h3 { font-size: var(--text-sm); font-weight: 700; line-height: 1.4; margin: 6px 0 3px; }
+.pi-tool-card__markdown h4,
+.pi-tool-card__markdown h5,
+.pi-tool-card__markdown h6 { font-size: var(--text-sm); font-weight: 600; line-height: 1.4; margin: 6px 0 3px; }
+.pi-tool-card__markdown h1:first-child,
+.pi-tool-card__markdown h2:first-child,
+.pi-tool-card__markdown h3:first-child { margin-top: 0; }
+
 /* Tables: compact sizing for sidebar width */
 .pi-tool-card__markdown table {
   font-size: var(--text-sm);


### PR DESCRIPTION
## Problem

Markdown rendered inside tool card results (e.g. extension output from GitHub Fetcher) had two issues:

1. **Headings rendered at browser defaults** — no h1–h6 size overrides existed for `.pi-tool-card__markdown`, so headings used ~2em/~1.5em instead of sidebar-appropriate sizes.
2. **YAML frontmatter rendered as giant headings** — marked.js interpreted the closing `---` delimiter as a setext heading marker, turning frontmatter fields (`name: xlsx`, `description: ...`) into an `<h2>`.

## Fix

- **`tool-card-markdown.css`**: Added h1–h6 rules capped at `--text-sm` to match surrounding tool card typography.
- **`tool-renderers.ts`**: Added `stripYamlFrontmatter()` to remove the `---`-delimited YAML block before markdown rendering.

## Before / After

| Before | After |
|--------|-------|
| YAML frontmatter fields render as massive bold headings | Frontmatter stripped; content starts at first real markdown |
| `## Heading` inside tool cards uses browser-default 1.5em | Headings constrained to `--text-sm` with appropriate weight |