### PR TITLE
refactor(ui): standardize recovery toolbar with overlay primitives

### DIFF
--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -190,7 +190,10 @@ export async function showRecoveryDialog(opts: {
   // -- Toolbar --
 
   const toolbar = document.createElement("div");
-  toolbar.className = "pi-recovery-toolbar";
+  toolbar.className = "pi-overlay-toolbar";
+
+  const toolbarActions = document.createElement("div");
+  toolbarActions.className = "pi-overlay-toolbar-actions";
 
   const fullBackupButton = document.createElement("button");
   fullBackupButton.type = "button";
@@ -213,10 +216,12 @@ export async function showRecoveryDialog(opts: {
   clearButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--danger";
   clearButton.textContent = "Clear all";
 
-  const statusText = document.createElement("span");
-  statusText.className = "pi-recovery-status";
+  toolbarActions.append(fullBackupButton, refreshButton, exportButton, clearButton);
 
-  toolbar.append(fullBackupButton, refreshButton, exportButton, clearButton, statusText);
+  const statusText = document.createElement("span");
+  statusText.className = "pi-overlay-toolbar-status";
+
+  toolbar.append(toolbarActions, statusText);
 
   // -- Retention --
 

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -144,6 +144,27 @@
   margin-top: 8px;
 }
 
+.pi-overlay-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pi-overlay-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pi-overlay-toolbar-status {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted-foreground);
+}
+
 .pi-overlay-btn {
   border-radius: var(--radius-sm);
   padding: 7px 12px;

--- a/src/ui/theme/overlays/recovery.css
+++ b/src/ui/theme/overlays/recovery.css
@@ -28,14 +28,6 @@
   flex-shrink: 0;
 }
 
-/* Toolbar */
-
-.pi-recovery-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 /* Retention row */
 
 .pi-recovery-retention {
@@ -52,13 +44,6 @@
   padding: 4px 6px;
   font-family: var(--font-mono);
   text-align: center;
-}
-
-.pi-recovery-status {
-  margin-left: auto;
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--muted-foreground);
 }
 
 .pi-recovery-list {


### PR DESCRIPTION
## Summary

Phase 8 for #175: normalize the backups overlay toolbar onto shared overlay primitives.

## Changes

- Added shared toolbar primitives in `overlays/primitives.css`:
  - `.pi-overlay-toolbar`
  - `.pi-overlay-toolbar-actions`
  - `.pi-overlay-toolbar-status`
- Migrated recovery overlay toolbar structure to use the shared classes:
  - toolbar wrapper now uses `.pi-overlay-toolbar`
  - grouped action buttons in `.pi-overlay-toolbar-actions`
  - status text now uses `.pi-overlay-toolbar-status`
- Removed recovery-only duplicated toolbar/status styles from `overlays/recovery.css`.

## Why

Issue #175 targets consistency across overlays. This slice removes a local style island and consolidates toolbar/status behavior into shared overlay primitives so future overlays can reuse the same pattern.

## Files

- `src/commands/builtins/recovery-overlay.ts`
- `src/ui/theme/overlays/primitives.css`
- `src/ui/theme/overlays/recovery.css`

## Validation

- `npm run check`
- `npm run build`
- Manual smoke via `agent-browser`:
  - `/backups`

Refs: #175
