### PR TITLE
chore(release): bump to 0.6.0-pre + proxy 0.2.0-pre

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel",
-  "version": "0.5.0-pre",
+  "version": "0.6.0-pre",
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {

--- a/pkg/proxy/package.json
+++ b/pkg/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel-proxy",
-  "version": "0.1.0",
+  "version": "0.2.0-pre",
   "description": "One-command local HTTPS proxy helper for Pi for Excel OAuth logins.",
   "type": "module",
   "bin": {

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -5,4 +5,4 @@
  */
 
 export const APP_NAME = "pi-for-excel";
-export const APP_VERSION = "0.5.0-pre";
+export const APP_VERSION = "0.6.0-pre";


### PR DESCRIPTION
## Summary
- bump app prerelease version to `0.6.0-pre`
- bump proxy CLI npm prerelease version to `0.2.0-pre`
- sync `APP_VERSION` metadata with `package.json`

## Validation
- npm run check
- npm run build
