### PR TITLE
refactor(ui): reuse inline row primitives for overlay filter controls

### DIFF
--- a/src/commands/builtins/integrations-overlay-elements.ts
+++ b/src/commands/builtins/integrations-overlay-elements.ts
@@ -80,7 +80,7 @@ export function createIntegrationsDialogElements(): IntegrationsDialogElements {
   webSearchStatus.className = "pi-integrations-web-search-status";
 
   const webSearchProviderRow = document.createElement("div");
-  webSearchProviderRow.className = "pi-integrations-web-search-provider-row";
+  webSearchProviderRow.className = "pi-integrations-web-search-provider-row pi-overlay-inline-row";
 
   const webSearchProviderSelect = document.createElement("select");
   webSearchProviderSelect.className = "pi-overlay-input";

--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -170,7 +170,7 @@ export async function showRecoveryDialog(opts: {
   // -- Search + filters --
 
   const searchRow = document.createElement("div");
-  searchRow.className = "pi-recovery-search-row";
+  searchRow.className = "pi-recovery-search-row pi-overlay-inline-row pi-overlay-inline-row--compact pi-overlay-inline-row--wrap";
 
   const searchInput = document.createElement("input");
   searchInput.type = "text";
@@ -226,7 +226,7 @@ export async function showRecoveryDialog(opts: {
   // -- Retention --
 
   const retentionRow = document.createElement("div");
-  retentionRow.className = "pi-recovery-retention";
+  retentionRow.className = "pi-recovery-retention pi-overlay-inline-row pi-overlay-inline-row--compact";
 
   const retentionLabel = document.createElement("label");
   retentionLabel.className = "pi-recovery-retention__label";

--- a/src/ui/theme/overlays/integrations.css
+++ b/src/ui/theme/overlays/integrations.css
@@ -67,12 +67,6 @@
   flex-wrap: wrap;
 }
 
-.pi-integrations-web-search-provider-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
 .pi-integrations-web-search-provider-row .pi-overlay-input {
   flex: 1;
 }

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -165,6 +165,20 @@
   color: var(--muted-foreground);
 }
 
+.pi-overlay-inline-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pi-overlay-inline-row--compact {
+  gap: 6px;
+}
+
+.pi-overlay-inline-row--wrap {
+  flex-wrap: wrap;
+}
+
 .pi-overlay-btn {
   border-radius: var(--radius-sm);
   padding: 7px 12px;

--- a/src/ui/theme/overlays/recovery.css
+++ b/src/ui/theme/overlays/recovery.css
@@ -6,13 +6,6 @@
 
 /* Search + filter row */
 
-.pi-recovery-search-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
 .pi-recovery-search {
   flex: 1;
   min-width: 120px;
@@ -31,9 +24,6 @@
 /* Retention row */
 
 .pi-recovery-retention {
-  display: flex;
-  align-items: center;
-  gap: 6px;
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   color: var(--muted-foreground);


### PR DESCRIPTION
## Summary

Phase 9 for #175: standardize search/filter-style inline rows in overlays using shared primitives.

## Changes

- Added shared inline row primitives in `overlays/primitives.css`:
  - `.pi-overlay-inline-row`
  - `.pi-overlay-inline-row--compact`
  - `.pi-overlay-inline-row--wrap`
- Migrated recovery overlay rows to use shared primitives:
  - search/filter row
  - retention row
- Migrated integrations web-search provider row to use shared inline row primitive.
- Removed duplicated local row layout declarations from:
  - `overlays/recovery.css`
  - `overlays/integrations.css`

## Why

Issue #175 tracks overlay/menu consistency. This slice removes repeated row layout patterns and consolidates them into shared overlay primitives, reducing CSS drift across overlays.

## Files

- `src/ui/theme/overlays/primitives.css`
- `src/commands/builtins/recovery-overlay.ts`
- `src/ui/theme/overlays/recovery.css`
- `src/commands/builtins/integrations-overlay-elements.ts`
- `src/ui/theme/overlays/integrations.css`

## Validation

- `npm run check`
- `npm run build`
- Manual smoke via `agent-browser`:
  - `/backups`
  - `/integrations`

Refs: #175
