### PR TITLE
refactor(ui): polish shared overlay primitive reuse

### DIFF
--- a/src/commands/builtins/extensions-overlay.ts
+++ b/src/commands/builtins/extensions-overlay.ts
@@ -258,7 +258,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
   localBridgeStatusRow.append(localBridgeStatusText, localBridgeStatusBadgeSlot);
 
   const localBridgeUrlRow = document.createElement("div");
-  localBridgeUrlRow.className = "pi-ext-local-bridge-url-row";
+  localBridgeUrlRow.className = "pi-overlay-input-actions-row";
 
   const localBridgeUrlInput = createOverlayInput({ placeholder: "https://localhost:3340" });
   const localBridgeSaveUrlButton = createOverlayButton({ text: "Save URL" });
@@ -505,7 +505,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
       const runtimeWarning = document.createElement("div");
       runtimeWarning.textContent =
         "Host-runtime fallback is enabled: this untrusted extension runs in host runtime. Disable fallback above to restore sandbox mode.";
-      runtimeWarning.className = "pi-ext-installed-row__error";
+      runtimeWarning.className = "pi-ext-installed-row__error pi-overlay-text-warning";
       details.appendChild(runtimeWarning);
     }
 
@@ -535,7 +535,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
       if (riskLabel) {
         const risk = document.createElement("span");
         risk.textContent = `(${riskLabel})`;
-        risk.className = "pi-ext-installed-row__risk";
+        risk.className = "pi-ext-installed-row__risk pi-overlay-text-warning";
         toggleText.append(" ", risk);
       }
 
@@ -580,7 +580,7 @@ export function showExtensionsDialog(manager: ExtensionRuntimeManager): void {
     if (status.lastError) {
       const errorLine = document.createElement("div");
       errorLine.textContent = `Last error: ${status.lastError}`;
-      errorLine.className = "pi-ext-installed-row__error";
+      errorLine.className = "pi-ext-installed-row__error pi-overlay-text-warning";
       details.appendChild(errorLine);
     }
 

--- a/src/commands/builtins/integrations-overlay-card.ts
+++ b/src/commands/builtins/integrations-overlay-card.ts
@@ -47,7 +47,7 @@ export function createIntegrationCard(args: {
   top.append(textWrap, badges);
 
   const warning = document.createElement("div");
-  warning.className = "pi-integrations-card__warning";
+  warning.className = "pi-integrations-card__warning pi-overlay-text-warning";
   warning.textContent = integration.warning ?? "";
   warning.hidden = !integration.warning;
 

--- a/src/commands/builtins/integrations-overlay-elements.ts
+++ b/src/commands/builtins/integrations-overlay-elements.ts
@@ -100,7 +100,7 @@ export function createIntegrationsDialogElements(): IntegrationsDialogElements {
   webSearchProviderRow.append(webSearchProviderSelect, webSearchProviderSignupLink);
 
   const webSearchInputRow = document.createElement("div");
-  webSearchInputRow.className = "pi-integrations-web-search-row";
+  webSearchInputRow.className = "pi-overlay-input-actions-row pi-overlay-input-actions-row--stack-mobile";
 
   const webSearchApiKeyInput = createOverlayInput({ placeholder: "API key", type: "password" });
   const webSearchSaveButton = createOverlayButton({ text: "Save key" });

--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -353,7 +353,7 @@ export async function showRecoveryDialog(opts: {
       meta.textContent = `${formatChangedLabel(checkpoint.changedCount)} · #${shortId(checkpoint.id)}`;
 
       const actions = document.createElement("div");
-      actions.className = "pi-recovery-item__actions";
+      actions.className = "pi-overlay-actions pi-overlay-actions--inline";
 
       const restoreButton = document.createElement("button");
       restoreButton.type = "button";

--- a/src/ui/theme/overlays/extensions.css
+++ b/src/ui/theme/overlays/extensions.css
@@ -27,13 +27,6 @@
   align-items: center;
 }
 
-.pi-ext-local-bridge-url-row {
-  display: grid;
-  grid-template-columns: 1fr auto auto auto;
-  gap: 8px;
-  align-items: center;
-}
-
 .pi-ext-install-url-row {
   display: grid;
   grid-template-columns: 160px 1fr auto;
@@ -128,11 +121,9 @@
 
 .pi-ext-installed-row__risk {
   font-size: var(--text-xs);
-  color: oklch(0.52 0.13 35);
 }
 
 .pi-ext-installed-row__error {
   font-family: var(--font-sans);
   font-size: var(--text-sm);
-  color: oklch(0.52 0.13 35);
 }

--- a/src/ui/theme/overlays/integrations.css
+++ b/src/ui/theme/overlays/integrations.css
@@ -58,7 +58,6 @@
 .pi-integrations-card__warning {
   font-family: var(--font-sans);
   font-size: var(--text-sm);
-  color: oklch(0.55 0.12 35);
 }
 
 .pi-integrations-card__toggles {
@@ -69,13 +68,6 @@
 
 .pi-integrations-web-search-provider-row .pi-overlay-input {
   flex: 1;
-}
-
-.pi-integrations-web-search-row {
-  display: grid;
-  grid-template-columns: 1fr auto auto auto;
-  gap: 8px;
-  align-items: center;
 }
 
 .pi-integrations-mcp-add-title {
@@ -113,7 +105,4 @@
     align-items: stretch;
   }
 
-  .pi-integrations-web-search-row {
-    grid-template-columns: 1fr;
-  }
 }

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -179,6 +179,17 @@
   flex-wrap: wrap;
 }
 
+.pi-overlay-input-actions-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.pi-overlay-text-warning {
+  color: oklch(0.54 0.12 35);
+}
+
 .pi-overlay-btn {
   border-radius: var(--radius-sm);
   padding: 7px 12px;
@@ -387,6 +398,16 @@
 
 .pi-overlay-actions--wrap {
   flex-wrap: wrap;
+}
+
+.pi-overlay-actions--inline {
+  margin-top: 0;
+}
+
+@media (max-width: 740px) {
+  .pi-overlay-input-actions-row--stack-mobile {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ── Conventions editor (rules overlay) ───────────────────────── */

--- a/src/ui/theme/overlays/recovery.css
+++ b/src/ui/theme/overlays/recovery.css
@@ -76,12 +76,6 @@
   color: var(--muted-foreground);
 }
 
-.pi-recovery-item__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
 .pi-recovery-item__restored {
   font-family: var(--font-mono);
   font-size: var(--text-xs);


### PR DESCRIPTION
## Summary

Polish pass after #175/#248 to reduce remaining overlay CSS duplication and tighten shared primitive reuse.

## Changes

### 1) Shared input-actions row primitive

Added to `overlays/primitives.css`:
- `.pi-overlay-input-actions-row`
- `.pi-overlay-input-actions-row--stack-mobile`

Applied to:
- Extensions local bridge URL row (`extensions-overlay.ts`)
- Integrations web-search API key row (`integrations-overlay-elements.ts`)

Removed duplicated local grid declarations from:
- `overlays/extensions.css`
- `overlays/integrations.css`

### 2) Shared warning text tone primitive

Added to `overlays/primitives.css`:
- `.pi-overlay-text-warning`

Applied to:
- Integrations card warning text (`integrations-overlay-card.ts`)
- Extensions risk labels + extension error/warning lines (`extensions-overlay.ts`)

Removed duplicated warning color declarations from:
- `overlays/integrations.css`
- `overlays/extensions.css`

### 3) Inline action-row modifier

Added to `overlays/primitives.css`:
- `.pi-overlay-actions--inline` (no top margin)

Applied to:
- Recovery per-item action row (`recovery-overlay.ts`)

Removed duplicated local action-row layout from:
- `overlays/recovery.css`

## Why

This keeps overlays on shared primitives, trims local one-off styles, and makes future overlay work less drift-prone.

## Files

- `src/ui/theme/overlays/primitives.css`
- `src/commands/builtins/extensions-overlay.ts`
- `src/commands/builtins/integrations-overlay-elements.ts`
- `src/commands/builtins/integrations-overlay-card.ts`
- `src/commands/builtins/recovery-overlay.ts`
- `src/ui/theme/overlays/extensions.css`
- `src/ui/theme/overlays/integrations.css`
- `src/ui/theme/overlays/recovery.css`

## Validation

- `npm run check`
- `npm run build`
- Manual smoke via `agent-browser`:
  - `/extensions`
  - `/integrations`
  - `/backups`

Follow-up polish for #175
