### PR TITLE
fix(ui): polish context tooltip copy and utilities gear trigger

### DIFF
--- a/src/taskpane/status-bar.ts
+++ b/src/taskpane/status-bar.ts
@@ -66,7 +66,7 @@ function renderStatusBar(
 
   // Context health: color + tooltip based on usage
   let ctxColor = "";
-  const ctxBaseTooltip = `How much of Pi's memory (context window) the conversation is using — ${totalTokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens. As this fills up, Pi may lose track of earlier details — start a new chat if quality drops.`;
+  const ctxBaseTooltip = `How much of Pi's memory (context window) the conversation is using — ${totalTokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens. as this fills up, Pi may get confused. Free up context with /compact or start a fresh chat with /new`;
   let ctxWarning = "";
   let ctxWarningText = "";
   if (pct > 100) {
@@ -131,7 +131,7 @@ function renderStatusBar(
   );
 
   el.innerHTML = `
-    <button type="button" class="pi-status-ctx pi-status-ctx--trigger pi-status-clickable has-tooltip" data-status-popover="${ctxPopoverText}" aria-label="Context usage ${pct}% of ${ctxLabel}"><span class="${ctxColor}">${pct}%</span> / ${ctxLabel}${usageDebug}<span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span><span class="pi-tooltip pi-tooltip--left">${ctxBaseTooltip}${ctxWarning}</span></button>
+    <button type="button" class="pi-status-ctx pi-status-ctx--trigger pi-status-clickable has-tooltip" data-status-popover="${ctxPopoverText}" aria-label="Context usage ${pct}% of ${ctxLabel}"><span class="${ctxColor}">${pct}%</span> / ${ctxLabel}${usageDebug}<span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span><span class="pi-tooltip pi-tooltip--left">${ctxBaseTooltip}${ctxWarning.length > 0 ? ` ${ctxWarning}` : ""}</span></button>
     ${lockBadge}
     ${rulesBadge}
     ${modeBadge}

--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -12,7 +12,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { Agent, AgentEvent } from "@mariozechner/pi-agent-core";
 import type { ToolResultMessage } from "@mariozechner/pi-ai";
 import type { StreamingMessageContainer } from "@mariozechner/pi-web-ui/dist/components/StreamingMessageContainer.js";
-import { ChevronRight } from "lucide";
+import { ChevronRight, Cog } from "lucide";
 import "./pi-input.js";
 import "./working-indicator.js";
 import { initToolGrouping } from "./tool-grouping.js";
@@ -693,7 +693,9 @@ export class PiSidebar extends LitElement {
             aria-haspopup="menu"
             aria-controls=${this._utilitiesMenuId}
             aria-expanded=${this._utilitiesMenuOpen ? "true" : "false"}
-          >⚙</button>
+          >
+            <span class="pi-utilities-btn__icon" aria-hidden="true">${icon(Cog, "sm")}</span>
+          </button>
           ${this._utilitiesMenuOpen ? this._renderUtilitiesMenu() : nothing}
         </div>
       </div>

--- a/src/ui/theme/components/tabs.css
+++ b/src/ui/theme/components/tabs.css
@@ -312,33 +312,63 @@
 }
 
 .pi-utilities-btn {
-  border: 1px solid var(--alpha-10);
-  background: var(--white-alpha-35);
-  color: var(--foreground);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  width: 24px;
-  height: 24px;
-  border-radius: var(--radius-sm);
+  border: 1px solid var(--alpha-12);
+  background:
+    linear-gradient(170deg, var(--white-alpha-70), var(--white-alpha-35));
+  color: var(--muted-foreground);
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   line-height: 1;
   flex-shrink: 0;
-  box-shadow: var(--glass-highlight), var(--glass-inner-shadow);
-  transition: background var(--duration-fast), color var(--duration-fast), box-shadow var(--duration-fast), border-color var(--duration-fast);
+  box-shadow: var(--glass-shadow), var(--glass-highlight), var(--glass-inner-shadow);
+  transition:
+    background var(--duration-fast),
+    color var(--duration-fast),
+    box-shadow var(--duration-fast),
+    border-color var(--duration-fast),
+    transform var(--duration-fast);
+}
+
+.pi-utilities-btn__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pi-utilities-btn__icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2.15;
 }
 
 .pi-utilities-btn:hover {
-  background: var(--white-alpha-55);
+  background: linear-gradient(170deg, var(--white-alpha-80), var(--white-alpha-50));
   color: var(--foreground);
-  box-shadow: var(--glass-shadow), var(--glass-highlight), var(--glass-inner-shadow);
+  border-color: var(--alpha-20);
+  box-shadow: var(--glass-shadow-lg), var(--glass-highlight), var(--glass-inner-shadow);
+  transform: translateY(-1px);
+}
+
+.pi-utilities-btn:active {
+  transform: translateY(0);
+}
+
+.pi-utilities-btn:focus-visible {
+  outline: none;
+  border-color: var(--green-alpha-30);
+  box-shadow: 0 0 0 2px var(--green-alpha-14), var(--glass-shadow), var(--glass-highlight), var(--glass-inner-shadow);
 }
 
 .pi-utilities-btn[aria-expanded="true"] {
-  background: var(--white-alpha-55);
-  border-color: var(--green-alpha-25);
+  background: linear-gradient(170deg, var(--white-alpha-80), var(--white-alpha-55));
+  color: var(--foreground);
+  border-color: var(--green-alpha-30);
+  box-shadow: 0 0 0 1px var(--green-alpha-20), var(--glass-shadow), var(--glass-highlight), var(--glass-inner-shadow);
 }
 
 


### PR DESCRIPTION
## Summary

Polishes the #250 UI follow-ups with no behavior changes:

- updates context usage tooltip copy to the requested sentence
- replaces the unicode utilities trigger glyph with a real Lucide gear icon
- refreshes the utilities trigger styling for better visual weight, hover feedback, and keyboard focus affordance in light/dark themes

## Changes

- `src/taskpane/status-bar.ts`
  - update `ctxBaseTooltip` wording
  - ensure warning text is appended with proper spacing in the tooltip
- `src/ui/pi-sidebar.ts`
  - render `${icon(Cog, "sm")}` instead of `⚙`
- `src/ui/theme/components/tabs.css`
  - improve `.pi-utilities-btn` sizing/contrast/states
  - add `.pi-utilities-btn__icon` sizing/stroke tuning
  - add explicit `:focus-visible` styling

## Validation

- `npm run lint`
- `npm run typecheck`
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/builtins-registry.test.ts`

Closes #250
