### PR TITLE
refactor(ui): relabel integrations surface as tools & mcp

### DIFF
--- a/src/commands/builtins/experimental-overlay.ts
+++ b/src/commands/builtins/experimental-overlay.ts
@@ -147,7 +147,7 @@ export function showExperimentalDialog(): void {
     title: "Experimental Features",
     subtitle:
       "These toggles are local to this browser profile. Use carefully — some are security-sensitive. "
-      + "Web Search and MCP are managed in /integrations.",
+      + "Web Search and MCP are managed in /integrations (Tools & MCP).",
   });
 
   const snapshots = getExperimentalFeatureSnapshots();

--- a/src/commands/builtins/experimental.ts
+++ b/src/commands/builtins/experimental.ts
@@ -167,7 +167,7 @@ function getLegacyFeatureRedirectMessage(featureArg: string): string | null {
     return null;
   }
 
-  return "External tools (including MCP) are managed in /integrations, not /experimental.";
+  return "External tools (including MCP) are managed in /integrations (Tools & MCP), not /experimental.";
 }
 
 function usageText(): string {

--- a/src/commands/builtins/integrations-overlay-elements.ts
+++ b/src/commands/builtins/integrations-overlay-elements.ts
@@ -1,7 +1,4 @@
 import {
-  INTEGRATIONS_LABEL,
-} from "../../integrations/naming.js";
-import {
   WEB_SEARCH_PROVIDERS,
   WEB_SEARCH_PROVIDER_INFO,
 } from "../../tools/web-search-config.js";
@@ -63,7 +60,7 @@ export function createIntegrationsDialogElements(): IntegrationsDialogElements {
 
   const integrationsSection = document.createElement("section");
   integrationsSection.className = "pi-overlay-section";
-  integrationsSection.appendChild(createOverlaySectionTitle(`${INTEGRATIONS_LABEL} bundles`));
+  integrationsSection.appendChild(createOverlaySectionTitle("Capability bundles"));
 
   const integrationsList = document.createElement("div");
   integrationsList.className = "pi-overlay-list";

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -10,6 +10,7 @@ import { dispatchIntegrationsChanged } from "../../integrations/events.js";
 import {
   INTEGRATIONS_LABEL,
   INTEGRATIONS_LABEL_LOWER,
+  INTEGRATIONS_MANAGER_LABEL,
 } from "../../integrations/naming.js";
 import {
   setExternalToolsEnabled,
@@ -87,9 +88,9 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
 
   const { header } = createOverlayHeader({
     onClose: closeOverlay,
-    closeLabel: "Close integrations",
-    title: INTEGRATIONS_LABEL,
-    subtitle: "Add capabilities like web search and external integrations. External tools are off by default.",
+    closeLabel: "Close tools and MCP",
+    title: INTEGRATIONS_MANAGER_LABEL,
+    subtitle: "Manage web search, page fetch, and MCP servers. External tools are off by default.",
   });
 
   const elements = createIntegrationsDialogElements();

--- a/src/commands/builtins/integrations.ts
+++ b/src/commands/builtins/integrations.ts
@@ -2,7 +2,7 @@
  * Builtin command for integration management UI.
  */
 
-import { INTEGRATIONS_COMMAND_NAME, INTEGRATIONS_LABEL_LOWER } from "../../integrations/naming.js";
+import { INTEGRATIONS_COMMAND_NAME, INTEGRATIONS_MANAGER_LABEL_LOWER } from "../../integrations/naming.js";
 import type { SlashCommand } from "../types.js";
 
 export interface IntegrationsCommandActions {
@@ -13,7 +13,7 @@ export function createIntegrationsCommands(actions: IntegrationsCommandActions):
   return [
     {
       name: INTEGRATIONS_COMMAND_NAME,
-      description: `Manage ${INTEGRATIONS_LABEL_LOWER} (web search, page fetch, MCP)`,
+      description: `Manage ${INTEGRATIONS_MANAGER_LABEL_LOWER} (web search, page fetch, MCP)`,
       source: "builtin",
       execute: () => {
         void actions.openIntegrationsManager();

--- a/src/integrations/naming.ts
+++ b/src/integrations/naming.ts
@@ -13,6 +13,9 @@ export const INTEGRATION_LABEL_LOWER = "integration";
 export const INTEGRATIONS_LABEL = "Integrations";
 export const INTEGRATIONS_LABEL_LOWER = "integrations";
 
+export const INTEGRATIONS_MANAGER_LABEL = "Tools & MCP";
+export const INTEGRATIONS_MANAGER_LABEL_LOWER = "tools & MCP";
+
 export const ACTIVE_INTEGRATIONS_PROMPT_HEADING = "Active Integrations";
 export const ACTIVE_INTEGRATIONS_TOOLTIP_PREFIX = "Active integrations";
 

--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -19,7 +19,7 @@ import { initToolGrouping } from "./tool-grouping.js";
 import { applyMessageStyleHooks } from "./message-style-hooks.js";
 import type { PiInput, PiInputAction } from "./pi-input.js";
 import { isDebugEnabled, formatK } from "../debug/debug.js";
-import { INTEGRATIONS_LABEL } from "../integrations/naming.js";
+import { INTEGRATIONS_MANAGER_LABEL } from "../integrations/naming.js";
 import {
   getPayloadStats,
   getLastContext,
@@ -858,7 +858,7 @@ export class PiSidebar extends LitElement {
           Rules & conventions…
         </button>
         <button role="menuitem" class="pi-utilities-menu__item" @click=${() => { this._closeUtilitiesMenu(); this.onOpenIntegrations?.(); }}>
-          ${INTEGRATIONS_LABEL}…
+          ${INTEGRATIONS_MANAGER_LABEL}…
         </button>
         ${this.onOpenExtensions
           ? html`


### PR DESCRIPTION
## Summary

Phase 1 for #176: clarify capability taxonomy by relabeling the `/integrations` UI surface as **Tools & MCP** while keeping command/API identifiers stable.

## Changes

- Added manager-facing naming constants in `src/integrations/naming.ts`:
  - `INTEGRATIONS_MANAGER_LABEL = "Tools & MCP"`
  - `INTEGRATIONS_MANAGER_LABEL_LOWER = "tools & MCP"`
- Updated user-facing entry points and text to use the new manager label:
  - Utilities menu item in `src/ui/pi-sidebar.ts`
  - `/integrations` command description in `src/commands/builtins/integrations.ts`
  - Integrations overlay header/title/subtitle in `src/commands/builtins/integrations-overlay.ts`
  - Integrations bundle section title to neutral wording (`"Capability bundles"`) in `src/commands/builtins/integrations-overlay-elements.ts`
- Updated legacy experimental redirect messaging to point to the renamed surface:
  - `src/commands/builtins/experimental.ts`
  - `src/commands/builtins/experimental-overlay.ts`

## Intent

This is a naming/IA-only slice to reduce user confusion called out in #176:
- Keeps `/integrations` command and internal integration model unchanged (low-risk)
- Improves discoverability and meaning in UI copy without introducing behavior changes

## Validation

- `npm run check`
- `npm run build`
- Manual smoke via `agent-browser`:
  - `/integrations` overlay opens with **Tools & MCP** header
  - `/experimental web-search` guidance points to `/integrations (Tools & MCP)`

Refs: #176
