### PR TITLE
build(deps): bump Pi packages to 0.52.12

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,6 +1,6 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-02-15
 
 This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.3-codex`, `claude-opus-4-6`).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "pi-for-excel",
-  "version": "0.5.0-pre",
+  "version": "0.6.1-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-for-excel",
-      "version": "0.5.0-pre",
+      "version": "0.6.1-pre",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
-        "@mariozechner/pi-agent-core": "^0.52.9",
-        "@mariozechner/pi-ai": "^0.52.5",
-        "@mariozechner/pi-web-ui": "^0.52.9",
+        "@mariozechner/pi-agent-core": "^0.52.12",
+        "@mariozechner/pi-ai": "^0.52.12",
+        "@mariozechner/pi-web-ui": "^0.52.12",
         "@sinclair/typebox": "^0.34.41",
         "lit": "^3.2.1",
         "marked": "^17.0.2"
@@ -3244,21 +3244,21 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.52.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.52.9.tgz",
-      "integrity": "sha512-x6OxWN5QnZGfK5TU822Xgcy5QeN3ZGIBaZiZISRI64BZYj5ENc40j4T+fbeRnAsrEkJoMC1Him8ixw68PRTovQ==",
+      "version": "0.52.12",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.52.12.tgz",
+      "integrity": "sha512-fBQdwLMvTteHUP9nJxMjtMpEHH4I8tdGnkerOoCFnS9y03AHdqy96IhtL+zZjw9N3dmVCOVqh8gwGjAGLZT31Q==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.52.9"
+        "@mariozechner/pi-ai": "^0.52.12"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.52.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.52.9.tgz",
-      "integrity": "sha512-sCdIVw7iomWcaEnVUFwq9e69Dat0ZCy/+XGkTtroY8H+GxHmDKUCrJV/yMpu8Jq9Oof11yCo7F/Vco7dvYCLZg==",
+      "version": "0.52.12",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.52.12.tgz",
+      "integrity": "sha512-oF7OMJu1aUx7MXJeJoJ/3JDXzD2a5SqK9nHVK3mCA8DRQaykv9g+wcFZaANcCl0vAR2QSDr5KN3ZMARlFNWiVg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -3303,9 +3303,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.52.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.52.9.tgz",
-      "integrity": "sha512-YHVZLRz9ULVlubRi51P1AQj7oOb+caiTv/HsNa7r587ale8kLNBx2Sa99fRWuFhNPu+SniwVi4pgqvkrWAcd/w==",
+      "version": "0.52.12",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.52.12.tgz",
+      "integrity": "sha512-QQ4LUlAYKN2BvT3EMU63+kYLlIkyr706+rUFBGWvkiT8ZyMy5if3oaVJpO5qAndsMB+MaUnttIBPh3iHiaJ01g==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -3331,14 +3331,14 @@
       }
     },
     "node_modules/@mariozechner/pi-web-ui": {
-      "version": "0.52.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.52.9.tgz",
-      "integrity": "sha512-abfPECN8z0QwlZlsTh9vdIuFEI5xrKpi3+AiQzss8XH/ErLcJQvIXNhL3t3dE9tk0e/xykV/9HoDMbKLNSZG1Q==",
+      "version": "0.52.12",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.52.12.tgz",
+      "integrity": "sha512-RA1wa5xkcmpbD2be/+aMbDuGUavTtA4Yfqa4b449Sa1QvRWh7NfrRKoP7xfeOuxrKnLGte+NxAfMgtET0XSIRw==",
       "license": "MIT",
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
-        "@mariozechner/pi-ai": "^0.52.9",
-        "@mariozechner/pi-tui": "^0.52.9",
+        "@mariozechner/pi-ai": "^0.52.12",
+        "@mariozechner/pi-tui": "^0.52.12",
         "docx-preview": "^0.3.7",
         "jszip": "^3.10.1",
         "lucide": "^0.544.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
-    "@mariozechner/pi-agent-core": "^0.52.9",
-    "@mariozechner/pi-ai": "^0.52.5",
-    "@mariozechner/pi-web-ui": "^0.52.9",
+    "@mariozechner/pi-agent-core": "^0.52.12",
+    "@mariozechner/pi-ai": "^0.52.12",
+    "@mariozechner/pi-web-ui": "^0.52.12",
     "@sinclair/typebox": "^0.34.41",
     "lit": "^3.2.1",
     "marked": "^17.0.2"


### PR DESCRIPTION
## Summary
- bump `@mariozechner/pi-agent-core`, `@mariozechner/pi-ai`, and `@mariozechner/pi-web-ui` to `^0.52.12`
- refresh lockfile resolutions for Pi packages (`pi-agent-core`, `pi-ai`, `pi-web-ui`, `pi-tui`)
- update `docs/model-updates.md` verification date after dependency + model-registry refresh

## Verification
- `npm run test:models`
- `npm run check`
- `npm run build`