### PR TITLE
fix(ui): Web Interface Guidelines audit — a11y, focus, animation, forms

### DIFF
--- a/src/taskpane.html
+++ b/src/taskpane.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="color-scheme: light dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pi for Excel</title>
+  <meta name="theme-color" content="#f7f7f5" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#303040" media="(prefers-color-scheme: dark)" />
 
   <!-- Office.js — must load before any Office API calls -->
   <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>

--- a/src/ui/pi-input.ts
+++ b/src/ui/pi-input.ts
@@ -286,6 +286,8 @@ export class PiInput extends LitElement {
           .value=${this._value}
           placeholder=${this.isStreaming ? "Guide response (↵) · New question (⌥↵)" : PLACEHOLDER_HINTS[this._placeholderIndex]}
           rows="1"
+          aria-label="Chat message"
+          autocomplete="off"
           @input=${this._onInput}
           @keydown=${this._onKeydown}
         ></textarea>

--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -932,13 +932,14 @@ export class PiSidebar extends LitElement {
       return html`
         <div class="px-4">
           <div class="pi-context-pill">
-            <div
+            <button
+              type="button"
               class="pi-context-pill__header"
               @click=${this._toggleContextPill}
             >
               <span>Context · no calls yet for this session</span>
               <span class="pi-context-pill__chevron ${expanded ? "pi-context-pill__chevron--open" : ""}">${icon(ChevronRight, "sm")}</span>
-            </div>
+            </button>
             ${expanded ? html`
               <div class="pi-context-pill__body">
                 <div class="pi-context-pill__section">
@@ -1007,13 +1008,14 @@ export class PiSidebar extends LitElement {
     return html`
       <div class="px-4">
         <div class="pi-context-pill">
-          <div
+          <button
+            type="button"
             class="pi-context-pill__header"
             @click=${this._toggleContextPill}
           >
             <span>Context · call #${call}${phaseLabel} · ${formatK(total)} chars</span>
             <span class="pi-context-pill__chevron ${expanded ? "pi-context-pill__chevron--open" : ""}">${icon(ChevronRight, "sm")}</span>
-          </div>
+          </button>
           ${expanded ? html`
             <div class="pi-context-pill__body">
               <div class="pi-context-pill__section">

--- a/src/ui/provider-login.ts
+++ b/src/ui/provider-login.ts
@@ -147,6 +147,8 @@ function promptForText(opts: {
     const input = document.createElement("input");
     input.className = "pi-prompt-input";
     input.type = "text";
+    input.autocomplete = "off";
+    input.setAttribute("aria-label", opts.title);
 
     const actions = document.createElement("div");
     actions.className = "pi-prompt-actions";
@@ -267,7 +269,7 @@ export function buildProviderRow(
         </div>
       ` : ""}
       <div class="pi-login-key-row">
-        <input class="pi-login-key" type="password" placeholder="${keyPlaceholder}" />
+        <input class="pi-login-key" type="password" placeholder="${keyPlaceholder}" aria-label="API key for ${label}" autocomplete="off" spellcheck="false" />
         <button class="pi-login-save">Save</button>
       </div>
       <p class="pi-login-error" hidden></p>

--- a/src/ui/theme/base.css
+++ b/src/ui/theme/base.css
@@ -25,3 +25,17 @@ body {
 *::-webkit-scrollbar-thumb:hover { background: oklch(0.70 0 0); }
 
 
+/* Prevent double-tap zoom delay on touch devices */
+button, a, [role="button"], [role="menuitem"], input, textarea, select {
+  touch-action: manipulation;
+}
+
+/* Reduced-motion: collapse all animations and transitions globally */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/ui/theme/components/empty-state.css
+++ b/src/ui/theme/components/empty-state.css
@@ -35,6 +35,7 @@
   line-height: 1.55;
   max-width: 220px;
   margin: 0;
+  text-wrap: balance;
 }
 
 .pi-empty__hints {

--- a/src/ui/theme/components/status-bar.css
+++ b/src/ui/theme/components/status-bar.css
@@ -277,15 +277,23 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
   padding: var(--pill-padding-y) var(--pill-padding-x);
+  border: none;
+  background: transparent;
   cursor: pointer;
   user-select: none;
   font-size: var(--text-base);
+  font-family: var(--font-sans);
   color: var(--muted-foreground);
   transition: color var(--duration-fast);
 }
 .pi-context-pill__header:hover {
   color: var(--foreground);
+}
+.pi-context-pill__header:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--pi-green-lighter);
 }
 .pi-context-pill__chevron {
   transition: transform var(--duration-fast);

--- a/src/ui/theme/components/tabs.css
+++ b/src/ui/theme/components/tabs.css
@@ -141,10 +141,13 @@
   caret-color: transparent;
 }
 
-.pi-session-tab__main:focus,
+.pi-session-tab__main:focus {
+  outline: none;
+}
+
 .pi-session-tab__main:focus-visible {
   outline: none;
-  box-shadow: none;
+  box-shadow: 0 0 0 2px var(--green-alpha-12);
 }
 
 .pi-session-tab__title {

--- a/src/ui/theme/components/welcome-login.css
+++ b/src/ui/theme/components/welcome-login.css
@@ -117,6 +117,11 @@
   outline: none;
 }
 
+.pi-welcome-proxy__url:focus-visible {
+  border-color: var(--green-alpha-25);
+  box-shadow: 0 0 0 2px var(--pi-green-lighter);
+}
+
 .pi-welcome-proxy__save {
   padding: 7px 10px;
   border-radius: var(--radius-sm);
@@ -202,6 +207,7 @@
   font-size: var(--text-md);
   font-weight: 600;
   color: var(--foreground);
+  text-wrap: balance;
 }
 
 .pi-prompt-message {
@@ -232,7 +238,7 @@
   outline: none;
 }
 
-.pi-prompt-input:focus {
+.pi-prompt-input:focus-visible {
   border-color: var(--green-alpha-25);
   box-shadow: 0 0 0 2px var(--pi-green-lighter);
 }
@@ -389,7 +395,7 @@
   outline: none;
 }
 
-.pi-login-key:focus {
+.pi-login-key:focus-visible {
   border-color: var(--green-alpha-25);
   box-shadow: 0 0 0 2px var(--pi-green-lighter);
 }

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -5,6 +5,7 @@
   width: min(520px, 92vw);
   max-height: min(80vh, 720px);
   gap: 10px;
+  overscroll-behavior: contain;
 }
 
 .pi-overlay-card--s {
@@ -25,6 +26,7 @@
   font-size: var(--text-md);
   font-weight: 600;
   color: var(--foreground);
+  text-wrap: balance;
 }
 
 .pi-overlay-tabs {

--- a/src/ui/tool-renderers.ts
+++ b/src/ui/tool-renderers.ts
@@ -210,7 +210,7 @@ function renderImages(images: ImageContent[]): TemplateResult {
         const src = `data:${img.mimeType};base64,${img.data}`;
         return html`
           <div class="border border-border rounded-lg overflow-hidden bg-background">
-            <img src=${src} class="block w-full h-auto" />
+            <img src=${src} alt="Tool result image" class="block w-full h-auto" />
           </div>
         `;
       })}


### PR DESCRIPTION
Closes #264

Audit the sidebar UI against the [Vercel Web Interface Guidelines](https://github.com/vercel-labs/web-interface-guidelines) and fix all flagged issues.

## Changes (11 files, +53 −11)

### Accessibility
- **`pi-input.ts`** — add `aria-label="Chat message"` and `autocomplete="off"` on textarea
- **`provider-login.ts`** — add `aria-label`, `autocomplete="off"`, `spellcheck="false"` on API key inputs; add `aria-label` and `autocomplete="off"` on prompt input
- **`tool-renderers.ts`** — add `alt="Tool result image"` on `<img>`
- **`pi-sidebar.ts`** — convert context pill headers from `<div @click>` → `<button type="button">` (keyboard-accessible)

### Focus states
- **`tabs.css`** — replace `box-shadow: none` with visible `0 0 0 2px var(--green-alpha-12)` ring on `:focus-visible`
- **`welcome-login.css`** — upgrade `:focus` → `:focus-visible` on `.pi-prompt-input` and `.pi-login-key`; add `:focus-visible` ring on `.pi-welcome-proxy__url`
- **`status-bar.css`** — add button reset styles and `:focus-visible` ring on `.pi-context-pill__header`

### Animation
- **`base.css`** — add `@media (prefers-reduced-motion: reduce)` that collapses all animation/transition durations globally

### Touch / mobile
- **`base.css`** — add `touch-action: manipulation` on buttons, links, inputs, textareas, selects to eliminate double-tap zoom delay on iPad

### Dark mode / theming
- **`taskpane.html`** — add `color-scheme: light dark` on `<html>` for native dark-mode adaptation; add `<meta name="theme-color">` with light/dark variants

### Content / layout
- **`primitives.css`** — add `overscroll-behavior: contain` on overlay cards; add `text-wrap: balance` on `.pi-overlay-title`
- **`empty-state.css`** — add `text-wrap: balance` on `.pi-empty__tagline`
- **`welcome-login.css`** — add `text-wrap: balance` on `.pi-prompt-title`

## Verification
- `npm run check` ✅
- `npm run build` ✅
- `npm run test:context` ✅ (419/419)
