### PR TITLE
refactor(extensions): extract sandbox runtime request helpers

### DIFF
--- a/src/extensions/sandbox-runtime.ts
+++ b/src/extensions/sandbox-runtime.ts
@@ -6,12 +6,8 @@
  * sanitized UI projection format (no raw HTML injection).
  */
 
-import type {
-  AgentEvent,
-  AgentTool,
-  AgentToolResult,
-} from "@mariozechner/pi-agent-core";
-import { Kind, Type, type TSchema } from "@sinclair/typebox";
+import type { AgentEvent, AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { TSchema } from "@sinclair/typebox";
 
 import type {
   ExtensionCommand,
@@ -21,7 +17,6 @@ import type {
   LlmCompletionResult,
   LoadedExtensionHandle,
   SkillSummary,
-  WidgetPlacement,
 } from "../commands/extension-api.js";
 import type { ExtensionCapability } from "./permissions.js";
 import {
@@ -46,7 +41,21 @@ import {
   showWidgetNode,
   upsertSandboxWidgetNode,
 } from "./sandbox/surfaces.js";
+import {
+  asBooleanOrUndefined,
+  asFiniteNumberOrNull,
+  asFiniteNumberOrNullOrUndefined,
+  asNonEmptyString,
+  asRecord,
+  asWidgetPlacementOrUndefined,
+  getErrorMessage,
+  normalizeSandboxToolParameters,
+  normalizeSandboxToolResult,
+  sanitizeText,
+} from "./sandbox/runtime-helpers.js";
 import { isRecord } from "../utils/type-guards.js";
+
+export { normalizeSandboxToolParameters } from "./sandbox/runtime-helpers.js";
 
 const LEGACY_WIDGET_ID = "__legacy__";
 
@@ -96,135 +105,6 @@ interface SandboxPendingRequest {
   resolve: (value: unknown) => void;
   reject: (reason: unknown) => void;
   timeoutId: ReturnType<typeof setTimeout>;
-}
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message;
-  }
-
-  return String(error);
-}
-
-function sanitizeText(value: unknown): string {
-  if (typeof value !== "string") {
-    return "";
-  }
-
-  return value;
-}
-
-function asNonEmptyString(value: unknown, field: string): string {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    throw new Error(`${field} must be a non-empty string.`);
-  }
-
-  return value.trim();
-}
-
-function asRecord(value: unknown, field: string): Record<string, unknown> {
-  if (!isRecord(value)) {
-    throw new Error(`${field} must be an object.`);
-  }
-
-  return value;
-}
-
-function asFiniteNumberOrNull(value: unknown): number | null {
-  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
-    return null;
-  }
-
-  return value;
-}
-
-function asFiniteNumberOrNullOrUndefined(value: unknown): number | null | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (value === null) {
-    return null;
-  }
-
-  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
-    return undefined;
-  }
-
-  return value;
-}
-
-function asWidgetPlacementOrUndefined(value: unknown): WidgetPlacement | undefined {
-  if (value === "above-input" || value === "below-input") {
-    return value;
-  }
-
-  return undefined;
-}
-
-function asBooleanOrUndefined(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
-}
-
-function isTypeBoxSchema(value: unknown): value is TSchema {
-  return isRecord(value) && Kind in value;
-}
-
-export function normalizeSandboxToolParameters(raw: unknown): TSchema {
-  if (isTypeBoxSchema(raw)) {
-    return raw;
-  }
-
-  if (!isRecord(raw)) {
-    throw new Error("register_tool parameters must be an object schema.");
-  }
-
-  return Type.Unsafe<unknown>(raw);
-}
-
-function normalizeToolResult(raw: unknown): AgentToolResult<unknown> {
-  const content: Array<{ type: "text"; text: string }> = [];
-
-  if (isRecord(raw) && Array.isArray(raw.content)) {
-    for (const item of raw.content) {
-      if (!isRecord(item)) {
-        continue;
-      }
-
-      if (item.type !== "text") {
-        continue;
-      }
-
-      if (typeof item.text !== "string") {
-        continue;
-      }
-
-      content.push({
-        type: "text",
-        text: item.text,
-      });
-    }
-  }
-
-  if (content.length === 0) {
-    const fallbackText = isRecord(raw) && Array.isArray(raw.content)
-      ? "Sandbox tool returned non-text content; showing serialized payload instead."
-      : "Sandbox tool returned an invalid payload; showing serialized payload instead.";
-
-    content.push({
-      type: "text",
-      text: `${fallbackText}\n\n\`\`\`json\n${JSON.stringify(raw, null, 2)}\n\`\`\``,
-    });
-  }
-
-  const details = isRecord(raw) && Object.prototype.hasOwnProperty.call(raw, "details")
-    ? raw.details
-    : undefined;
-
-  return {
-    content,
-    details,
-  };
 }
 
 class SandboxRuntimeHost {
@@ -577,7 +457,7 @@ class SandboxRuntimeHost {
                 params: toolParams,
               });
 
-              return normalizeToolResult(result);
+              return normalizeSandboxToolResult(result);
             },
           };
 

--- a/src/extensions/sandbox/runtime-helpers.ts
+++ b/src/extensions/sandbox/runtime-helpers.ts
@@ -1,0 +1,135 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Kind, Type, type TSchema } from "@sinclair/typebox";
+
+import { isRecord } from "../../utils/type-guards.js";
+
+type WidgetPlacement = "above-input" | "below-input";
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export function sanitizeText(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value;
+}
+
+export function asNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+export function asRecord(value: unknown, field: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${field} must be an object.`);
+  }
+
+  return value;
+}
+
+export function asFiniteNumberOrNull(value: unknown): number | null {
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return value;
+}
+
+export function asFiniteNumberOrNullOrUndefined(value: unknown): number | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return value;
+}
+
+export function asWidgetPlacementOrUndefined(value: unknown): WidgetPlacement | undefined {
+  if (value === "above-input" || value === "below-input") {
+    return value;
+  }
+
+  return undefined;
+}
+
+export function asBooleanOrUndefined(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function isTypeBoxSchema(value: unknown): value is TSchema {
+  return isRecord(value) && Kind in value;
+}
+
+export function normalizeSandboxToolParameters(raw: unknown): TSchema {
+  if (isTypeBoxSchema(raw)) {
+    return raw;
+  }
+
+  if (!isRecord(raw)) {
+    throw new Error("register_tool parameters must be an object schema.");
+  }
+
+  return Type.Unsafe<unknown>(raw);
+}
+
+export function normalizeSandboxToolResult(raw: unknown): AgentToolResult<unknown> {
+  const content: Array<{ type: "text"; text: string }> = [];
+
+  if (isRecord(raw) && Array.isArray(raw.content)) {
+    for (const item of raw.content) {
+      if (!isRecord(item)) {
+        continue;
+      }
+
+      if (item.type !== "text") {
+        continue;
+      }
+
+      if (typeof item.text !== "string") {
+        continue;
+      }
+
+      content.push({
+        type: "text",
+        text: item.text,
+      });
+    }
+  }
+
+  if (content.length === 0) {
+    const fallbackText = isRecord(raw) && Array.isArray(raw.content)
+      ? "Sandbox tool returned non-text content; showing serialized payload instead."
+      : "Sandbox tool returned an invalid payload; showing serialized payload instead.";
+
+    content.push({
+      type: "text",
+      text: `${fallbackText}\n\n\`\`\`json\n${JSON.stringify(raw, null, 2)}\n\`\`\``,
+    });
+  }
+
+  const details = isRecord(raw) && Object.prototype.hasOwnProperty.call(raw, "details")
+    ? raw.details
+    : undefined;
+
+  return {
+    content,
+    details,
+  };
+}


### PR DESCRIPTION
## Summary
- extract sandbox runtime request/normalization helpers from `src/extensions/sandbox-runtime.ts` into `src/extensions/sandbox/runtime-helpers.ts`
- keep `sandbox-runtime.ts` focused on host lifecycle and request dispatch
- preserve existing API surface by re-exporting `normalizeSandboxToolParameters` from `sandbox-runtime.ts`
- keep helper module under `src/extensions/sandbox/` so it is not treated as a bundled extension entry candidate

## Why
`sandbox-runtime.ts` had accumulated parsing/normalization utilities that are independent from iframe lifecycle and RPC orchestration. Moving these pure helpers improves readability and keeps dispatch flow easier to follow, while preserving runtime behavior.

## Validation
- npm run check
- npm run build
- npm run test:models
- npm run test:context
- npm run test:security
