### PR TITLE
feat(ui): add external skill install/remove controls

### DIFF
--- a/src/commands/builtins/skills-overlay.ts
+++ b/src/commands/builtins/skills-overlay.ts
@@ -5,16 +5,23 @@
 import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.js";
 import { isExperimentalFeatureEnabled } from "../../experiments/flags.js";
 import { mergeAgentSkillDefinitions, listAgentSkills } from "../../skills/catalog.js";
-import { loadExternalAgentSkillsFromSettings } from "../../skills/external-store.js";
+import {
+  loadExternalAgentSkillsFromSettings,
+  removeExternalAgentSkillFromSettings,
+  upsertExternalAgentSkillInSettings,
+  type ExternalSkillSettingsStore,
+} from "../../skills/external-store.js";
 import type { AgentSkillDefinition } from "../../skills/types.js";
 import {
   closeOverlayById,
   createOverlayBadge,
+  createOverlayButton,
   createOverlayDialog,
   createOverlayHeader,
   createOverlaySectionTitle,
 } from "../../ui/overlay-dialog.js";
 import { SKILLS_OVERLAY_ID } from "../../ui/overlay-ids.js";
+import { showToast } from "../../ui/toast.js";
 
 interface SkillsSnapshot {
   bundled: AgentSkillDefinition[];
@@ -36,6 +43,9 @@ function createSkillItem(args: {
   skill: AgentSkillDefinition;
   active: boolean;
   shadowed: boolean;
+  removable: boolean;
+  busy: boolean;
+  onRemove?: () => void;
 }): HTMLElement {
   const item = document.createElement("div");
   item.className = "pi-overlay-surface pi-skills-item";
@@ -77,6 +87,24 @@ function createSkillItem(args: {
   }
 
   item.append(top, description, meta);
+
+  if (args.removable && args.onRemove) {
+    const actions = document.createElement("div");
+    actions.className = "pi-overlay-actions pi-overlay-actions--inline";
+
+    const removeButton = createOverlayButton({
+      text: "Remove",
+      className: "pi-overlay-btn--compact pi-overlay-btn--danger",
+    });
+    removeButton.disabled = args.busy;
+    removeButton.addEventListener("click", () => {
+      args.onRemove?.();
+    });
+
+    actions.appendChild(removeButton);
+    item.appendChild(actions);
+  }
+
   return item;
 }
 
@@ -86,6 +114,9 @@ function renderSkillList(args: {
   activeNames: ReadonlySet<string>;
   shadowedNames?: ReadonlySet<string>;
   emptyMessage: string;
+  removable?: boolean;
+  busy: boolean;
+  onRemove?: (skillName: string) => void;
 }): void {
   args.container.replaceChildren();
 
@@ -103,12 +134,14 @@ function renderSkillList(args: {
       skill,
       active: args.activeNames.has(normalizedName),
       shadowed: args.shadowedNames?.has(normalizedName) ?? false,
+      removable: args.removable === true,
+      busy: args.busy,
+      onRemove: args.onRemove ? () => args.onRemove?.(skill.name) : undefined,
     }));
   }
 }
 
-async function buildSnapshot(): Promise<SkillsSnapshot> {
-  const settings = getAppStorage().settings;
+async function buildSnapshot(settings: ExternalSkillSettingsStore): Promise<SkillsSnapshot> {
   const bundled = listAgentSkills();
 
   let external: AgentSkillDefinition[] = [];
@@ -146,6 +179,8 @@ export function showSkillsDialog(): void {
     cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--l pi-skills-dialog",
   });
 
+  const settings = getAppStorage().settings;
+
   const { header } = createOverlayHeader({
     onClose: dialog.close,
     closeLabel: "Close skills",
@@ -167,9 +202,10 @@ export function showSkillsDialog(): void {
   summaryText.className = "pi-skills-summary";
   summaryText.textContent = "Loading skills…";
 
+  const defaultSummaryHint = "Skills are injected when relevant; the agent can read full SKILL.md content with the skills tool.";
   const summaryHint = document.createElement("p");
   summaryHint.className = "pi-overlay-hint";
-  summaryHint.textContent = "Skills are injected when relevant; the agent can read full SKILL.md content with the skills tool.";
+  summaryHint.textContent = defaultSummaryHint;
 
   summaryCard.append(summaryTitle, summaryText, summaryHint);
 
@@ -193,61 +229,183 @@ export function showSkillsDialog(): void {
   externalSection.className = "pi-overlay-section";
   externalSection.appendChild(createOverlaySectionTitle("External skills"));
 
+  const installCard = document.createElement("div");
+  installCard.className = "pi-overlay-surface";
+
+  const installTitle = document.createElement("p");
+  installTitle.className = "pi-skills-install-title";
+  installTitle.textContent = "Add or update external skill (paste full SKILL.md):";
+
+  const installInput = document.createElement("textarea");
+  installInput.className = "pi-skills-install-input";
+  installInput.setAttribute("aria-label", "External skill markdown");
+  installInput.placeholder = "---\nname: my-skill\ndescription: What this skill does\n---\n\n# Instructions\n...";
+
+  const installActions = document.createElement("div");
+  installActions.className = "pi-overlay-actions pi-overlay-actions--inline";
+
+  const installButton = createOverlayButton({
+    text: "Install / update",
+    className: "pi-overlay-btn--primary",
+  });
+
+  const clearButton = createOverlayButton({
+    text: "Clear",
+    className: "pi-overlay-btn--compact",
+  });
+
+  installActions.append(installButton, clearButton);
+
+  const installHint = document.createElement("p");
+  installHint.className = "pi-overlay-hint";
+  installHint.textContent = "External skills are local to this profile. If a bundled skill has the same name, the bundled one stays active.";
+
+  installCard.append(installTitle, installInput, installActions, installHint);
+
   const externalList = document.createElement("div");
   externalList.className = "pi-overlay-list";
-  externalSection.appendChild(externalList);
+
+  externalSection.append(installCard, externalList);
 
   body.append(summaryCard, activeSection, bundledSection, externalSection);
   dialog.card.append(header, body);
 
+  let snapshot: SkillsSnapshot | null = null;
+  let busy = false;
+
+  const setBusy = (next: boolean): void => {
+    busy = next;
+    installInput.disabled = next;
+    installButton.disabled = next;
+    clearButton.disabled = next;
+
+    if (snapshot) {
+      render(snapshot);
+    }
+  };
+
+  const render = (current: SkillsSnapshot): void => {
+    const activeNames = new Set(current.active.map((skill) => normalizeSkillName(skill.name)));
+    const bundledNames = new Set(current.bundled.map((skill) => normalizeSkillName(skill.name)));
+    const shadowedExternalNames = new Set(
+      current.external
+        .map((skill) => normalizeSkillName(skill.name))
+        .filter((name) => bundledNames.has(name)),
+    );
+
+    if (current.externalDiscoveryEnabled) {
+      summaryText.textContent = `Prompt currently includes ${formatSkillCount(current.active.length)} (bundled + discoverable external).`;
+    } else {
+      summaryText.textContent = `Prompt currently includes ${formatSkillCount(current.active.length)} (bundled only). External discovery is disabled.`;
+    }
+
+    summaryHint.textContent = defaultSummaryHint;
+    summaryHint.classList.remove("pi-overlay-text-warning");
+
+    if (current.externalLoadError) {
+      summaryHint.textContent = `External skills could not be loaded (${current.externalLoadError}). Showing bundled skills only.`;
+      summaryHint.classList.add("pi-overlay-text-warning");
+    }
+
+    renderSkillList({
+      container: activeList,
+      skills: current.active,
+      activeNames,
+      emptyMessage: "No active skills.",
+      busy,
+    });
+
+    renderSkillList({
+      container: bundledList,
+      skills: current.bundled,
+      activeNames,
+      emptyMessage: "No bundled skills are available in this build.",
+      busy,
+    });
+
+    const externalEmptyMessage = current.externalDiscoveryEnabled
+      ? "No external skills are configured."
+      : "No external skills are configured. Enable /experimental on external_skills_discovery after adding one to activate it.";
+
+    renderSkillList({
+      container: externalList,
+      skills: current.external,
+      activeNames,
+      shadowedNames: shadowedExternalNames,
+      emptyMessage: externalEmptyMessage,
+      removable: true,
+      busy,
+      onRemove: (skillName: string) => {
+        if (busy) return;
+
+        void (async () => {
+          setBusy(true);
+          try {
+            const removed = await removeExternalAgentSkillFromSettings({
+              settings,
+              name: skillName,
+            });
+
+            if (!removed) {
+              showToast(`External skill not found: ${skillName}`);
+            } else {
+              showToast(`Removed external skill: ${skillName}`);
+            }
+
+            snapshot = await buildSnapshot(settings);
+            render(snapshot);
+          } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : "Unknown error";
+            showToast(`Failed to remove external skill: ${message}`);
+          } finally {
+            setBusy(false);
+          }
+        })();
+      },
+    });
+  };
+
+  installButton.addEventListener("click", () => {
+    if (busy) return;
+
+    const markdown = installInput.value.trim();
+    if (markdown.length === 0) {
+      showToast("Paste a SKILL.md document first.");
+      return;
+    }
+
+    void (async () => {
+      setBusy(true);
+      try {
+        const result = await upsertExternalAgentSkillInSettings({
+          settings,
+          markdown,
+        });
+
+        showToast(`Saved external skill: ${result.name}`);
+        installInput.value = "";
+
+        snapshot = await buildSnapshot(settings);
+        render(snapshot);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : "Unknown error";
+        showToast(`Failed to save external skill: ${message}`);
+      } finally {
+        setBusy(false);
+      }
+    })();
+  });
+
+  clearButton.addEventListener("click", () => {
+    if (busy) return;
+    installInput.value = "";
+    installInput.focus();
+  });
+
   void (async () => {
     try {
-      const snapshot = await buildSnapshot();
-
-      const activeNames = new Set(snapshot.active.map((skill) => normalizeSkillName(skill.name)));
-      const bundledNames = new Set(snapshot.bundled.map((skill) => normalizeSkillName(skill.name)));
-      const shadowedExternalNames = new Set(
-        snapshot.external
-          .map((skill) => normalizeSkillName(skill.name))
-          .filter((name) => bundledNames.has(name)),
-      );
-
-      if (snapshot.externalDiscoveryEnabled) {
-        summaryText.textContent = `Prompt currently includes ${formatSkillCount(snapshot.active.length)} (bundled + discoverable external).`;
-      } else {
-        summaryText.textContent = `Prompt currently includes ${formatSkillCount(snapshot.active.length)} (bundled only). External discovery is disabled.`;
-      }
-
-      if (snapshot.externalLoadError) {
-        summaryHint.textContent = `External skills could not be loaded (${snapshot.externalLoadError}). Showing bundled skills only.`;
-        summaryHint.classList.add("pi-overlay-text-warning");
-      }
-
-      renderSkillList({
-        container: activeList,
-        skills: snapshot.active,
-        activeNames,
-        emptyMessage: "No active skills.",
-      });
-
-      renderSkillList({
-        container: bundledList,
-        skills: snapshot.bundled,
-        activeNames,
-        emptyMessage: "No bundled skills are available in this build.",
-      });
-
-      const externalEmptyMessage = snapshot.externalDiscoveryEnabled
-        ? "No external skills are configured."
-        : "No external skills are configured. Enable /experimental on external_skills_discovery after adding one to activate it.";
-
-      renderSkillList({
-        container: externalList,
-        skills: snapshot.external,
-        activeNames,
-        shadowedNames: shadowedExternalNames,
-        emptyMessage: externalEmptyMessage,
-      });
+      snapshot = await buildSnapshot(settings);
+      render(snapshot);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "Unknown error";
       summaryText.textContent = `Failed to load skills: ${message}`;

--- a/src/ui/theme/overlays/skills.css
+++ b/src/ui/theme/overlays/skills.css
@@ -51,3 +51,35 @@
   padding: 2px 6px;
   border-radius: 6px;
 }
+
+.pi-skills-install-title {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--muted-foreground);
+}
+
+.pi-skills-install-input {
+  width: 100%;
+  min-height: 140px;
+  resize: vertical;
+  border: 1px solid var(--alpha-12);
+  border-radius: var(--radius-sm);
+  padding: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  background: var(--white-alpha-70);
+  color: var(--foreground);
+  outline: none;
+}
+
+.pi-skills-install-input:focus,
+.pi-skills-install-input:focus-visible {
+  border-color: var(--green-alpha-25);
+  box-shadow: 0 0 0 2px var(--pi-green-lighter);
+}
+
+.pi-skills-install-input:disabled {
+  opacity: 0.65;
+}

--- a/tests/skills-external-store.test.ts
+++ b/tests/skills-external-store.test.ts
@@ -4,6 +4,8 @@ import { test } from "node:test";
 import {
   EXTERNAL_AGENT_SKILLS_STORAGE_KEY,
   loadExternalAgentSkillsFromSettings,
+  removeExternalAgentSkillFromSettings,
+  upsertExternalAgentSkillInSettings,
 } from "../src/skills/external-store.ts";
 
 class MemorySettingsStore {
@@ -13,15 +15,16 @@ class MemorySettingsStore {
     return Promise.resolve(this.values.has(key) ? this.values.get(key) ?? null : null);
   }
 
-  set(key: string, value: unknown): void {
+  set(key: string, value: unknown): Promise<void> {
     this.values.set(key, value);
+    return Promise.resolve();
   }
 }
 
 void test("loadExternalAgentSkillsFromSettings loads valid external skills", async () => {
   const settings = new MemorySettingsStore();
 
-  settings.set(EXTERNAL_AGENT_SKILLS_STORAGE_KEY, {
+  await settings.set(EXTERNAL_AGENT_SKILLS_STORAGE_KEY, {
     version: 1,
     items: [
       {
@@ -47,7 +50,7 @@ description: External custom skill.
 void test("loadExternalAgentSkillsFromSettings ignores invalid payloads", async () => {
   const settings = new MemorySettingsStore();
 
-  settings.set(EXTERNAL_AGENT_SKILLS_STORAGE_KEY, {
+  await settings.set(EXTERNAL_AGENT_SKILLS_STORAGE_KEY, {
     version: 1,
     items: [
       {
@@ -68,11 +71,92 @@ void test("loadExternalAgentSkillsFromSettings ignores invalid payloads", async 
 void test("loadExternalAgentSkillsFromSettings returns empty for unknown version", async () => {
   const settings = new MemorySettingsStore();
 
-  settings.set(EXTERNAL_AGENT_SKILLS_STORAGE_KEY, {
+  void settings.set(EXTERNAL_AGENT_SKILLS_STORAGE_KEY, {
     version: 2,
     items: [],
   });
 
   const skills = await loadExternalAgentSkillsFromSettings(settings);
   assert.deepEqual(skills, []);
+});
+
+void test("upsertExternalAgentSkillInSettings installs and overwrites by skill name", async () => {
+  const settings = new MemorySettingsStore();
+
+  await upsertExternalAgentSkillInSettings({
+    settings,
+    markdown: `---
+name: custom-skill
+description: First description.
+---
+
+# First
+`,
+  });
+
+  await upsertExternalAgentSkillInSettings({
+    settings,
+    markdown: `---
+name: custom-skill
+description: Updated description.
+---
+
+# Updated
+`,
+  });
+
+  const skills = await loadExternalAgentSkillsFromSettings(settings);
+  assert.equal(skills.length, 1);
+  assert.equal(skills[0].name, "custom-skill");
+  assert.equal(skills[0].description, "Updated description.");
+  assert.equal(skills[0].location, "skills/external/custom-skill/SKILL.md");
+});
+
+void test("upsertExternalAgentSkillInSettings enforces expectedName when provided", async () => {
+  const settings = new MemorySettingsStore();
+
+  await assert.rejects(
+    () => upsertExternalAgentSkillInSettings({
+      settings,
+      expectedName: "different-name",
+      markdown: `---
+name: custom-skill
+description: External custom skill.
+---
+
+# Custom
+`,
+    }),
+    /Skill name mismatch: expected "different-name" but markdown declares "custom-skill"/,
+  );
+});
+
+void test("removeExternalAgentSkillFromSettings removes by name and reports whether removed", async () => {
+  const settings = new MemorySettingsStore();
+
+  await upsertExternalAgentSkillInSettings({
+    settings,
+    markdown: `---
+name: custom-skill
+description: External custom skill.
+---
+
+# Custom
+`,
+  });
+
+  const removed = await removeExternalAgentSkillFromSettings({
+    settings,
+    name: "custom-skill",
+  });
+  assert.equal(removed, true);
+
+  const skillsAfterRemove = await loadExternalAgentSkillsFromSettings(settings);
+  assert.deepEqual(skillsAfterRemove, []);
+
+  const removedMissing = await removeExternalAgentSkillFromSettings({
+    settings,
+    name: "missing-skill",
+  });
+  assert.equal(removedMissing, false);
 });


### PR DESCRIPTION
## Summary

Phase 3 for #176: make the new Skills manager actionable by allowing users to install/update and remove external skills directly from the overlay.

## What changed

### Skills overlay: external skill management

`src/commands/builtins/skills-overlay.ts`

- Added **install/update** flow in the External skills section:
  - multiline `External skill markdown` input
  - `Install / update` action (expects full SKILL.md)
  - `Clear` action
- Added per-skill **Remove** action for external skills.
- Added busy-state wiring so install/remove controls disable during mutation.
- Added success/failure toasts for install/remove actions.
- Added aria label for markdown textarea for accessibility and deterministic automation.

### Shared skills persistence helpers (single source of truth)

`src/skills/external-store.ts`

- Added mutating helpers:
  - `upsertExternalAgentSkillInSettings(...)`
  - `removeExternalAgentSkillFromSettings(...)`
- Added `ExternalSkillMutableSettingsStore` + upsert result type.
- Kept loading behavior unchanged.

### Refactor extension runtime skill install/uninstall to reuse shared helpers

`src/extensions/skills-store.ts`

- Removed duplicated install/uninstall persistence logic.
- `installExternalExtensionSkill(...)` now delegates to `upsertExternalAgentSkillInSettings(...)`.
- `uninstallExternalExtensionSkill(...)` now delegates to `removeExternalAgentSkillFromSettings(...)`.

### Styles

`src/ui/theme/overlays/skills.css`

- Added styles for install title and markdown textarea.

### Tests

`tests/skills-external-store.test.ts`

- Added coverage for:
  - upsert install/overwrite behavior
  - expected-name mismatch validation
  - remove behavior + boolean removed/not-removed result

## Why

Issue #176 calls out that skills were invisible and lacked management UX. Phase 2 added a read-only skills surface; this phase adds the first mutating management actions with minimal scope and shared persistence helpers.

## Validation

- `npm run check`
- `npm run build`
- Manual smoke via `agent-browser`:
  - Open Skills from utilities menu
  - Paste SKILL.md and install/update
  - Remove installed external skill

Refs: #176
