### PR TITLE
refactor(extensions): extract sandbox request parsers

### DIFF
--- a/tests/sandbox-runtime-schema.test.ts
+++ b/tests/sandbox-runtime-schema.test.ts
@@ -4,6 +4,10 @@ import { test } from "node:test";
 import { Kind, Type } from "@sinclair/typebox";
 
 import { normalizeSandboxToolParameters } from "../src/extensions/sandbox-runtime.ts";
+import {
+  parseSandboxHttpRequestOptions,
+  parseSandboxLlmCompletionRequest,
+} from "../src/extensions/sandbox/runtime-helpers.ts";
 import { isRecord } from "../src/utils/type-guards.ts";
 
 void test("normalizeSandboxToolParameters keeps TypeBox schema unchanged", () => {
@@ -43,4 +47,56 @@ void test("normalizeSandboxToolParameters rejects non-object schema values", () 
     },
     /object schema/i,
   );
+});
+
+void test("parseSandboxLlmCompletionRequest validates and normalizes request payload", () => {
+  const request = parseSandboxLlmCompletionRequest({
+    model: "openai/gpt-5-mini",
+    systemPrompt: "system",
+    maxTokens: 123,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ],
+  });
+
+  assert.deepEqual(request, {
+    model: "openai/gpt-5-mini",
+    systemPrompt: "system",
+    maxTokens: 123,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ],
+  });
+
+  assert.throws(
+    () => {
+      parseSandboxLlmCompletionRequest({ messages: "bad" });
+    },
+    /messages must be an array/i,
+  );
+});
+
+void test("parseSandboxHttpRequestOptions normalizes method/headers/body", () => {
+  const options = parseSandboxHttpRequestOptions({
+    method: "POST",
+    headers: {
+      Authorization: "Bearer token",
+      Invalid: 42,
+    },
+    body: "{\"ok\":true}",
+    timeoutMs: 2500,
+  });
+
+  assert.deepEqual(options, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer token",
+    },
+    body: "{\"ok\":true}",
+    timeoutMs: 2500,
+  });
+
+  assert.equal(parseSandboxHttpRequestOptions("not-an-object"), undefined);
 });


### PR DESCRIPTION
## Summary
- extract sandbox request parsing logic for `llm_complete` and `http_fetch` into shared helpers in `src/extensions/sandbox/runtime-helpers.ts`
- keep `sandbox-runtime.ts` focused on dispatch/capability checks while reusing parser helpers
- add focused schema tests for new parser helpers in `tests/sandbox-runtime-schema.test.ts`

## Why
After the previous extraction, `sandbox-runtime.ts` still carried nested parsing branches for LLM/http payloads. Moving those to pure helper functions keeps the switch easier to scan and makes parser behavior directly testable.

## Validation
- npm run check
- npm run build
- npm run test:models
- npm run test:context
- npm run test:security
