### PR TITLE
feat(memory): clarify workspace memory contract and add compaction nudge

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -51,6 +51,13 @@ Then we ask the current model to produce a structured checkpoint (or update the 
 
 Those arguments are appended to the prompt as an “Additional focus”.
 
+Compaction also runs a lightweight **memory nudge** on the messages being summarized:
+
+- if older user messages include explicit memory cues (for example, "remember this" / "don't forget"), Pi shows a reminder toast before summarization
+- the summarizer gets extra focus instructions to call out durable memory in **Critical Context** and distinguish:
+  - behavioral preferences/rules → `instructions`
+  - factual memory → `notes/` or workbook-scoped notes
+
 ### 4) Replace the session messages
 
 After summarization succeeds, we replace the in-memory session with:

--- a/src/compaction/memory-nudge.ts
+++ b/src/compaction/memory-nudge.ts
@@ -1,0 +1,115 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+import { extractTextBlocks } from "../utils/content.js";
+
+const AUTO_CONTEXT_PREFIX = "[Auto-context]";
+const DEFAULT_MAX_SNIPPETS = 3;
+const MAX_SNIPPET_CHARS = 180;
+
+const MEMORY_CUE_PATTERNS: readonly RegExp[] = [
+  /\bremember(?:\s+this|\s+that)?\b/i,
+  /\bdon['’]t\s+forget\b/i,
+  /\bkeep\s+(?:this|that)\s+in\s+mind\b/i,
+  /\bfor\s+future\s+reference\b/i,
+  /\bmake\s+a\s+note\b/i,
+  /\bplease\s+save\b/i,
+];
+
+export interface CompactionMemoryCueSummary {
+  cueCount: number;
+  snippets: string[];
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/gu, " ").trim();
+}
+
+function isMemoryCueText(text: string): boolean {
+  return MEMORY_CUE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function toSnippet(text: string): string {
+  if (text.length <= MAX_SNIPPET_CHARS) return text;
+  return `${text.slice(0, MAX_SNIPPET_CHARS - 1).trimEnd()}…`;
+}
+
+function messageText(message: AgentMessage): string {
+  if (message.role !== "user" && message.role !== "user-with-attachments") {
+    return "";
+  }
+
+  if (typeof message.content === "string") {
+    return normalizeWhitespace(message.content);
+  }
+
+  return normalizeWhitespace(extractTextBlocks(message.content));
+}
+
+export function collectCompactionMemoryCues(
+  messages: readonly AgentMessage[],
+  maxSnippets = DEFAULT_MAX_SNIPPETS,
+): CompactionMemoryCueSummary {
+  const safeMaxSnippets = Math.max(0, maxSnippets);
+  const snippets: string[] = [];
+  const seenSnippetKeys = new Set<string>();
+  let cueCount = 0;
+
+  for (const message of messages) {
+    const text = messageText(message);
+    if (!text) continue;
+    if (text.startsWith(AUTO_CONTEXT_PREFIX)) continue;
+    if (!isMemoryCueText(text)) continue;
+
+    cueCount += 1;
+
+    if (snippets.length >= safeMaxSnippets) continue;
+
+    const snippet = toSnippet(text);
+    const snippetKey = snippet.toLowerCase();
+    if (seenSnippetKeys.has(snippetKey)) continue;
+
+    seenSnippetKeys.add(snippetKey);
+    snippets.push(snippet);
+  }
+
+  return {
+    cueCount,
+    snippets,
+  };
+}
+
+export function buildCompactionMemoryFocusInstruction(
+  summary: CompactionMemoryCueSummary,
+): string | null {
+  if (summary.cueCount <= 0) return null;
+
+  const lines: string[] = [
+    "Before finalizing the summary, identify durable memory that should be written to workspace files.",
+    "- Behavioral preferences/rules should be called out for the instructions tool.",
+    "- Factual workbook/domain memory should be called out for notes/ or workbooks/<name>/notes.md.",
+    "- If durable memory is present, include a short bullet list in Critical Context under 'Memory to persist'.",
+  ];
+
+  if (summary.snippets.length > 0) {
+    lines.push("Potential user cues:");
+    for (const snippet of summary.snippets) {
+      lines.push(`- \"${snippet}\"`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function mergeCompactionAdditionalFocus(
+  ...focusParts: Array<string | null | undefined>
+): string | undefined {
+  const normalized = focusParts
+    .map((part) => (typeof part === "string" ? part.trim() : ""))
+    .filter((part) => part.length > 0);
+
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  return normalized.join("\n\n");
+}

--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -226,17 +226,25 @@ const WORKSPACE = `## Workspace
 You have a persistent file workspace that survives across sessions and workbooks. Use it to save notes, analysis artifacts, and working files.
 
 ### Folder conventions
-- \`notes/\` — Your persistent memory. Write things you learn here so you can recall them in future sessions. Keep a brief \`notes/index.md\` listing what each note covers.
-- \`workbooks/<name>/\` — Artifacts tied to a specific workbook (CSVs, analysis, charts). Use a short slug derived from the workbook name.
+- \`notes/\` — Persistent factual memory across workbooks. Keep \`notes/index.md\` as a brief catalog (one line per note).
+- \`workbooks/<name>/\` — Workbook-scoped artifacts (CSVs, analysis, charts, workbook-specific notes). Use a short slug derived from the workbook name.
 - \`scratch/\` — Temporary working files. May be auto-cleaned.
 - \`imports/\` — Files uploaded by the user.
 - \`assistant-docs/\` — Built-in read-only documentation.
 
 You may create other folders as needed — these are conventions, not constraints.
 
+### Memory contract
+- If the user says "remember this" (or asks for durable memory), persist it to workspace files.
+- Behavioral preferences/rules (how to behave) belong in the **instructions** tool.
+- Factual knowledge (what is true about the workbook/domain) belongs in \`notes/\` or \`workbooks/<name>/\`.
+- Memory is file-backed: if it is not written to workspace files, it will not survive compaction or session boundaries.
+- Before creating a new note, read \`notes/index.md\` and update an existing relevant note when possible instead of creating duplicates.
+- Prefer \`workbooks/<name>/notes.md\` for workbook-specific memory.
+
 ### Tips
-- When you learn something useful about a workbook or domain, save it to \`notes/\`. Future sessions can read \`notes/index.md\` to pick up where you left off.
-- Use \`files list notes/\` or \`files list workbooks/\` to scope listings to a folder instead of listing everything.
+- Future sessions start fresh. \`notes/index.md\` is your memory entry point — read it when notes exist.
+- Use \`files list notes/\` or \`files list workbooks/\` to scope listings instead of listing everything.
 - Prefer text formats (Markdown, CSV, JSON) for workspace files.`;
 
 const WORKFLOW = `## Workflow

--- a/tests/auto-compaction.test.ts
+++ b/tests/auto-compaction.test.ts
@@ -1,7 +1,30 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
 import { shouldAutoCompactForProjectedTokens } from "../src/compaction/auto-compaction.ts";
+import {
+  buildCompactionMemoryFocusInstruction,
+  collectCompactionMemoryCues,
+  mergeCompactionAdditionalFocus,
+} from "../src/compaction/memory-nudge.ts";
+
+function createUserMessage(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp,
+  };
+}
+
+function createAssistantMessage(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp,
+  };
+}
 
 void test("does not trigger auto-compaction before hard threshold", () => {
   const shouldCompact = shouldAutoCompactForProjectedTokens({
@@ -33,4 +56,68 @@ void test("small context windows still use reserve-based hard threshold", () => 
 
   assert.equal(below, false);
   assert.equal(above, true);
+});
+
+void test("collects memory cues from user messages and ignores auto-context", () => {
+  const messages: AgentMessage[] = [
+    createUserMessage("[Auto-context] Please remember this summary.", 1),
+    createUserMessage("Please remember this: this workbook uses calendar year.", 2),
+    createAssistantMessage("Got it.", 3),
+    createUserMessage("Don't forget to keep EUR as the default currency.", 4),
+  ];
+
+  const summary = collectCompactionMemoryCues(messages);
+
+  assert.equal(summary.cueCount, 2);
+  assert.equal(summary.snippets.length, 2);
+  assert.ok(summary.snippets.every((snippet) => !snippet.startsWith("[Auto-context]")));
+  assert.match(summary.snippets[0] ?? "", /remember this/i);
+  assert.match(summary.snippets[1] ?? "", /don['’]t forget/i);
+});
+
+void test("deduplicates snippets and respects snippet limits", () => {
+  const messages: AgentMessage[] = [
+    createUserMessage("Remember this: freeze panes on Summary.", 1),
+    createUserMessage("Remember this: freeze panes on Summary.", 2),
+    createUserMessage("Please save this for future reference: Revenue is net of refunds.", 3),
+    createUserMessage("Please save this for future reference: Revenue is net of refunds.", 4),
+  ];
+
+  const summary = collectCompactionMemoryCues(messages, 1);
+
+  assert.equal(summary.cueCount, 4);
+  assert.equal(summary.snippets.length, 1);
+});
+
+void test("builds memory focus instructions only when cues are present", () => {
+  const noCueInstruction = buildCompactionMemoryFocusInstruction({
+    cueCount: 0,
+    snippets: [],
+  });
+  assert.equal(noCueInstruction, null);
+
+  const instruction = buildCompactionMemoryFocusInstruction({
+    cueCount: 2,
+    snippets: [
+      "Remember this: workbook uses calendar year.",
+      "Don't forget EUR defaults.",
+    ],
+  });
+
+  assert.notEqual(instruction, null);
+  assert.match(instruction ?? "", /instructions tool/i);
+  assert.match(instruction ?? "", /notes\//i);
+  assert.match(instruction ?? "", /Memory to persist/i);
+  assert.match(instruction ?? "", /Potential user cues/i);
+});
+
+void test("merges compaction focus parts", () => {
+  const merged = mergeCompactionAdditionalFocus(
+    "focus on formulas",
+    null,
+    "capture durable memory",
+  );
+
+  assert.equal(merged, "focus on formulas\n\ncapture durable memory");
+  assert.equal(mergeCompactionAdditionalFocus(" ", null, undefined), undefined);
 });

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -117,7 +117,11 @@ void test("system prompt includes workspace folder conventions", () => {
   assert.match(prompt, /scratch\//);
   assert.match(prompt, /imports\//);
   assert.match(prompt, /notes\/index\.md/);
-  assert.match(prompt, /persistent memory/i);
+  assert.match(prompt, /Memory contract/);
+  assert.match(prompt, /remember this/i);
+  assert.match(prompt, /file-backed/i);
+  assert.match(prompt, /\*\*instructions\*\* tool/i);
+  assert.match(prompt, /workbooks\/<name>\/notes\.md/i);
 });
 
 void test("system prompt mentions extension manager tool for chat-driven authoring", () => {


### PR DESCRIPTION
## Summary
- clarify the workspace memory contract in the system prompt:
  - rules vs notes split
  - file-backed durability reminder
  - read-before-write guidance via `notes/index.md`
  - workbook-specific memory path (`workbooks/<name>/notes.md`)
- add a lightweight pre-compaction memory nudge that detects explicit memory cues in messages being compacted
- feed the memory nudge into compaction `Additional focus` so summaries call out durable memory candidates in **Critical Context**
- document the memory nudge behavior in `docs/compaction.md`

## Implementation details
- added `src/compaction/memory-nudge.ts`:
  - `collectCompactionMemoryCues()`
  - `buildCompactionMemoryFocusInstruction()`
  - `mergeCompactionAdditionalFocus()`
- integrated memory cue detection/focus wiring into `/compact` in `src/commands/builtins/export.ts`
- expanded compaction coverage in `tests/auto-compaction.test.ts`
- updated workspace prompt expectations in `tests/system-prompt.test.ts`

## Verification
- `npm run check`
- `npm run build`
- `npm run test:models`
- `npm run test:context`

Closes #268
