### PR TITLE
refactor(recovery): extract format-state normalization helpers

### DIFF
--- a/src/workbook/recovery/format-state-normalization.ts
+++ b/src/workbook/recovery/format-state-normalization.ts
@@ -1,0 +1,197 @@
+import type { RecoveryFormatBorderState } from "./types.js";
+
+export const RECOVERY_BORDER_KEYS = [
+  "borderTop",
+  "borderBottom",
+  "borderLeft",
+  "borderRight",
+  "borderInsideHorizontal",
+  "borderInsideVertical",
+] as const;
+
+export type RecoveryBorderKey = (typeof RECOVERY_BORDER_KEYS)[number];
+
+type RecoveryBorderEdge =
+  | "EdgeTop"
+  | "EdgeBottom"
+  | "EdgeLeft"
+  | "EdgeRight"
+  | "InsideHorizontal"
+  | "InsideVertical";
+
+export const BORDER_KEY_TO_EDGE: Record<RecoveryBorderKey, RecoveryBorderEdge> = {
+  borderTop: "EdgeTop",
+  borderBottom: "EdgeBottom",
+  borderLeft: "EdgeLeft",
+  borderRight: "EdgeRight",
+  borderInsideHorizontal: "InsideHorizontal",
+  borderInsideVertical: "InsideVertical",
+};
+
+type RecoveryUnderlineStyle = "None" | "Single" | "Double" | "SingleAccountant" | "DoubleAccountant";
+
+const RECOVERY_UNDERLINE_STYLES: readonly RecoveryUnderlineStyle[] = [
+  "None",
+  "Single",
+  "Double",
+  "SingleAccountant",
+  "DoubleAccountant",
+];
+
+export function isRecoveryUnderlineStyle(value: unknown): value is RecoveryUnderlineStyle {
+  if (typeof value !== "string") return false;
+
+  for (const candidate of RECOVERY_UNDERLINE_STYLES) {
+    if (candidate === value) return true;
+  }
+
+  return false;
+}
+
+type RecoveryHorizontalAlignment =
+  | "General"
+  | "Left"
+  | "Center"
+  | "Right"
+  | "Fill"
+  | "Justify"
+  | "CenterAcrossSelection"
+  | "Distributed";
+
+const RECOVERY_HORIZONTAL_ALIGNMENTS: readonly RecoveryHorizontalAlignment[] = [
+  "General",
+  "Left",
+  "Center",
+  "Right",
+  "Fill",
+  "Justify",
+  "CenterAcrossSelection",
+  "Distributed",
+];
+
+export function isRecoveryHorizontalAlignment(value: unknown): value is RecoveryHorizontalAlignment {
+  if (typeof value !== "string") return false;
+
+  for (const candidate of RECOVERY_HORIZONTAL_ALIGNMENTS) {
+    if (candidate === value) return true;
+  }
+
+  return false;
+}
+
+type RecoveryVerticalAlignment = "Top" | "Center" | "Bottom" | "Justify" | "Distributed";
+
+const RECOVERY_VERTICAL_ALIGNMENTS: readonly RecoveryVerticalAlignment[] = [
+  "Top",
+  "Center",
+  "Bottom",
+  "Justify",
+  "Distributed",
+];
+
+export function isRecoveryVerticalAlignment(value: unknown): value is RecoveryVerticalAlignment {
+  if (typeof value !== "string") return false;
+
+  for (const candidate of RECOVERY_VERTICAL_ALIGNMENTS) {
+    if (candidate === value) return true;
+  }
+
+  return false;
+}
+
+type RecoveryRangeBorderStyle =
+  | "None"
+  | "Continuous"
+  | "Dash"
+  | "DashDot"
+  | "DashDotDot"
+  | "Dot"
+  | "Double"
+  | "SlantDashDot";
+
+const RECOVERY_RANGE_BORDER_STYLES: readonly RecoveryRangeBorderStyle[] = [
+  "None",
+  "Continuous",
+  "Dash",
+  "DashDot",
+  "DashDotDot",
+  "Dot",
+  "Double",
+  "SlantDashDot",
+];
+
+function isRecoveryRangeBorderStyle(value: unknown): value is RecoveryRangeBorderStyle {
+  if (typeof value !== "string") return false;
+
+  for (const candidate of RECOVERY_RANGE_BORDER_STYLES) {
+    if (candidate === value) return true;
+  }
+
+  return false;
+}
+
+type RecoveryRangeBorderWeight = "Hairline" | "Thin" | "Medium" | "Thick";
+
+const RECOVERY_RANGE_BORDER_WEIGHTS: readonly RecoveryRangeBorderWeight[] = [
+  "Hairline",
+  "Thin",
+  "Medium",
+  "Thick",
+];
+
+function isRecoveryRangeBorderWeight(value: unknown): value is RecoveryRangeBorderWeight {
+  if (typeof value !== "string") return false;
+
+  for (const candidate of RECOVERY_RANGE_BORDER_WEIGHTS) {
+    if (candidate === value) return true;
+  }
+
+  return false;
+}
+
+export function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function normalizeOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export function normalizeOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function captureBorderState(border: Excel.RangeBorder): RecoveryFormatBorderState | null {
+  const styleRaw = border.style;
+  if (!isRecoveryRangeBorderStyle(styleRaw)) {
+    return null;
+  }
+
+  const weightRaw = border.weight;
+  const colorRaw = border.color;
+
+  return {
+    style: styleRaw,
+    weight: isRecoveryRangeBorderWeight(weightRaw) ? weightRaw : undefined,
+    color: normalizeOptionalString(colorRaw),
+  };
+}
+
+export function applyBorderState(border: Excel.RangeBorder, state: RecoveryFormatBorderState): void {
+  if (!isRecoveryRangeBorderStyle(state.style)) {
+    throw new Error("Format checkpoint is invalid: border style is unsupported.");
+  }
+
+  border.style = state.style;
+
+  if (state.style !== "None" && state.weight !== undefined) {
+    if (!isRecoveryRangeBorderWeight(state.weight)) {
+      throw new Error("Format checkpoint is invalid: border weight is unsupported.");
+    }
+    border.weight = state.weight;
+  }
+
+  if (typeof state.color === "string") {
+    border.color = state.color;
+  }
+}

--- a/src/workbook/recovery/format-state.ts
+++ b/src/workbook/recovery/format-state.ts
@@ -13,172 +13,24 @@ import {
 } from "./format-selection.js";
 import type {
   RecoveryFormatAreaState,
-  RecoveryFormatBorderState,
   RecoveryFormatCaptureResult,
   RecoveryFormatRangeState,
   RecoveryFormatSelection,
 } from "./types.js";
 
-const RECOVERY_BORDER_KEYS = [
-  "borderTop",
-  "borderBottom",
-  "borderLeft",
-  "borderRight",
-  "borderInsideHorizontal",
-  "borderInsideVertical",
-] as const;
-
-type RecoveryBorderKey = (typeof RECOVERY_BORDER_KEYS)[number];
-
-type RecoveryBorderEdge =
-  | "EdgeTop"
-  | "EdgeBottom"
-  | "EdgeLeft"
-  | "EdgeRight"
-  | "InsideHorizontal"
-  | "InsideVertical";
-
-const BORDER_KEY_TO_EDGE: Record<RecoveryBorderKey, RecoveryBorderEdge> = {
-  borderTop: "EdgeTop",
-  borderBottom: "EdgeBottom",
-  borderLeft: "EdgeLeft",
-  borderRight: "EdgeRight",
-  borderInsideHorizontal: "InsideHorizontal",
-  borderInsideVertical: "InsideVertical",
-};
-
-type RecoveryUnderlineStyle = "None" | "Single" | "Double" | "SingleAccountant" | "DoubleAccountant";
-
-const RECOVERY_UNDERLINE_STYLES: readonly RecoveryUnderlineStyle[] = [
-  "None",
-  "Single",
-  "Double",
-  "SingleAccountant",
-  "DoubleAccountant",
-];
-
-function isRecoveryUnderlineStyle(value: unknown): value is RecoveryUnderlineStyle {
-  if (typeof value !== "string") return false;
-
-  for (const candidate of RECOVERY_UNDERLINE_STYLES) {
-    if (candidate === value) return true;
-  }
-
-  return false;
-}
-
-type RecoveryHorizontalAlignment =
-  | "General"
-  | "Left"
-  | "Center"
-  | "Right"
-  | "Fill"
-  | "Justify"
-  | "CenterAcrossSelection"
-  | "Distributed";
-
-const RECOVERY_HORIZONTAL_ALIGNMENTS: readonly RecoveryHorizontalAlignment[] = [
-  "General",
-  "Left",
-  "Center",
-  "Right",
-  "Fill",
-  "Justify",
-  "CenterAcrossSelection",
-  "Distributed",
-];
-
-function isRecoveryHorizontalAlignment(value: unknown): value is RecoveryHorizontalAlignment {
-  if (typeof value !== "string") return false;
-
-  for (const candidate of RECOVERY_HORIZONTAL_ALIGNMENTS) {
-    if (candidate === value) return true;
-  }
-
-  return false;
-}
-
-type RecoveryVerticalAlignment = "Top" | "Center" | "Bottom" | "Justify" | "Distributed";
-
-const RECOVERY_VERTICAL_ALIGNMENTS: readonly RecoveryVerticalAlignment[] = [
-  "Top",
-  "Center",
-  "Bottom",
-  "Justify",
-  "Distributed",
-];
-
-function isRecoveryVerticalAlignment(value: unknown): value is RecoveryVerticalAlignment {
-  if (typeof value !== "string") return false;
-
-  for (const candidate of RECOVERY_VERTICAL_ALIGNMENTS) {
-    if (candidate === value) return true;
-  }
-
-  return false;
-}
-
-type RecoveryRangeBorderStyle =
-  | "None"
-  | "Continuous"
-  | "Dash"
-  | "DashDot"
-  | "DashDotDot"
-  | "Dot"
-  | "Double"
-  | "SlantDashDot";
-
-const RECOVERY_RANGE_BORDER_STYLES: readonly RecoveryRangeBorderStyle[] = [
-  "None",
-  "Continuous",
-  "Dash",
-  "DashDot",
-  "DashDotDot",
-  "Dot",
-  "Double",
-  "SlantDashDot",
-];
-
-function isRecoveryRangeBorderStyle(value: unknown): value is RecoveryRangeBorderStyle {
-  if (typeof value !== "string") return false;
-
-  for (const candidate of RECOVERY_RANGE_BORDER_STYLES) {
-    if (candidate === value) return true;
-  }
-
-  return false;
-}
-
-type RecoveryRangeBorderWeight = "Hairline" | "Thin" | "Medium" | "Thick";
-
-const RECOVERY_RANGE_BORDER_WEIGHTS: readonly RecoveryRangeBorderWeight[] = [
-  "Hairline",
-  "Thin",
-  "Medium",
-  "Thick",
-];
-
-function isRecoveryRangeBorderWeight(value: unknown): value is RecoveryRangeBorderWeight {
-  if (typeof value !== "string") return false;
-
-  for (const candidate of RECOVERY_RANGE_BORDER_WEIGHTS) {
-    if (candidate === value) return true;
-  }
-
-  return false;
-}
-
-function normalizeOptionalString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-function normalizeOptionalBoolean(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
-}
-
-function normalizeOptionalNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
+import {
+  BORDER_KEY_TO_EDGE,
+  RECOVERY_BORDER_KEYS,
+  applyBorderState,
+  captureBorderState,
+  isRecoveryHorizontalAlignment,
+  isRecoveryUnderlineStyle,
+  isRecoveryVerticalAlignment,
+  normalizeOptionalBoolean,
+  normalizeOptionalNumber,
+  normalizeOptionalString,
+  type RecoveryBorderKey,
+} from "./format-state-normalization.js";
 
 function normalizeRecoveryAddress(address: string): string {
   return address.trim();
@@ -267,41 +119,6 @@ async function resolveFormatCaptureTarget(
     sheetName: sheet.name,
     areas: [...areasTarget.areas.items],
   };
-}
-
-function captureBorderState(border: Excel.RangeBorder): RecoveryFormatBorderState | null {
-  const styleRaw = border.style;
-  if (!isRecoveryRangeBorderStyle(styleRaw)) {
-    return null;
-  }
-
-  const weightRaw = border.weight;
-  const colorRaw = border.color;
-
-  return {
-    style: styleRaw,
-    weight: isRecoveryRangeBorderWeight(weightRaw) ? weightRaw : undefined,
-    color: normalizeOptionalString(colorRaw),
-  };
-}
-
-function applyBorderState(border: Excel.RangeBorder, state: RecoveryFormatBorderState): void {
-  if (!isRecoveryRangeBorderStyle(state.style)) {
-    throw new Error("Format checkpoint is invalid: border style is unsupported.");
-  }
-
-  border.style = state.style;
-
-  if (state.style !== "None" && state.weight !== undefined) {
-    if (!isRecoveryRangeBorderWeight(state.weight)) {
-      throw new Error("Format checkpoint is invalid: border weight is unsupported.");
-    }
-    border.weight = state.weight;
-  }
-
-  if (typeof state.color === "string") {
-    border.color = state.color;
-  }
 }
 
 function validateStringGrid(

--- a/tests/recovery-log-format.test.ts
+++ b/tests/recovery-log-format.test.ts
@@ -10,6 +10,14 @@ import {
   type RecoveryFormatRangeState,
 } from "../src/workbook/recovery-states.ts";
 import {
+  isRecoveryHorizontalAlignment,
+  isRecoveryUnderlineStyle,
+  isRecoveryVerticalAlignment,
+  normalizeOptionalBoolean,
+  normalizeOptionalNumber,
+  normalizeOptionalString,
+} from "../src/workbook/recovery/format-state-normalization.ts";
+import {
   createInMemorySettingsStore,
   findSnapshotById,
   withoutUndefined,
@@ -53,6 +61,33 @@ void test("estimateFormatCaptureCellCount scales by serialized checkpoint shape"
     2_621_440,
   );
 });
+
+void test("format-state normalization guards accept only supported values", () => {
+  assert.equal(isRecoveryUnderlineStyle("Single"), true);
+  assert.equal(isRecoveryUnderlineStyle("DoubleAccountant"), true);
+  assert.equal(isRecoveryUnderlineStyle("Wave"), false);
+
+  assert.equal(isRecoveryHorizontalAlignment("General"), true);
+  assert.equal(isRecoveryHorizontalAlignment("CenterAcrossSelection"), true);
+  assert.equal(isRecoveryHorizontalAlignment("DistributedAcrossSelection"), false);
+
+  assert.equal(isRecoveryVerticalAlignment("Top"), true);
+  assert.equal(isRecoveryVerticalAlignment("Distributed"), true);
+  assert.equal(isRecoveryVerticalAlignment("Middle"), false);
+});
+
+void test("format-state normalization keeps only optional scalar values", () => {
+  assert.equal(normalizeOptionalString("abc"), "abc");
+  assert.equal(normalizeOptionalString(123), undefined);
+
+  assert.equal(normalizeOptionalBoolean(true), true);
+  assert.equal(normalizeOptionalBoolean("true"), undefined);
+
+  assert.equal(normalizeOptionalNumber(12.5), 12.5);
+  assert.equal(normalizeOptionalNumber(Number.NaN), undefined);
+  assert.equal(normalizeOptionalNumber(Infinity), undefined);
+});
+
 void test("persisted format checkpoints retain dimension state", async () => {
   const settingsStore = createInMemorySettingsStore();
 


### PR DESCRIPTION
## Summary
- extract format-state normalization and enum-guard helpers from `src/workbook/recovery/format-state.ts` into `src/workbook/recovery/format-state-normalization.ts`
- keep `format-state.ts` focused on capture/apply orchestration logic
- add focused assertions in `tests/recovery-log-format.test.ts` for the extracted normalization helpers

## Why
`format-state.ts` mixed low-level normalization/validation helpers with workbook capture/apply flow. Moving these helpers into a dedicated module makes the main file easier to read and keeps validation behavior centralized.

## Validation
- npm run check
- npm run build
- npm run test:models
- npm run test:context
- npm run test:security
