### PR TITLE
refactor(recovery): extract format-state utility helpers

### DIFF
--- a/src/workbook/recovery/format-state-utils.ts
+++ b/src/workbook/recovery/format-state-utils.ts
@@ -1,0 +1,68 @@
+import type { RecoveryFormatRangeState } from "./types.js";
+
+function normalizeRecoveryAddress(address: string): string {
+  return address.trim();
+}
+
+export function dedupeRecoveryAddresses(addresses: readonly string[]): string[] {
+  const unique = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const rawAddress of addresses) {
+    const address = normalizeRecoveryAddress(rawAddress);
+    if (address.length === 0 || unique.has(address)) {
+      continue;
+    }
+
+    unique.add(address);
+    ordered.push(address);
+  }
+
+  return ordered;
+}
+
+export function collectMergedAreaAddresses(state: RecoveryFormatRangeState): string[] {
+  const addresses: string[] = [];
+
+  for (const area of state.areas) {
+    if (!Array.isArray(area.mergedAreas)) {
+      continue;
+    }
+
+    for (const address of area.mergedAreas) {
+      addresses.push(address);
+    }
+  }
+
+  return dedupeRecoveryAddresses(addresses);
+}
+
+export function validateStringGrid(
+  value: unknown,
+  rowCount: number,
+  columnCount: number,
+): string[][] | null {
+  if (!Array.isArray(value) || value.length !== rowCount) {
+    return null;
+  }
+
+  const out: string[][] = [];
+
+  for (const rowValue of value) {
+    if (!Array.isArray(rowValue) || rowValue.length !== columnCount) {
+      return null;
+    }
+
+    const outRow: string[] = [];
+    for (const cellValue of rowValue) {
+      if (typeof cellValue !== "string") {
+        return null;
+      }
+      outRow.push(cellValue);
+    }
+
+    out.push(outRow);
+  }
+
+  return out;
+}

--- a/src/workbook/recovery/format-state.ts
+++ b/src/workbook/recovery/format-state.ts
@@ -31,43 +31,11 @@ import {
   normalizeOptionalString,
   type RecoveryBorderKey,
 } from "./format-state-normalization.js";
-
-function normalizeRecoveryAddress(address: string): string {
-  return address.trim();
-}
-
-function dedupeRecoveryAddresses(addresses: readonly string[]): string[] {
-  const unique = new Set<string>();
-  const ordered: string[] = [];
-
-  for (const rawAddress of addresses) {
-    const address = normalizeRecoveryAddress(rawAddress);
-    if (address.length === 0 || unique.has(address)) {
-      continue;
-    }
-
-    unique.add(address);
-    ordered.push(address);
-  }
-
-  return ordered;
-}
-
-function collectMergedAreaAddresses(state: RecoveryFormatRangeState): string[] {
-  const addresses: string[] = [];
-
-  for (const area of state.areas) {
-    if (!Array.isArray(area.mergedAreas)) {
-      continue;
-    }
-
-    for (const address of area.mergedAreas) {
-      addresses.push(address);
-    }
-  }
-
-  return dedupeRecoveryAddresses(addresses);
-}
+import {
+  collectMergedAreaAddresses,
+  dedupeRecoveryAddresses,
+  validateStringGrid,
+} from "./format-state-utils.js";
 
 interface ResolvedFormatCaptureTarget {
   sheetName: string;
@@ -119,36 +87,6 @@ async function resolveFormatCaptureTarget(
     sheetName: sheet.name,
     areas: [...areasTarget.areas.items],
   };
-}
-
-function validateStringGrid(
-  value: unknown,
-  rowCount: number,
-  columnCount: number,
-): string[][] | null {
-  if (!Array.isArray(value) || value.length !== rowCount) {
-    return null;
-  }
-
-  const out: string[][] = [];
-
-  for (const rowValue of value) {
-    if (!Array.isArray(rowValue) || rowValue.length !== columnCount) {
-      return null;
-    }
-
-    const outRow: string[] = [];
-    for (const cellValue of rowValue) {
-      if (typeof cellValue !== "string") {
-        return null;
-      }
-      outRow.push(cellValue);
-    }
-
-    out.push(outRow);
-  }
-
-  return out;
 }
 
 interface PreparedFormatAreaCapture {


### PR DESCRIPTION
## Summary
- extract format-state utility helpers from `src/workbook/recovery/format-state.ts` into `src/workbook/recovery/format-state-utils.ts`
- move reusable address deduplication/merged-area collection and string-grid validation logic into the helper module
- keep `format-state.ts` focused on capture/apply orchestration
- add focused test coverage in `tests/recovery-log-format.test.ts` for extracted utility behavior

## Why
After the previous normalization extraction, `format-state.ts` still contained generic utility logic mixed with workflow code. This extraction keeps generic helpers centralized and makes the main recovery flow easier to scan.

## Validation
- npm run check
- npm run build
- npm run test:models
- npm run test:context
- npm run test:security
