### PR TITLE
fix(ui): replace remaining window.confirm flows

### DIFF
--- a/src/commands/builtins/recovery-overlay.ts
+++ b/src/commands/builtins/recovery-overlay.ts
@@ -16,6 +16,7 @@ import {
   createOverlayDialog,
   createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
+import { requestConfirmationDialog } from "../../ui/confirm-dialog.js";
 import { RECOVERY_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 
@@ -389,10 +390,19 @@ export async function showRecoveryDialog(opts: {
       deleteButton.addEventListener("click", () => {
         if (busy) return;
 
-        const proceed = window.confirm("Delete this backup?");
-        if (!proceed) return;
-
         void (async () => {
+          const proceed = await requestConfirmationDialog({
+            title: "Delete this backup?",
+            message: `Backup: ${checkpoint.address} (#${shortId(checkpoint.id)})`,
+            confirmLabel: "Delete",
+            cancelLabel: "Cancel",
+            confirmButtonTone: "danger",
+            restoreFocusOnClose: false,
+          });
+          if (!proceed || busy) {
+            return;
+          }
+
           setBusy(true);
           statusText.textContent = "Deleting…";
 
@@ -517,10 +527,19 @@ export async function showRecoveryDialog(opts: {
   clearButton.addEventListener("click", () => {
     if (busy || allCheckpoints.length === 0) return;
 
-    const proceed = window.confirm(`Delete all ${allCheckpoints.length} backups for this workbook?`);
-    if (!proceed) return;
-
     void (async () => {
+      const proceed = await requestConfirmationDialog({
+        title: "Delete all backups for this workbook?",
+        message: `This will delete ${allCheckpoints.length} backup${allCheckpoints.length === 1 ? "" : "s"}.`,
+        confirmLabel: "Delete all",
+        cancelLabel: "Cancel",
+        confirmButtonTone: "danger",
+        restoreFocusOnClose: false,
+      });
+      if (!proceed || busy) {
+        return;
+      }
+
       setBusy(true);
       statusText.textContent = "Clearing…";
       try {

--- a/src/commands/builtins/resume-overlay.ts
+++ b/src/commands/builtins/resume-overlay.ts
@@ -16,6 +16,7 @@ import {
   createOverlayDialog,
   createOverlayHeader,
 } from "../../ui/overlay-dialog.js";
+import { requestConfirmationDialog } from "../../ui/confirm-dialog.js";
 import { RESUME_OVERLAY_ID } from "../../ui/overlay-ids.js";
 import { showToast } from "../../ui/toast.js";
 import { formatWorkbookLabel, getWorkbookContext } from "../../workbook/context.js";
@@ -226,7 +227,13 @@ export async function showResumeDialog(opts: {
       if (workbookId) {
         const linkedWorkbookId = await getSessionWorkbookId(storage.settings, id);
         if (linkedWorkbookId && linkedWorkbookId !== workbookId) {
-          const proceed = window.confirm(getCrossWorkbookResumeConfirmMessage(targetMode));
+          const proceed = await requestConfirmationDialog({
+            title: "Resume session from another workbook?",
+            message: getCrossWorkbookResumeConfirmMessage(targetMode),
+            confirmLabel: "Resume anyway",
+            cancelLabel: "Cancel",
+            restoreFocusOnClose: false,
+          });
           if (!proceed) return;
         }
       }

--- a/src/commands/builtins/session.ts
+++ b/src/commands/builtins/session.ts
@@ -4,6 +4,7 @@
 
 import type { SlashCommand } from "../types.js";
 import type { ResumeDialogTarget } from "./resume-target.js";
+import { requestConfirmationDialog } from "../../ui/confirm-dialog.js";
 import { showToast } from "../../ui/toast.js";
 
 export interface ManualFullBackupSummary {
@@ -175,7 +176,14 @@ export function createSessionLifecycleCommands(actions: SessionCommandActions): 
           }
 
           if (action === "clear") {
-            const proceed = window.confirm("Delete all manual full-workbook backups for this workbook?");
+            const proceed = await requestConfirmationDialog({
+              title: "Delete all manual full-workbook backups?",
+              message: "This will remove all manual full-workbook backups for the active workbook.",
+              confirmLabel: "Delete all",
+              cancelLabel: "Cancel",
+              confirmButtonTone: "danger",
+              restoreFocusOnClose: true,
+            });
             if (!proceed) {
               return;
             }

--- a/src/tools/experimental-tool-gates/wrappers.ts
+++ b/src/tools/experimental-tool-gates/wrappers.ts
@@ -66,21 +66,10 @@ export function buildPythonBridgeApprovalMessage(
 }
 
 function defaultRequestPythonBridgeApproval(
-  request: PythonBridgeApprovalRequest,
+  _request: PythonBridgeApprovalRequest,
 ): Promise<boolean> {
-  if (typeof window === "undefined" || typeof window.confirm !== "function") {
-    return Promise.resolve(true);
-  }
-
-  try {
-    return Promise.resolve(
-      window.confirm(
-        buildPythonBridgeApprovalMessage(request.toolName, request.bridgeUrl, request.params),
-      ),
-    );
-  } catch {
-    return Promise.resolve(true);
-  }
+  // Fails open when no UI approval handler is injected.
+  return Promise.resolve(true);
 }
 
 export function buildOfficeJsExecuteApprovalMessage(
@@ -105,21 +94,11 @@ export function buildOfficeJsExecuteApprovalMessage(
 }
 
 function defaultRequestOfficeJsExecuteApproval(
-  request: OfficeJsExecuteApprovalRequest,
+  _request: OfficeJsExecuteApprovalRequest,
 ): Promise<boolean> {
-  if (typeof window === "undefined" || typeof window.confirm !== "function") {
-    return Promise.reject(new Error(
-      "Office.js execution requires explicit user approval, but confirmation UI is unavailable.",
-    ));
-  }
-
-  try {
-    return Promise.resolve(window.confirm(buildOfficeJsExecuteApprovalMessage(request)));
-  } catch {
-    return Promise.reject(new Error(
-      "Office.js execution requires explicit user approval, but confirmation UI is unavailable.",
-    ));
-  }
+  return Promise.reject(new Error(
+    "Office.js execution requires explicit user approval, but confirmation UI is unavailable.",
+  ));
 }
 
 function getOfficeJsExecuteApprovalRequest(params: unknown): OfficeJsExecuteApprovalRequest {

--- a/src/tools/with-workbook-coordinator.ts
+++ b/src/tools/with-workbook-coordinator.ts
@@ -108,20 +108,10 @@ function defaultGetExecutionMode(): Promise<ExecutionMode> {
   return Promise.resolve("yolo");
 }
 
-function defaultRequestMutationApproval(request: MutationApprovalRequest): Promise<boolean> {
-  if (typeof window === "undefined" || typeof window.confirm !== "function") {
-    return Promise.reject(new Error(
-      "Confirm mode requires explicit user approval, but confirmation UI is unavailable.",
-    ));
-  }
-
-  try {
-    return Promise.resolve(window.confirm(buildMutationApprovalMessage(request)));
-  } catch {
-    return Promise.reject(new Error(
-      "Safe mode requires explicit user approval, but confirmation UI is unavailable.",
-    ));
-  }
+function defaultRequestMutationApproval(_request: MutationApprovalRequest): Promise<boolean> {
+  return Promise.reject(new Error(
+    "Confirm mode requires explicit user approval, but confirmation UI is unavailable.",
+  ));
 }
 
 async function requireMutationApprovalIfNeeded(args: {

--- a/src/ui/overlay-ids.ts
+++ b/src/ui/overlay-ids.ts
@@ -15,5 +15,6 @@ export const SKILLS_OVERLAY_ID = "pi-skills-overlay";
 export const FILES_WORKSPACE_OVERLAY_ID = "pi-files-workspace-overlay";
 export const WELCOME_LOGIN_OVERLAY_ID = "pi-welcome-login-overlay";
 export const PROVIDER_PROMPT_OVERLAY_ID = "pi-prompt-overlay";
+export const CONFIRM_DIALOG_OVERLAY_ID = "pi-confirm-dialog-overlay";
 export const TOOL_APPROVAL_OVERLAY_ID = "pi-tool-approval-overlay";
 export const EXTENSION_OVERLAY_ID = "pi-ext-overlay";

--- a/src/ui/theme/overlays/primitives.css
+++ b/src/ui/theme/overlays/primitives.css
@@ -266,6 +266,11 @@
   color: var(--muted-foreground);
 }
 
+.pi-confirm-dialog__message {
+  margin-bottom: 0;
+  white-space: pre-wrap;
+}
+
 .pi-overlay-header {
   display: flex;
   align-items: flex-start;

--- a/tests/experimental-tool-gates.test.ts
+++ b/tests/experimental-tool-gates.test.ts
@@ -33,25 +33,6 @@ function createTestTool(
   };
 }
 
-function installWindowMock(value: unknown): () => void {
-  const previous = Object.getOwnPropertyDescriptor(globalThis, "window");
-
-  Object.defineProperty(globalThis, "window", {
-    configurable: true,
-    writable: true,
-    value,
-  });
-
-  return () => {
-    if (previous) {
-      Object.defineProperty(globalThis, "window", previous);
-      return;
-    }
-
-    Reflect.deleteProperty(globalThis, "window");
-  };
-}
-
 void test("keeps tmux tool registered when experiment is disabled", async () => {
   let probeCalled = false;
 
@@ -247,62 +228,22 @@ void test("execute_office_js fails closed when confirmation UI is unavailable", 
   assert.equal(executeCount, 0);
 });
 
-void test("execute_office_js maps unsupported window.confirm errors to unavailable UI error", async () => {
+void test("python bridge approvals fail open when no approval handler is configured", async () => {
   let executeCount = 0;
 
-  const restoreWindow = installWindowMock({
-    confirm: () => {
-      throw new Error("Function window.confirm is not supported.");
-    },
+  const [pythonTool] = await applyExperimentalToolGates([
+    createTestTool("python_run", () => {
+      executeCount += 1;
+    }),
+  ], {
+    getPythonBridgeUrl: () => Promise.resolve("https://localhost:3340"),
+    validatePythonBridgeUrl: (url) => url,
+    probePythonBridge: () => Promise.resolve(true),
   });
 
-  try {
-    const [officeTool] = await applyExperimentalToolGates([
-      createTestTool("execute_office_js", () => {
-        executeCount += 1;
-      }),
-    ], {});
-
-    await assert.rejects(
-      () => officeTool.execute("call-office", {
-        explanation: "Rebuild totals",
-        code: "return { ok: true };",
-      }),
-      /approval.*unavailable|confirmation UI is unavailable/i,
-    );
-  } finally {
-    restoreWindow();
-  }
-
-  assert.equal(executeCount, 0);
-});
-
-void test("python bridge approvals fail open when window.confirm is unsupported", async () => {
-  let executeCount = 0;
-
-  const restoreWindow = installWindowMock({
-    confirm: () => {
-      throw new Error("Function window.confirm is not supported.");
-    },
+  await pythonTool.execute("call-python-no-approval-handler", {
+    code: "print('hello')",
   });
-
-  try {
-    const [pythonTool] = await applyExperimentalToolGates([
-      createTestTool("python_run", () => {
-        executeCount += 1;
-      }),
-    ], {
-      getPythonBridgeUrl: () => Promise.resolve("https://localhost:3340"),
-      validatePythonBridgeUrl: (url) => url,
-      probePythonBridge: () => Promise.resolve(true),
-    });
-
-    await pythonTool.execute("call-python-unsupported-confirm", {
-      code: "print('hello')",
-    });
-  } finally {
-    restoreWindow();
-  }
 
   assert.equal(executeCount, 1);
 });

--- a/tests/overlay-dialog.test.ts
+++ b/tests/overlay-dialog.test.ts
@@ -7,8 +7,8 @@ import {
   createOverlayDialog,
   createOverlayDialogManager,
 } from "../src/ui/overlay-dialog.ts";
-import { TOOL_APPROVAL_OVERLAY_ID } from "../src/ui/overlay-ids.ts";
-import { requestToolApprovalDialog } from "../src/taskpane/tool-approval-dialog.ts";
+import { CONFIRM_DIALOG_OVERLAY_ID } from "../src/ui/overlay-ids.ts";
+import { requestConfirmationDialog } from "../src/ui/confirm-dialog.ts";
 import { installFakeDom } from "./fake-dom.test.ts";
 
 void test("closeOverlayById returns false when overlay does not exist", () => {
@@ -138,17 +138,18 @@ void test("overlay dialog manager reuses mounted dialog and resets after dismiss
   }
 });
 
-void test("tool approval dialog resolves true when approval button is clicked", async () => {
+void test("confirmation dialog resolves true when confirm button is clicked", async () => {
   const { document, restore } = installFakeDom();
 
   try {
-    const pendingApproval = requestToolApprovalDialog({
-      title: "Allow workbook mutation in Safe mode?",
+    const pendingApproval = requestConfirmationDialog({
+      title: "Allow workbook mutation in Confirm mode?",
       message: "Tool: write_cells",
       confirmLabel: "Allow once",
+      restoreFocusOnClose: false,
     });
 
-    const overlay = document.getElementById(TOOL_APPROVAL_OVERLAY_ID);
+    const overlay = document.getElementById(CONFIRM_DIALOG_OVERLAY_ID);
     assert.ok(overlay);
 
     const buttons = overlay.querySelectorAll("button");
@@ -174,7 +175,7 @@ void test("tool approval dialog resolves true when approval button is clicked", 
 
     const approved = await pendingApproval;
     assert.equal(approved, true);
-    assert.equal(document.getElementById(TOOL_APPROVAL_OVERLAY_ID), null);
+    assert.equal(document.getElementById(CONFIRM_DIALOG_OVERLAY_ID), null);
   } finally {
     restore();
   }


### PR DESCRIPTION
## Summary
- replace remaining `window.confirm` call sites with a shared overlay confirmation dialog (`src/ui/confirm-dialog.ts`)
- migrate confirmations in recovery, resume, extensions, session backup clear, files delete, and tab-close flows to async dialog confirmations
- wire taskpane runtime tool approvals through the shared confirm dialog with the dedicated tool-approval overlay id
- remove legacy taskpane-only confirm dialog module and add/update tests for the new confirm dialog + gate defaults
- remove direct `window.confirm` usage from tool gate defaults (safe mode and Office.js now fail closed without injected UI, Python bridge remains fail-open)

## Testing
- npm run check
- npm run build
- npm run test:models
- npm run test:context
