### PR TITLE
feat(commands): add tools and addons command entrypoints

### DIFF
--- a/docs/agent-skills-interop.md
+++ b/docs/agent-skills-interop.md
@@ -58,4 +58,4 @@ The system prompt also includes `<available_skills>` entries so the model can ch
 - **Integrations** manage runtime consent, scoping, and local configuration in the Excel add-in.
 
 Use the term **skill** only for standards-based `SKILL.md` artifacts.
-Use **integration** for Excel runtime toggles and UI (`/integrations`).
+Use **integration** for Excel runtime toggles and UI (`/tools`, alias: `/integrations`).

--- a/docs/integrations-external-tools.md
+++ b/docs/integrations-external-tools.md
@@ -7,7 +7,7 @@ Issue: [#24](https://github.com/tmustier/pi-for-excel/issues/24)
 
 ## What shipped
 
-- **Integrations manager UI** (`/integrations`)
+- **Tools & MCP manager UI** (`/tools`, alias: `/integrations`)
   - enable/disable integration bundles per **session** and/or **workbook**
   - clear warnings for network/tool access
   - active integrations shown in the status bar
@@ -17,11 +17,11 @@ Issue: [#24](https://github.com/tmustier/pi-for-excel/issues/24)
 - **Web Search integration**
   - tools: `web_search`, `fetch_page`
   - providers: Serper.dev (default), Tavily, Brave Search
-  - configurable provider + provider-specific API key in `/integrations`
+  - configurable provider + provider-specific API key in `/tools` (or `/integrations`)
   - result output includes explicit `Sent:` attribution and provider/transport metadata
 - **MCP integration**
   - tool: `mcp`
-  - server registry (`mcp.servers.v1`) configurable in `/integrations`
+  - server registry (`mcp.servers.v1`) configurable in `/tools` (or `/integrations`)
   - add/remove/test server URL + optional bearer token
 
 ## Runtime model

--- a/src/commands/builtins/addons-overlay.ts
+++ b/src/commands/builtins/addons-overlay.ts
@@ -5,6 +5,7 @@
  * Integrations, Skills, and Extensions managers.
  */
 
+import { INTEGRATIONS_MANAGER_LABEL } from "../../integrations/naming.js";
 import {
   closeOverlayById,
   createOverlayButton,
@@ -33,7 +34,7 @@ export function showAddonsDialog(actions: AddonsDialogActions): void {
     onClose: dialog.close,
     closeLabel: "Close add-ons",
     title: "Add-ons",
-    subtitle: "Manage integrations, skills, and extensions.",
+    subtitle: "Manage tools & MCP, skills, and extensions.",
   });
 
   const body = document.createElement("div");
@@ -49,7 +50,7 @@ export function showAddonsDialog(actions: AddonsDialogActions): void {
   actionsRow.className = "pi-overlay-actions";
 
   const integrationsButton = createOverlayButton({
-    text: "Integrations",
+    text: INTEGRATIONS_MANAGER_LABEL,
     className: "pi-overlay-btn--primary",
   });
   integrationsButton.addEventListener("click", () => {

--- a/src/commands/builtins/addons.ts
+++ b/src/commands/builtins/addons.ts
@@ -1,0 +1,22 @@
+/**
+ * Builtin command for Add-ons entrypoint UI.
+ */
+
+import type { SlashCommand } from "../types.js";
+
+export interface AddonsCommandActions {
+  openAddonsManager: () => void | Promise<void>;
+}
+
+export function createAddonsCommands(actions: AddonsCommandActions): SlashCommand[] {
+  return [
+    {
+      name: "addons",
+      description: "Open Add-ons (Tools & MCP, Skills, Extensions)",
+      source: "builtin",
+      execute: () => {
+        void actions.openAddonsManager();
+      },
+    },
+  ];
+}

--- a/src/commands/builtins/experimental.ts
+++ b/src/commands/builtins/experimental.ts
@@ -167,7 +167,7 @@ function getLegacyFeatureRedirectMessage(featureArg: string): string | null {
     return null;
   }
 
-  return "External tools (including MCP) are managed in /integrations (Tools & MCP), not /experimental.";
+  return "External tools (including MCP) are managed in /tools (alias: /integrations), not /experimental.";
 }
 
 function usageText(): string {

--- a/src/commands/builtins/index.ts
+++ b/src/commands/builtins/index.ts
@@ -13,11 +13,17 @@ import { createExportCommands, createCompactCommands } from "./export.js";
 import { createSessionIdentityCommands, createSessionLifecycleCommands, type SessionCommandActions } from "./session.js";
 import { createHelpCommands } from "./help.js";
 import { createExtensionsCommands, type ExtensionsCommandActions } from "./extensions.js";
+import { createAddonsCommands, type AddonsCommandActions } from "./addons.js";
 import { createIntegrationsCommands, type IntegrationsCommandActions } from "./integrations.js";
 import { createSkillsCommands, type SkillsCommandActions } from "./skills.js";
 
 export interface BuiltinsContext
-  extends SessionCommandActions, SettingsCommandActions, ExtensionsCommandActions, IntegrationsCommandActions, SkillsCommandActions {
+  extends SessionCommandActions,
+    SettingsCommandActions,
+    ExtensionsCommandActions,
+    AddonsCommandActions,
+    IntegrationsCommandActions,
+    SkillsCommandActions {
   getActiveAgent: ActiveAgentProvider;
 }
 
@@ -27,6 +33,7 @@ export function registerBuiltins(context: BuiltinsContext): void {
   const builtins: SlashCommand[] = [
     ...createModelCommands(context.getActiveAgent),
     ...createSettingsCommands(context),
+    ...createAddonsCommands(context),
     ...createIntegrationsCommands(context),
     ...createSkillsCommands(context),
     ...createExperimentalCommands(),

--- a/src/commands/builtins/integrations.ts
+++ b/src/commands/builtins/integrations.ts
@@ -2,7 +2,11 @@
  * Builtin command for integration management UI.
  */
 
-import { INTEGRATIONS_COMMAND_NAME, INTEGRATIONS_MANAGER_LABEL_LOWER } from "../../integrations/naming.js";
+import {
+  INTEGRATIONS_COMMAND_NAME,
+  INTEGRATIONS_MANAGER_LABEL_LOWER,
+  TOOLS_COMMAND_NAME,
+} from "../../integrations/naming.js";
 import type { SlashCommand } from "../types.js";
 
 export interface IntegrationsCommandActions {
@@ -10,14 +14,22 @@ export interface IntegrationsCommandActions {
 }
 
 export function createIntegrationsCommands(actions: IntegrationsCommandActions): SlashCommand[] {
+  const openManager = () => {
+    void actions.openIntegrationsManager();
+  };
+
   return [
     {
-      name: INTEGRATIONS_COMMAND_NAME,
+      name: TOOLS_COMMAND_NAME,
       description: `Manage ${INTEGRATIONS_MANAGER_LABEL_LOWER} (web search, page fetch, MCP)`,
       source: "builtin",
-      execute: () => {
-        void actions.openIntegrationsManager();
-      },
+      execute: openManager,
+    },
+    {
+      name: INTEGRATIONS_COMMAND_NAME,
+      description: `Alias for /${TOOLS_COMMAND_NAME}`,
+      source: "builtin",
+      execute: openManager,
     },
   ];
 }

--- a/src/commands/busy-command-policy.ts
+++ b/src/commands/busy-command-policy.ts
@@ -5,7 +5,7 @@
  * execution cannot drift.
  */
 
-import { INTEGRATIONS_COMMAND_NAME } from "../integrations/naming.js";
+import { INTEGRATIONS_COMMAND_NAME, TOOLS_COMMAND_NAME } from "../integrations/naming.js";
 
 const BUSY_ALLOWED_COMMANDS = new Set<string>([
   "compact",
@@ -17,6 +17,8 @@ const BUSY_ALLOWED_COMMANDS = new Set<string>([
   "yolo",
   "extensions",
   "skills",
+  "addons",
+  TOOLS_COMMAND_NAME,
   INTEGRATIONS_COMMAND_NAME,
 ]);
 

--- a/src/integrations/naming.ts
+++ b/src/integrations/naming.ts
@@ -6,6 +6,7 @@
  */
 
 export const INTEGRATIONS_COMMAND_NAME = "integrations";
+export const TOOLS_COMMAND_NAME = "tools";
 
 export const INTEGRATION_LABEL = "Integration";
 export const INTEGRATION_LABEL_LOWER = "integration";
@@ -20,7 +21,7 @@ export const ACTIVE_INTEGRATIONS_PROMPT_HEADING = "Active Integrations";
 export const ACTIVE_INTEGRATIONS_TOOLTIP_PREFIX = "Active integrations";
 
 export function integrationsCommandHint(): string {
-  return `/${INTEGRATIONS_COMMAND_NAME}`;
+  return `/${TOOLS_COMMAND_NAME} (or /${INTEGRATIONS_COMMAND_NAME})`;
 }
 
 export function formatIntegrationCountLabel(count: number): string {

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -1357,6 +1357,7 @@ export async function initTaskpane(opts: {
     getExecutionMode: () => Promise.resolve(getExecutionMode()),
     setExecutionMode,
     openExtensionsManager,
+    openAddonsManager,
     openIntegrationsManager,
     openSkillsManager,
   });

--- a/tests/experimental-command.test.ts
+++ b/tests/experimental-command.test.ts
@@ -164,7 +164,7 @@ void test("/experimental on with unknown feature reports available slugs", async
   assert.match(toasts[0], /tmux-bridge/u);
 });
 
-void test("/experimental on mcp-tools redirects to /integrations", async () => {
+void test("/experimental on mcp-tools redirects to /tools alias", async () => {
   const toasts: string[] = [];
 
   const command = getExperimentalCommand({
@@ -178,7 +178,8 @@ void test("/experimental on mcp-tools redirects to /integrations", async () => {
   await command.execute("on mcp-tools");
 
   assert.equal(toasts.length, 1);
-  assert.match(toasts[0], /managed in \/integrations/u);
+  assert.match(toasts[0], /managed in \/tools/u);
+  assert.match(toasts[0], /alias: \/integrations/u);
 });
 
 void test("/experimental tmux-bridge-url shows configured value", async () => {


### PR DESCRIPTION
## Summary

Phase 5 for #176: tighten capability taxonomy discoverability by aligning command entrypoints and labels around **Add-ons** + **Tools & MCP** while preserving `/integrations` backward compatibility.

## What changed

### 1) New slash command: `/addons`

Added `src/commands/builtins/addons.ts` and wired it in builtins registration.

- `/addons` opens the Add-ons manager directly.
- This mirrors the gear-menu "Add-ons…" entrypoint for keyboard-first workflows.

### 2) New slash alias: `/tools` (with `/integrations` preserved)

Updated `src/commands/builtins/integrations.ts`:

- Added `/tools` command to open Tools & MCP manager.
- Kept `/integrations` as a stable alias (same action).
- Updated descriptions to make alias semantics explicit.

Updated naming helper in `src/integrations/naming.ts`:

- Added `TOOLS_COMMAND_NAME`.
- `integrationsCommandHint()` now surfaces `/tools` first while still showing `/integrations` as alias.

### 3) Add-ons overlay label consistency

Updated `src/commands/builtins/addons-overlay.ts`:

- Replaced hardcoded "Integrations" button label with shared `INTEGRATIONS_MANAGER_LABEL` (`Tools & MCP`).
- Updated subtitle copy to match.

### 4) Busy-command policy

Updated `src/commands/busy-command-policy.ts`:

- Added `/addons` and `/tools` to busy-allowed overlay/navigation commands.

### 5) Wiring + copy consistency

- `src/commands/builtins/index.ts`: register add-ons command set.
- `src/taskpane/init.ts`: pass `openAddonsManager` into `registerBuiltins()` context.
- `src/commands/builtins/experimental.ts` and `experimental-overlay.ts`: updated legacy MCP redirect messaging to `/tools` (alias `/integrations`).

### 6) Docs updates

- `docs/integrations-external-tools.md`
- `docs/agent-skills-interop.md`

Both now document `/tools` with `/integrations` alias for compatibility.

### 7) Tests

Updated:
- `tests/builtins-registry.test.ts`
- `tests/experimental-command.test.ts`

Added coverage for:
- add-ons command registration
- tools alias semantics
- add-ons overlay naming reuse
- busy policy updates
- updated experimental redirect copy

## Validation

- `npm run check`
- `npm run build`
- Targeted tests:
  - `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/experimental-command.test.ts tests/builtins-registry.test.ts`
- Manual smoke (`agent-browser`):
  - gear menu → Add-ons overlay shows **Tools & MCP** button
  - slash menu shows `/addons`, `/tools`, and `/integrations` alias

Refs: #176
