### PR TITLE
feat(python): make Python capability intuitive to agent and users

### DIFF
--- a/src/commands/builtins/experimental-overlay.ts
+++ b/src/commands/builtins/experimental-overlay.ts
@@ -150,6 +150,8 @@ export function buildExperimentalFeatureContent(): HTMLDivElement {
     }));
   }
 
+  content.appendChild(buildPythonBridgeSection());
+
   if (advancedSecurityFeatures.length > 0) {
     content.appendChild(buildFeatureSection({
       title: "Advanced / security controls",
@@ -168,13 +170,87 @@ export function buildExperimentalFeatureContent(): HTMLDivElement {
   return content;
 }
 
+function buildPythonBridgeSection(): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "pi-overlay-section pi-experimental-section";
+
+  const title = document.createElement("h3");
+  title.className = "pi-overlay-section-title";
+  title.textContent = "Native Python bridge";
+
+  const hint = document.createElement("p");
+  hint.className = "pi-overlay-hint";
+  hint.textContent =
+    "Python already works out of the box via Pyodide (in-browser WebAssembly). "
+    + "The native bridge is optional — it connects to a local Python process for "
+    + "full ecosystem access (C extensions, filesystem, long-running scripts).";
+
+  const commands = document.createElement("div");
+  commands.className = "pi-experimental-list";
+
+  const urlRow = document.createElement("div");
+  urlRow.className = "pi-experimental-row";
+
+  const urlHeader = document.createElement("div");
+  urlHeader.className = "pi-experimental-row__header";
+
+  const urlTitle = document.createElement("div");
+  urlTitle.className = "pi-experimental-row__title";
+  urlTitle.textContent = "Bridge URL";
+
+  urlHeader.appendChild(urlTitle);
+
+  const urlDesc = document.createElement("div");
+  urlDesc.className = "pi-experimental-row__description";
+  urlDesc.textContent = "Set the URL of your local Python bridge server (e.g. https://localhost:3340).";
+
+  const urlMeta = document.createElement("div");
+  urlMeta.className = "pi-experimental-row__meta";
+
+  const urlCommand = document.createElement("code");
+  urlCommand.className = "pi-experimental-row__command";
+  urlCommand.textContent = "/experimental python-bridge-url <url|show|clear>";
+
+  urlMeta.appendChild(urlCommand);
+  urlRow.append(urlHeader, urlDesc, urlMeta);
+
+  const tokenRow = document.createElement("div");
+  tokenRow.className = "pi-experimental-row";
+
+  const tokenHeader = document.createElement("div");
+  tokenHeader.className = "pi-experimental-row__header";
+
+  const tokenTitle = document.createElement("div");
+  tokenTitle.className = "pi-experimental-row__title";
+  tokenTitle.textContent = "Bridge token";
+
+  tokenHeader.appendChild(tokenTitle);
+
+  const tokenDesc = document.createElement("div");
+  tokenDesc.className = "pi-experimental-row__description";
+  tokenDesc.textContent = "Optional bearer token if your bridge server requires authentication.";
+
+  const tokenMeta = document.createElement("div");
+  tokenMeta.className = "pi-experimental-row__meta";
+
+  const tokenCommand = document.createElement("code");
+  tokenCommand.className = "pi-experimental-row__command";
+  tokenCommand.textContent = "/experimental python-bridge-token <token|show|clear>";
+
+  tokenMeta.appendChild(tokenCommand);
+  tokenRow.append(tokenHeader, tokenDesc, tokenMeta);
+
+  commands.append(urlRow, tokenRow);
+  section.append(title, hint, commands);
+  return section;
+}
+
 export function buildExperimentalFeatureFooter(): HTMLParagraphElement {
   const footer = document.createElement("p");
   footer.className = "pi-experimental-footer";
   footer.textContent =
     "Tip: use /experimental on <feature>, /experimental off <feature>, /experimental toggle <feature>, "
-    + "/experimental tmux-bridge-url <url>, /experimental tmux-bridge-token <token>, /experimental tmux-status, "
-    + "/experimental python-bridge-url <url>, or /experimental python-bridge-token <token>.";
+    + "/experimental tmux-bridge-url <url>, /experimental tmux-bridge-token <token>, or /experimental tmux-status.";
   return footer;
 }
 

--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -216,6 +216,16 @@ ${CORE_TOOL_PROMPT_LINES}
 - **extensions_manager** — list/install/reload/enable/disable/uninstall sidebar extensions from code (for extension authoring from chat)
 - **execute_office_js** — run direct Office.js against the active workbook when structured tools cannot express the operation (explanation + user approval required)
 
+### Python
+
+Two Python tools are always available:
+- **python_run** — execute a Python snippet and inspect stdout/stderr/result. Use for computation, data processing, or analysis that is awkward in formulas.
+- **python_transform_range** — read an Excel range into Python as \`input_data\`, transform it, and write the result grid back. One tool call for read → compute → write.
+
+Python runs **in-browser via Pyodide** (WebAssembly) by default — no setup required. Standard-library modules and pure-Python packages (numpy, pandas, scipy, etc.) work out of the box. Auto-install via micropip handles most imports automatically.
+
+If the user has configured a **native Python bridge** (power-user opt-in via Settings → Experimental), execution uses their local Python instead. This unlocks the full ecosystem (C extensions, filesystem, long-running scripts). Prefer Pyodide unless the task requires native-only capabilities.
+
 Other tools may be available depending on enabled experiments/integrations.
 Use **files** for workspace artifacts (list/read/write/delete files). Pass \`path\` on \`list\` to scope to a folder.
 Built-in assistant docs are always available under \`assistant-docs/\` (for example \`assistant-docs/docs/extensions.md\`).

--- a/src/tools/python-run.ts
+++ b/src/tools/python-run.ts
@@ -362,9 +362,9 @@ function buildOutputPreview(output: string | undefined): string | undefined {
 
 function buildNoPythonAvailableMessage(): string {
   return (
-    "No Python runtime available. " +
-    "Configure a native bridge with /experimental python-bridge-url https://localhost:3340, " +
-    "or use a browser that supports WebAssembly (for in-browser Pyodide)."
+    "Python is unavailable in this environment. " +
+    "The current browser/WebView does not support WebAssembly Workers (needed for in-browser Pyodide). " +
+    "Power users can configure a native Python bridge in Settings → Experimental."
   );
 }
 
@@ -397,8 +397,9 @@ export function createPythonRunTool(
     name: "python_run",
     label: "Python Run",
     description:
-      "Run Python code. Uses a local bridge if configured, otherwise " +
-      "falls back to in-browser Pyodide (WebAssembly). " +
+      "Run Python code in-browser via Pyodide (no setup needed). " +
+      "Standard library and pure-Python packages (numpy, pandas, etc.) work automatically. " +
+      "If a native Python bridge is configured, uses local Python instead. " +
       "Pass optional input_json, inspect stdout/stderr, and chain results into write_cells.",
     parameters: schema,
     execute: async (

--- a/src/tools/python-transform-range.ts
+++ b/src/tools/python-transform-range.ts
@@ -401,8 +401,9 @@ export function createPythonTransformRangeTool(
     name: "python_transform_range",
     label: "Python Transform Range",
     description:
-      "Read an Excel range, run Python transformation on `{ range, values }`, " +
-      "and write the result grid back to Excel.",
+      "Read an Excel range, run Python transformation on `{ range, values }` (available as `input_data`), " +
+      "and write the result grid back. " +
+      "Runs in-browser via Pyodide by default; uses native Python bridge when configured.",
     parameters: schema,
     execute: async (
       toolCallId: string,
@@ -450,9 +451,9 @@ export function createPythonTransformRangeTool(
               content: [{
                 type: "text",
                 text:
-                  "No Python runtime available. " +
-                  "Configure a native bridge with /experimental python-bridge-url https://localhost:3340, " +
-                  "or use a browser that supports WebAssembly (for in-browser Pyodide).",
+                  "Python is unavailable in this environment. " +
+                  "The current browser/WebView does not support WebAssembly Workers (needed for in-browser Pyodide). " +
+                  "Power users can configure a native Python bridge in Settings → Experimental.",
               }],
               details: {
                 kind: "python_transform_range",

--- a/tests/python-pyodide-fallback.test.ts
+++ b/tests/python-pyodide-fallback.test.ts
@@ -94,7 +94,7 @@ void test("python_run returns error when neither bridge nor Pyodide available", 
 
   assert.equal(result.details?.ok, false);
   assert.equal(result.details?.error, "no_python_runtime");
-  assert.match(firstText(result), /No Python runtime available/);
+  assert.match(firstText(result), /Python is unavailable/);
 });
 
 void test("python_run propagates Pyodide execution errors", async () => {

--- a/tests/python-run-tool.test.ts
+++ b/tests/python-run-tool.test.ts
@@ -27,7 +27,7 @@ void test("python_run returns guidance when no backend is available", async () =
 
   const result = await tool.execute("tc-missing", { code: "print('hello')" });
 
-  assert.match(firstText(result), /No Python runtime available/u);
+  assert.match(firstText(result), /Python is unavailable/u);
   assert.equal(result.details?.kind, "python_bridge");
   assert.equal(result.details?.ok, false);
   assert.equal(result.details?.error, "no_python_runtime");

--- a/tests/python-transform-range-tool.test.ts
+++ b/tests/python-transform-range-tool.test.ts
@@ -39,7 +39,7 @@ void test("python_transform_range returns bridge setup guidance when URL is miss
     code: "result = input_data['values']",
   });
 
-  assert.match(firstText(result), /No Python runtime available/u);
+  assert.match(firstText(result), /Python is unavailable/u);
   assert.equal(result.details?.kind, "python_transform_range");
   assert.equal(result.details?.blocked, false);
   assert.equal(result.details?.error, "no_python_runtime");

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -89,6 +89,16 @@ void test("system prompt includes workbook history recovery tool", () => {
   assert.match(prompt, /modify_structure/);
 });
 
+void test("system prompt documents Python tools and Pyodide default", () => {
+  const prompt = buildSystemPrompt();
+  assert.match(prompt, /### Python/);
+  assert.match(prompt, /\*\*python_run\*\*/);
+  assert.match(prompt, /\*\*python_transform_range\*\*/);
+  assert.match(prompt, /Pyodide/);
+  assert.match(prompt, /no setup required/i);
+  assert.match(prompt, /native Python bridge/i);
+});
+
 void test("system prompt documents trace_dependencies precedents/dependents modes", () => {
   const prompt = buildSystemPrompt();
   assert.match(prompt, /\*\*trace_dependencies\*\*/);


### PR DESCRIPTION
## Summary

Make the Python capability intuitive to the agent and clear to users.

**Problem:** The agent had no awareness that Python tools existed (nothing in the system prompt). Tool descriptions led with "local bridge if configured, falls back to Pyodide" — implying setup was needed. Error messages directed users to `/experimental python-bridge-url` even though Pyodide works out of the box. The settings UI buried bridge config with no explanation of what Pyodide already provides.

**Solution:**

### System prompt
Added a `### Python` section under Tools that:
- Documents `python_run` and `python_transform_range` as always-available
- Explains Pyodide runs in-browser by default with zero setup
- Mentions native bridge as a power-user opt-in for C extensions / filesystem / long-running scripts

### Tool descriptions
- `python_run`: leads with "Run Python code in-browser via Pyodide (no setup needed)"
- `python_transform_range`: clarifies "Runs in-browser via Pyodide by default"

### Error messages
- Replaced "No Python runtime available. Configure a native bridge..." with clear explanation that WebAssembly Workers are unavailable in the current environment, and the native bridge is a power-user option in Settings

### Settings → Experimental overlay
- Added dedicated "Native Python bridge" section with:
  - Clear explanation that Python already works via Pyodide
  - Bridge URL and token config rows with command hints

### DECISIONS.md
- Updated Python section to document the two-tier runtime model and agent awareness

## Testing
- All existing tests updated and passing (error message assertions)
- New system prompt test verifying Python section content
- `npm run build` clean
- `npm run typecheck` clean (pre-existing Excel namespace errors only)
