### PR TITLE
docs(smoke): prefer /tools command in h1 operator template

### DIFF
--- a/docs/release-smoke-runs/templates/macos-h1-host-operator-template.md
+++ b/docs/release-smoke-runs/templates/macos-h1-host-operator-template.md
@@ -20,7 +20,7 @@ Validate all H-1 failure paths produce clear, recoverable UX:
 2. Sideload latest manifest and open Pi taskpane.
 3. Ensure screenshot path exists, e.g. `~/Desktop/pi-h1-<date>/`.
 4. In Pi:
-   - open `/integrations`
+   - open `/tools` (alias: `/integrations`)
    - enable `Allow external tools (web search / MCP)`
    - enable web search for this session
 5. Record baseline screenshot (`h1-baseline.png`).
@@ -39,7 +39,7 @@ Validate all H-1 failure paths produce clear, recoverable UX:
 
 ## H1-A — Wrong API key
 
-1. `/integrations` → Web Search provider = Serper (or your configured provider).
+1. `/tools` (or `/integrations`) → Web Search provider = Serper (or your configured provider).
 2. Set key to an intentionally invalid value (e.g. `bad-key-h1`).
 3. Prompt: `Use web_search for 'EUR USD exchange rate' and show raw result.`
 


### PR DESCRIPTION
## Summary

Follow-up closeout for #176 after PR #291:
update remaining smoke-run operator guidance to use `/tools` as primary command while keeping `/integrations` alias documented.

## Changes

- `docs/release-smoke-runs/templates/macos-h1-host-operator-template.md`
  - Pre-run setup now says: open `/tools` (alias: `/integrations`)
  - H1-A scenario now references `/tools` (or `/integrations`)

## Why

PR #291 unified Add-ons and command routing semantics. This finishes the operator-facing docs alignment so release runbooks match shipped command taxonomy.

## Validation

- `npm run check`
- `npm run build`

Refs: #176
