### PR TITLE
test(proxy): cover dev cloudcode rewrite precedence

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -124,6 +124,19 @@ If the user is non-technical, a teammate/admin can run this step for them on the
 
 3. Retry OAuth login
 
+Quick proxy sanity check (advanced):
+- In Terminal, run:
+
+```bash
+curl -k -i -s \
+  'https://localhost:3000/api-proxy/google-cloudcode/v1internal:streamGenerateContent?alt=sse' \
+  -X POST -H 'content-type: application/json' -d '{}' | head
+```
+
+- `401` means proxy routing is working (request reached Google, but without auth token).
+- `404` usually means a proxy/path issue.
+- Use single quotes around the URL in zsh so `?alt=sse` is not treated as a glob.
+
 Notes:
 - Keep the proxy URL on **HTTPS** (`https://...`), not HTTP.
 - API-key providers generally work without proxy.

--- a/src/auth/dev-rewrites.ts
+++ b/src/auth/dev-rewrites.ts
@@ -1,0 +1,33 @@
+/**
+ * Dev-only fetch rewrite rules for Vite proxy routes.
+ *
+ * Keep the list ordered from most specific to least specific prefixes.
+ */
+
+export const DEV_REWRITES: ReadonlyArray<readonly [prefix: string, proxy: string]> = [
+  // OAuth token endpoints
+  ["https://console.anthropic.com/", "/oauth-proxy/anthropic/"],
+  ["https://github.com/", "/oauth-proxy/github/"],
+  ["https://auth.openai.com/", "/api-proxy/openai-auth/"],
+  ["https://oauth2.googleapis.com/", "/api-proxy/google-oauth/"],
+
+  // API endpoints
+  ["https://api.anthropic.com/", "/api-proxy/anthropic/"],
+  ["https://api.openai.com/", "/api-proxy/openai/"],
+  ["https://chatgpt.com/", "/api-proxy/chatgpt/"],
+
+  // Google routes: keep Cloud Code Assist entries before generic Google route.
+  ["https://daily-cloudcode-pa.sandbox.googleapis.com/", "/api-proxy/google-cloudcode-sandbox/"],
+  ["https://cloudcode-pa.googleapis.com/", "/api-proxy/google-cloudcode/"],
+  ["https://generativelanguage.googleapis.com/", "/api-proxy/google/"],
+];
+
+export function rewriteDevProxyUrl(url: string): string | null {
+  for (const [prefix, proxy] of DEV_REWRITES) {
+    if (url.startsWith(prefix)) {
+      return url.replace(prefix, proxy);
+    }
+  }
+
+  return null;
+}

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -10,6 +10,7 @@ import {
   providerPriority,
 } from "../src/models/model-ordering.ts";
 import { BROWSER_OAUTH_PROVIDERS, mapToApiProvider } from "../src/auth/provider-map.ts";
+import { rewriteDevProxyUrl } from "../src/auth/dev-rewrites.ts";
 import { installProcessEnvShim } from "../src/compat/process-env-shim.ts";
 
 void test("parseMajorMinor packs Claude-style -major-minor as major*10+minor", () => {
@@ -108,6 +109,25 @@ void test("process-env shim adds process.env for browser-like runtimes", () => {
 
   const envValue = runtime.process.env;
   assert.ok(envValue && typeof envValue === "object" && !Array.isArray(envValue));
+});
+
+void test("dev rewrite routes cloudcode hosts to dedicated proxies", () => {
+  assert.equal(
+    rewriteDevProxyUrl("https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"),
+    "/api-proxy/google-cloudcode/v1internal:streamGenerateContent?alt=sse",
+  );
+
+  assert.equal(
+    rewriteDevProxyUrl("https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:streamGenerateContent?alt=sse"),
+    "/api-proxy/google-cloudcode-sandbox/v1internal:streamGenerateContent?alt=sse",
+  );
+
+  assert.equal(
+    rewriteDevProxyUrl("https://generativelanguage.googleapis.com/v1beta/models"),
+    "/api-proxy/google/v1beta/models",
+  );
+
+  assert.equal(rewriteDevProxyUrl("https://example.com/test"), null);
 });
 
 void test("vite proxy orders Google routes from most specific to least specific", () => {


### PR DESCRIPTION
## Summary
- extract dev rewrite rules into `src/auth/dev-rewrites.ts` with a shared `rewriteDevProxyUrl()` helper
- use `rewriteDevProxyUrl()` inside `src/auth/cors-proxy.ts` to keep rewrite behavior centralized and testable
- add regression assertions in `tests/model-ordering.test.ts` for Cloud Code Assist dev rewrites:
  - `cloudcode-pa.googleapis.com` → `/api-proxy/google-cloudcode/...`
  - `daily-cloudcode-pa.sandbox.googleapis.com` → `/api-proxy/google-cloudcode-sandbox/...`
  - generic Google host still maps to `/api-proxy/google/...`
- update `docs/install.md` with an OAuth proxy sanity check command, plus 401-vs-404 interpretation and zsh quoting guidance

## Validation
- `npm run check`
- `npm run test:models`
- `npm run typecheck`
