### PR TITLE
feat(integrations): default external tools gate to on

### DIFF
--- a/docs/integrations-external-tools.md
+++ b/docs/integrations-external-tools.md
@@ -12,11 +12,11 @@ Issue: [#24](https://github.com/tmustier/pi-for-excel/issues/24)
   - clear warnings for network/tool access
   - active integrations shown in the status bar
 - **Global safety gate**: `external.tools.enabled`
-  - default: **off**
-  - blocks all external integration tools until user enables it
+  - default: **on**
+  - when disabled, blocks all external integration tools
 - **Web Search integration**
   - tools: `web_search`, `fetch_page`
-  - providers: Serper.dev (default), Tavily, Brave Search
+  - providers: Jina (default, no key required), Serper.dev, Tavily, Brave Search
   - configurable provider + provider-specific API key in `/tools` (or `/integrations`)
   - result output includes explicit `Sent:` attribution and provider/transport metadata
 - **MCP integration**

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -91,7 +91,7 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
     onClose: closeOverlay,
     closeLabel: "Close tools and MCP",
     title: INTEGRATIONS_MANAGER_LABEL,
-    subtitle: "Manage web search, page fetch, and MCP servers. External tools are off by default.",
+    subtitle: "Manage web search, page fetch, and MCP servers. External tools are on by default.",
   });
 
   const elements = createIntegrationsDialogElements();

--- a/src/integrations/store.ts
+++ b/src/integrations/store.ts
@@ -227,6 +227,8 @@ function parseStoredBoolean(value: unknown): boolean {
 
 export async function getExternalToolsEnabled(settings: IntegrationSettingsStore): Promise<boolean> {
   const raw = await settings.get(EXTERNAL_TOOLS_ENABLED_SETTING_KEY);
+  // Default ON so web search works out of the box with zero additional setup.
+  if (raw == null) return true;
   return parseStoredBoolean(raw);
 }
 

--- a/tests/integrations-store.test.ts
+++ b/tests/integrations-store.test.ts
@@ -88,16 +88,16 @@ void test("setIntegrationEnabledInScope toggles session/workbook flags", async (
   );
 });
 
-void test("external tools gate defaults off and can be enabled", async () => {
+void test("external tools gate defaults on and can be disabled", async () => {
   const settings = new MemorySettingsStore();
 
-  assert.equal(await getExternalToolsEnabled(settings), false);
-
-  await setExternalToolsEnabled(settings, true);
   assert.equal(await getExternalToolsEnabled(settings), true);
 
   await setExternalToolsEnabled(settings, false);
   assert.equal(await getExternalToolsEnabled(settings), false);
+
+  await setExternalToolsEnabled(settings, true);
+  assert.equal(await getExternalToolsEnabled(settings), true);
 });
 
 void test("unconfigured session scope is explicit empty", async () => {


### PR DESCRIPTION
## Summary
- default `external.tools.enabled` to **on** when unset
- keep web search default-enabled behavior from #300
- update Integrations overlay copy to reflect the new default
- update integration-store tests for the new gate default
- refresh integrations docs to match current behavior (`external.tools.enabled` default + Jina default provider)

## Why
Current flow still requires users to discover and enable the global external-tools switch before web search works. This removes that friction so web search is available out of the box.

## Validation
- `npm run check`
- `npm run build`
- `npx tsx --test tests/integrations-store.test.ts`
