### PR TITLE
feat(settings): tabbed settings flow for logins/extensions/more

### DIFF
--- a/src/commands/builtins/settings.ts
+++ b/src/commands/builtins/settings.ts
@@ -6,7 +6,7 @@ import type { ExecutionMode } from "../../execution/mode.js";
 import { formatExecutionModeLabel, toggleExecutionMode } from "../../execution/mode.js";
 import { showToast } from "../../ui/toast.js";
 import type { SlashCommand } from "../types.js";
-import { showProviderPicker, showSettingsDialog } from "./overlays.js";
+import { showSettingsDialog } from "./overlays.js";
 
 export interface SettingsCommandActions {
   openInstructionsEditor: () => Promise<void>;
@@ -53,7 +53,7 @@ export function createSettingsCommands(actions: SettingsCommandActions): SlashCo
   return [
     {
       name: "settings",
-      description: "Settings (providers, proxy, experiments)",
+      description: "Settings (logins, extensions, more)",
       source: "builtin",
       execute: () => {
         void showSettingsDialog();
@@ -61,10 +61,10 @@ export function createSettingsCommands(actions: SettingsCommandActions): SlashCo
     },
     {
       name: "login",
-      description: "Add or change provider API keys",
+      description: "Open logins settings (proxy + providers)",
       source: "builtin",
       execute: async () => {
-        await showProviderPicker();
+        await showSettingsDialog({ section: "logins" });
       },
     },
     {

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -54,6 +54,7 @@ import {
   showShortcutsDialog,
   type RecoveryCheckpointSummary,
 } from "../commands/builtins/overlays.js";
+import { configureSettingsDialogDependencies } from "../commands/builtins/settings-overlay.js";
 import { wireCommandMenu } from "../commands/command-menu.js";
 import { isBusyAllowedCommand } from "../commands/busy-command-policy.js";
 import { commandRegistry } from "../commands/types.js";
@@ -1349,6 +1350,15 @@ export async function initTaskpane(opts: {
       },
     });
   };
+
+  configureSettingsDialogDependencies({
+    openAddonsHub: (section?: AddonsSection) => {
+      openAddonsManager(section);
+    },
+    openRulesDialog: openRulesEditor,
+    openRecoveryDialog,
+    openShortcutsDialog: showShortcutsDialog,
+  });
 
   registerBuiltins({
     getActiveAgent,

--- a/src/ui/theme/overlays/settings.css
+++ b/src/ui/theme/overlays/settings.css
@@ -14,6 +14,18 @@
   padding-right: 2px;
 }
 
+.pi-settings-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pi-settings-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .pi-settings-section {
   display: flex;
   flex-direction: column;
@@ -60,6 +72,18 @@
 
 .pi-settings-proxy-status {
   margin: 0;
+}
+
+.pi-settings-extensions-actions,
+.pi-settings-advanced-actions {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.pi-settings-more {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 @media (max-width: 520px) {

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -187,6 +187,8 @@ void test("taskpane init wires add-ons menu opener", async () => {
   assert.match(initSource, /openIntegrationsManager/);
   assert.match(initSource, /openSkillsManager/);
   assert.match(initSource, /openExtensionsManager/);
+  assert.match(initSource, /configureSettingsDialogDependencies/);
+  assert.match(initSource, /openAddonsHub:\s*\(section\?: AddonsSection\)\s*=>\s*\{\s*openAddonsManager\(section\);\s*\}/);
   assert.match(initSource, /registerBuiltins\([\s\S]*openAddonsManager/);
   assert.match(initSource, /sidebar\.onOpenAddons\s*=\s*\(\)\s*=>\s*\{\s*openAddonsManager\(\);\s*\};/);
 });
@@ -286,7 +288,7 @@ void test("settings builtins route to unified settings overlay", async () => {
   assert.match(settingsSource, /name:\s*"settings"/);
   assert.match(settingsSource, /showSettingsDialog/);
   assert.match(settingsSource, /name:\s*"login"/);
-  assert.match(settingsSource, /showProviderPicker/);
+  assert.match(settingsSource, /showSettingsDialog\(\{ section: "logins" \}\)/);
 
   assert.match(settingsSource, /name:\s*"yolo"/);
   assert.match(settingsSource, /Toggle execution mode \(Auto vs Confirm\)/);
@@ -326,6 +328,10 @@ void test("settings overlay serializes open flow and tolerates provider storage 
   assert.match(settingsOverlaySource, /pendingSectionFocus/);
   assert.match(settingsOverlaySource, /await settingsDialogOpenInFlight/);
   assert.match(settingsOverlaySource, /Saved provider state is temporarily unavailable/);
+  assert.match(settingsOverlaySource, /SETTINGS_TABS/);
+  assert.match(settingsOverlaySource, /configureSettingsDialogDependencies/);
+  assert.match(settingsOverlaySource, /buildExtensionsSection/);
+  assert.match(settingsOverlaySource, /buildMoreSection/);
 });
 
 void test("slash-command busy policy is centralized and includes /yolo and /addons", async () => {


### PR DESCRIPTION
## Summary
- convert Settings overlay to tabbed IA: **Logins / Extensions / More**
- move Logins content to a clear order: **Proxy first, Providers second**
- add a Settings-hosted Extensions launcher with section shortcuts (connections/extensions/skills)
- add Settings "More" tab with:
  - **Advanced** actions (Rules, Backups, Keyboard shortcuts)
  - **Experimental** section
- wire Settings overlay dependencies from taskpane init so advanced actions can open their dialogs
- route `/login` to the Settings Logins tab

This is PR 1/2 of the requested split.

## Testing
- npm run check
- npm run test:context
- npm run build
- npm run test:security
- npm run test:models
