### PR TITLE
feat(mcp): mark MCP Gateway as Alpha in UI and catalog

### DIFF
--- a/src/commands/builtins/integrations-overlay-elements.ts
+++ b/src/commands/builtins/integrations-overlay-elements.ts
@@ -128,7 +128,7 @@ export function createIntegrationsDialogElements(): IntegrationsDialogElements {
 
   const mcpSection = document.createElement("section");
   mcpSection.className = "pi-overlay-section";
-  mcpSection.appendChild(createOverlaySectionTitle("MCP servers"));
+  mcpSection.appendChild(createOverlaySectionTitle("MCP servers (Alpha)"));
 
   const mcpList = document.createElement("div");
   mcpList.className = "pi-overlay-list";
@@ -160,7 +160,7 @@ export function createIntegrationsDialogElements(): IntegrationsDialogElements {
 
   const mcpHint = document.createElement("p");
   mcpHint.className = "pi-overlay-hint";
-  mcpHint.textContent = "Server URL, optional bearer token, and one-click connection test.";
+  mcpHint.textContent = "Alpha: HTTP MCP servers only. Stdio server support (Gmail, Slack, etc.) coming soon — see GitHub for roadmap.";
 
   mcpAddCard.append(mcpAddTitle, mcpAddRow, mcpHint);
 

--- a/src/commands/builtins/integrations-overlay.ts
+++ b/src/commands/builtins/integrations-overlay.ts
@@ -91,7 +91,7 @@ export function showIntegrationsDialog(dependencies: IntegrationsDialogDependenc
     onClose: closeOverlay,
     closeLabel: "Close tools and MCP",
     title: INTEGRATIONS_MANAGER_LABEL,
-    subtitle: "Manage web search, page fetch, and MCP servers. External tools are on by default.",
+    subtitle: "Manage web search, page fetch, and MCP servers (alpha). External tools are on by default.",
   });
 
   const elements = createIntegrationsDialogElements();

--- a/src/integrations/catalog.ts
+++ b/src/integrations/catalog.ts
@@ -55,8 +55,8 @@ const INTEGRATION_DEFINITIONS: Record<IntegrationId, IntegrationDefinition> = {
   },
   mcp_tools: {
     id: "mcp_tools",
-    title: "MCP Gateway",
-    description: "Call tools from user-configured MCP servers.",
+    title: "MCP Gateway (Alpha)",
+    description: "Call tools from user-configured MCP servers. Alpha: currently limited to HTTP MCP servers only.",
     agentSkillName: "mcp-gateway",
     warning: "External tools: MCP servers may execute arbitrary remote actions.",
     toolNames: ["mcp"],


### PR DESCRIPTION
Marks the MCP integration as **Alpha** across the UI and catalog to set expectations — the current implementation only supports HTTP MCP servers, while most real-world MCPs (Gmail, Slack, Granola, etc.) are stdio-based and need a bridge layer.

### Changes
- Integration catalog: title → **MCP Gateway (Alpha)**, description notes HTTP-only limitation
- `/integrations` overlay: subtitle mentions (alpha)
- MCP servers section title → **MCP servers (Alpha)**
- Add-server hint → explains stdio support is coming

Refs #310