### PR TITLE
fix(copy): update identity copy from assistant to agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source, multi-model AI sidebar add-in for Microsoft Excel. Powered by [Pi](https://pi.dev).
 
-Pi for Excel gives you a conversational AI assistant that can read, write, and format your spreadsheets — directly from an Excel sidebar panel. Bring your own API key or OAuth login for Anthropic, OpenAI, Google Gemini, or GitHub Copilot.
+Pi for Excel is an AI agent that lives inside Excel. It reads your workbook, makes changes, and does research — using any model you choose. Bring your own API key or OAuth login for Anthropic, OpenAI, Google Gemini, or GitHub Copilot.
 
 ## Features
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pi for Excel</title>
-  <meta name="description" content="A powerful, open-source agent inside Excel. Reads your spreadsheets, writes formulas, formats cells — powered by the models you already use." />
+  <meta name="description" content="An open-source AI agent inside Excel. Reads your workbook, makes changes, searches the web — with any model you already use." />
   <link rel="icon" href="/assets/icon-32.png" type="image/png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -205,7 +205,7 @@ function buildConventionOverridesSection(
   return `### Active convention overrides\n${lines.join("\n")}\nUse these defaults when formatting. The user can change them via the conventions tool.`;
 }
 
-const IDENTITY = `You are Pi, an AI assistant embedded in Microsoft Excel as a sidebar add-in. You help users understand, analyze, and modify their spreadsheets.`;
+const IDENTITY = `You are Pi, an AI agent embedded in Microsoft Excel as a sidebar add-in. You can read, modify, format, and research — working directly in the user's live workbook.`;
 
 const CORE_TOOL_PROMPT_LINES = buildCoreToolPromptLines();
 

--- a/src/taskpane/welcome-login.ts
+++ b/src/taskpane/welcome-login.ts
@@ -101,7 +101,7 @@ export async function showWelcomeLogin(providerKeys: ProviderKeysStore): Promise
     subtitle.textContent = "Connect an AI provider to get started";
 
     const intro = createElement("p", "pi-welcome-intro");
-    intro.textContent = "Pi reads your workbook, explains formulas, and makes edits directly in Excel.";
+    intro.textContent = "An AI agent that reads your spreadsheet, makes changes, and does the research — using models you already have.";
 
     const providerSectionTitle = createElement("p", "pi-welcome-section-title");
     providerSectionTitle.textContent = "Choose a provider";

--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -1037,7 +1037,7 @@ export class PiSidebar extends LitElement {
         <div class="pi-empty__content">
           <div class="pi-empty__logo">π</div>
           <p class="pi-empty__tagline">
-            Reads your workbook, writes formulas, formats cells, and builds models.
+            Understands your spreadsheet. Remembers how you like things. Builds its own tools.
           </p>
           <div class="pi-empty__hints">
             ${this.emptyHints.map((hint) => html`


### PR DESCRIPTION
## Summary

Align user-facing copy across 5 surfaces to use 'agent' instead of 'assistant' and emphasize workbook interaction + research capabilities.

### Changes

| Surface | Old | New |
|---|---|---|
| Empty state tagline | Reads your workbook, writes formulas, formats cells, and builds models. | Understands your spreadsheet. Remembers how you like things. Builds its own tools. |
| Welcome overlay intro | Pi reads your workbook, explains formulas, and makes edits directly in Excel. | An AI agent that reads your spreadsheet, makes changes, and does the research — using models you already have. |
| Meta description | A powerful, open-source agent inside Excel... | An open-source AI agent inside Excel... |
| System prompt identity | You are Pi, an AI assistant... | You are Pi, an AI agent... |
| README opening | Pi for Excel gives you a conversational AI assistant... | Pi for Excel is an AI agent that lives inside Excel... |

### Verification

- `npm run check` ✓
- `npm run build` ✓
- `npm run test:context` ✓ (475 tests pass)

Part of #272