### PR TITLE
feat(skills): graduate external skills discovery — remove experimental flag

### DIFF
--- a/src/commands/builtins/addons-overlay-skills.ts
+++ b/src/commands/builtins/addons-overlay-skills.ts
@@ -1,4 +1,3 @@
-import { isExperimentalFeatureEnabled } from "../../experiments/flags.js";
 import { getFilesWorkspace } from "../../files/workspace.js";
 import {
   filterAgentSkillsByEnabledState,
@@ -40,15 +39,10 @@ export async function buildSkillsSnapshot(settings: AddonsSettingsStore): Promis
     activationLoadError = error instanceof Error ? error.message : "Unknown error";
   }
 
-  const externalDiscoveryEnabled = isExperimentalFeatureEnabled("external_skills_discovery");
   const skills = mergeAgentSkillDefinitions(bundled, external);
 
-  const discoverableSkills = externalDiscoveryEnabled
-    ? skills
-    : bundled;
-
   const activeSkills = filterAgentSkillsByEnabledState({
-    skills: discoverableSkills,
+    skills,
     disabledSkillNames: disabledNames,
   });
 
@@ -56,7 +50,6 @@ export async function buildSkillsSnapshot(settings: AddonsSettingsStore): Promis
     skills,
     activeNames: new Set(activeSkills.map((skill) => skill.name.trim().toLowerCase())),
     disabledNames,
-    externalDiscoveryEnabled,
     externalLoadError,
     activationLoadError,
   };
@@ -127,13 +120,6 @@ export function renderSkillsSection(args: {
   }
 
   section.appendChild(list);
-
-  if (!args.snapshot.externalDiscoveryEnabled) {
-    const notice = document.createElement("p");
-    notice.className = "pi-overlay-hint";
-    notice.textContent = "External skill discovery is off; external skills may appear inactive until enabled in Experimental settings.";
-    section.appendChild(notice);
-  }
 
   if (args.snapshot.externalLoadError) {
     const warning = document.createElement("p");

--- a/src/commands/builtins/addons-overlay-types.ts
+++ b/src/commands/builtins/addons-overlay-types.ts
@@ -45,7 +45,6 @@ export interface SkillsSnapshot {
   skills: AgentSkillDefinition[];
   activeNames: Set<string>;
   disabledNames: Set<string>;
-  externalDiscoveryEnabled: boolean;
   externalLoadError: string | null;
   activationLoadError: string | null;
 }

--- a/src/experiments/flags.ts
+++ b/src/experiments/flags.ts
@@ -10,7 +10,6 @@ import { dispatchExperimentalFeatureChanged } from "./events.js";
 
 export type ExperimentalFeatureId =
   | "tmux_bridge"
-  | "external_skills_discovery"
   | "ui_dark_mode"
   | "remote_extension_urls"
   | "extension_permission_gates"
@@ -43,16 +42,6 @@ const EXPERIMENTAL_FEATURES = [
     description: "Allow local tmux bridge integration for interactive shell sessions.",
     wiring: "wired",
     storageKey: "pi.experimental.tmuxBridge",
-  },
-  {
-    id: "external_skills_discovery",
-    slug: "external-skills-discovery",
-    aliases: ["external-skills", "skills-discovery"],
-    title: "External skills discovery",
-    description: "Allow loading Agent Skills from Files workspace external skill files.",
-    warning: "Security: external skills can contain untrusted instructions and executable references.",
-    wiring: "wired",
-    storageKey: "pi.experimental.externalSkillsDiscovery",
   },
   {
     id: "ui_dark_mode",

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -26,7 +26,6 @@ import {
   PI_EXPERIMENTAL_FEATURE_CHANGED_EVENT,
   PI_EXPERIMENTAL_TOOL_CONFIG_CHANGED_EVENT,
 } from "../experiments/events.js";
-import { isExperimentalFeatureEnabled } from "../experiments/flags.js";
 import { convertToLlm } from "../messages/convert-to-llm.js";
 import { getFilesWorkspace } from "../files/workspace.js";
 import { createAllTools } from "../tools/index.js";
@@ -351,13 +350,11 @@ export async function initTaskpane(opts: {
 
     let mergedSkills = bundledSkills;
 
-    if (isExperimentalFeatureEnabled("external_skills_discovery")) {
-      try {
-        const externalSkills = await loadExternalAgentSkillsFromWorkspace(getFilesWorkspace());
-        mergedSkills = mergeAgentSkillDefinitions(bundledSkills, externalSkills);
-      } catch (error: unknown) {
-        console.warn("[skills] Failed to load external skills:", error);
-      }
+    try {
+      const externalSkills = await loadExternalAgentSkillsFromWorkspace(getFilesWorkspace());
+      mergedSkills = mergeAgentSkillDefinitions(bundledSkills, externalSkills);
+    } catch (error: unknown) {
+      console.warn("[skills] Failed to load external skills:", error);
     }
 
     try {

--- a/src/tools/skills.ts
+++ b/src/tools/skills.ts
@@ -50,9 +50,8 @@ async function getDefaultCatalog(): Promise<SkillsToolCatalog> {
   return defaultCatalog;
 }
 
-async function defaultIsExternalDiscoveryEnabled(): Promise<boolean> {
-  const flagsModule = await import("../experiments/flags.js");
-  return flagsModule.isExperimentalFeatureEnabled("external_skills_discovery");
+function defaultIsExternalDiscoveryEnabled(): boolean {
+  return true;
 }
 
 async function defaultLoadExternalSkills(): Promise<AgentSkillDefinition[]> {

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -118,14 +118,9 @@ void test("builtins registry wires /addons, /experimental, /extensions, and /int
   assert.match(experimentalFlagsSource, /extension-sandbox-rollback/);
   assert.match(experimentalFlagsSource, /extension_widget_v2/);
   assert.match(experimentalFlagsSource, /extension-widget-v2/);
-  assert.match(experimentalFlagsSource, /external_skills_discovery/);
-  assert.match(experimentalFlagsSource, /external-skills-discovery/);
   assert.match(experimentalFlagsSource, /ui_dark_mode/);
   assert.match(experimentalFlagsSource, /dark-mode/);
-  assert.match(
-    experimentalFlagsSource,
-    /id:\s*"external_skills_discovery"[\s\S]*?wiring:\s*"wired"/,
-  );
+  assert.doesNotMatch(experimentalFlagsSource, /external_skills_discovery/);
   assert.doesNotMatch(experimentalFlagsSource, /id:\s*"mcp_tools"/);
 });
 


### PR DESCRIPTION
## Summary

External skills (user-pasted SKILL.md markdown in Files workspace) are now always discoverable without requiring an experimental feature toggle.

### Changes

- Remove `external_skills_discovery` from `ExperimentalFeatureId` union and `EXPERIMENTAL_FEATURES` array
- Simplify `defaultIsExternalDiscoveryEnabled()` → always returns `true`
- Remove flag gate in `init.ts` `resolveAvailableSkills` — external skills always merged
- Remove conditional filtering in `addons-overlay-skills.ts` and `skills-overlay.ts`
- Update empty-state message: "No external skills are configured. Add one using the form above."
- Update test assertions to expect flag absence

### Files changed

| File | Change |
|---|---|
| `src/experiments/flags.ts` | Remove feature from type + array |
| `src/tools/skills.ts` | Simplify to always-true |
| `src/taskpane/init.ts` | Remove gate, keep body |
| `src/commands/builtins/addons-overlay-skills.ts` | Remove conditional filtering + notice |
| `src/commands/builtins/addons-overlay-types.ts` | Remove field from type |
| `src/commands/builtins/skills-overlay.ts` | Remove all conditional branches |
| `tests/builtins-registry.test.ts` | Flip assertions to doesNotMatch |

### Verification

- `npm run check` ✓
- `npm run build` ✓
- `npm run test:context` ✓ (475 tests pass)

Part of #272