### PR TITLE
refactor(ui): simplify files overlay — click-to-open, overflow menu

### DIFF
--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -407,6 +407,9 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     const row = document.createElement("div");
     row.className = "pi-files-dialog__row";
     row.style.cursor = "pointer";
+    row.tabIndex = 0;
+    row.setAttribute("role", "button");
+    row.setAttribute("aria-label", `Open ${file.path}`);
 
     const fileIcon = file.kind === "text" ? "📄" : isImageMimeType(file.mimeType) ? "🖼" : "📎";
 
@@ -446,11 +449,18 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
 
     info.append(nameRow, meta);
 
-    // Click row to open viewer
-    row.addEventListener("click", (event) => {
-      // Don't open viewer if the click was on the overflow menu button
+    // Click or keyboard activate row to open viewer
+    const activateRow = (event: Event) => {
       if ((event.target as HTMLElement).closest(".pi-files-dialog__overflow")) return;
+      if ((event.target as HTMLElement).closest(".pi-files-overflow-menu")) return;
       void openViewer(file);
+    };
+    row.addEventListener("click", activateRow);
+    row.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        activateRow(event);
+      }
     });
 
     // Overflow menu (⋯)
@@ -526,7 +536,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
         }, "danger");
       }
 
-      overflowBtn.appendChild(menu);
+      row.appendChild(menu);
 
       const closeOnOutsideClick = (e: MouseEvent) => {
         if (!menu.contains(e.target as Node)) {

--- a/src/ui/theme/components/files.css
+++ b/src/ui/theme/components/files.css
@@ -182,6 +182,7 @@
   align-items: flex-start;
   gap: 10px;
   padding: 8px;
+  position: relative;
   border-radius: var(--radius-sm);
   border: 1px solid var(--alpha-8);
   background: var(--white-alpha-55);


### PR DESCRIPTION
## Summary

Streamline the files workspace dialog with click-to-open rows and a compact overflow menu.

### Changes

| Before | After |
|---|---|
| 4 inline buttons per file (Open, Download, Rename, Delete) | Click row → open viewer; ⋯ overflow for other actions |
| Helper text + select dropdown + 4 control buttons | Upload + Select folder only; pills-only filtering |
| No file type icons | 📄 text, 🖼 image, 📎 other |

### Removed controls

- **"New text file"** button (broken — #316)
- **"Use sandbox workspace"** button (power user edge case)
- **Helper text** ("Built-in docs are always available...")
- **`<select>` dropdown** filter (quick-filter pills are enough)

### Overflow menu

Appears on row hover. Read-only files show only Download:
```
┌──────────────┐
│ Download     │
│ Rename       │
│ ──────────── │
│ Delete       │  ← red
└──────────────┘
```

### Verification

- `npm run check` ✓
- `npm run build` ✓
- `npm run test:context` ✓ (475 tests)

Part of #272