### PR TITLE
refactor(settings): rename tabs, remove extensions doorway, use 'local helper' copy

### DIFF
--- a/src/commands/builtins/settings.ts
+++ b/src/commands/builtins/settings.ts
@@ -53,7 +53,7 @@ export function createSettingsCommands(actions: SettingsCommandActions): SlashCo
   return [
     {
       name: "settings",
-      description: "Settings (logins, extensions, more)",
+      description: "Settings (providers and advanced options)",
       source: "builtin",
       execute: () => {
         void showSettingsDialog();
@@ -61,7 +61,7 @@ export function createSettingsCommands(actions: SettingsCommandActions): SlashCo
     },
     {
       name: "login",
-      description: "Open logins settings (proxy + providers)",
+      description: "Open provider settings",
       source: "builtin",
       execute: async () => {
         await showSettingsDialog({ section: "logins" });

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -1350,9 +1350,6 @@ export async function initTaskpane(opts: {
   };
 
   configureSettingsDialogDependencies({
-    openExtensionsHub: (section?: AddonsSection) => {
-      openAddonsManager(section);
-    },
     openRulesDialog: openRulesEditor,
     openRecoveryDialog,
     openShortcutsDialog: showShortcutsDialog,


### PR DESCRIPTION
## Summary

Simplify the settings overlay from 3 tabs to 2 and align copy with the spec.

### Changes

| Before | After |
|---|---|
| 3 tabs: Logins / Extensions / More | 2 tabs: **Providers** / More |
| Extensions tab = doorway with links to hub | Removed — hub accessible via gear menu & `/extensions` |
| "Proxy", "Enable proxy" | "Local helper", "Route through local helper" |
| Subtitle: "Logins, extensions, and advanced options." | "Providers, execution mode, and advanced options" |

### Removed

- `buildExtensionsSection()` function (~80 lines)
- `EXTENSIONS_LINKS` constant
- `openExtensionsHub` dependency

### Verification

- `npm run check` ✓
- `npm run build` ✓
- `npm run test:context` ✓ (475 tests)

Part of #272