### PR TITLE
fix(disclosure): make 'Change anytime in Settings' a clickable link

### DIFF
--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -1534,7 +1534,10 @@ export async function initTaskpane(opts: {
   // Must run after runtime bootstrap so the sidebar has rendered .pi-messages.
   {
     const { createDisclosureBar } = await import("../ui/disclosure-bar.js");
-    const disclosureEl = createDisclosureBar({ providerCount: availableProviders.length });
+    const disclosureEl = createDisclosureBar({
+      providerCount: availableProviders.length,
+      onOpenSettings: () => void showSettingsDialog(),
+    });
     if (disclosureEl) {
       const messagesContainer = sidebar.querySelector(".pi-messages");
       if (messagesContainer) {

--- a/src/ui/disclosure-bar.ts
+++ b/src/ui/disclosure-bar.ts
@@ -26,6 +26,8 @@ function setAcknowledged(): void {
 export interface DisclosureBarOptions {
   /** Number of configured providers (bar only shows when ≥1). */
   providerCount: number;
+  /** Callback to open Settings overlay. If provided, "Change anytime in Settings" becomes a link. */
+  onOpenSettings?: () => void;
 }
 
 /**
@@ -116,9 +118,23 @@ export function createDisclosureBar(options: DisclosureBarOptions): HTMLElement 
   customizeBtn.textContent = "Customize";
   actions.appendChild(customizeBtn);
 
-  const hint = document.createElement("span");
-  hint.className = "pi-disclosure-bar__muted";
-  hint.textContent = "· Change anytime in Settings";
+  let hint: HTMLElement;
+  if (options.onOpenSettings) {
+    const link = document.createElement("button");
+    link.type = "button";
+    link.className = "pi-disclosure-bar__settings-link";
+    link.textContent = "Change anytime in Settings";
+    link.addEventListener("click", () => {
+      dismiss();
+      options.onOpenSettings?.();
+    });
+    hint = link;
+  } else {
+    const span = document.createElement("span");
+    span.className = "pi-disclosure-bar__muted";
+    span.textContent = "· Change anytime in Settings";
+    hint = span;
+  }
   actions.appendChild(hint);
 
   customizeBtn.addEventListener("click", () => {

--- a/src/ui/theme/components/disclosure-bar.css
+++ b/src/ui/theme/components/disclosure-bar.css
@@ -43,6 +43,22 @@
   color: var(--muted-foreground);
 }
 
+.pi-disclosure-bar__settings-link {
+  background: none;
+  border: none;
+  color: var(--muted-foreground);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.pi-disclosure-bar__settings-link:hover {
+  color: var(--foreground);
+}
+
 /* ── Expandable picker ──────────────────────────────── */
 
 .pi-disclosure-picker {


### PR DESCRIPTION
## Summary

Makes the "Change anytime in Settings" text in the disclosure bar a clickable link that opens Settings and dismisses the bar. Previously it was a plain `<span>` — spec says it should be actionable.

## Changes

- `disclosure-bar.ts`: Added `onOpenSettings` callback to `DisclosureBarOptions`. When provided, renders a dotted-underline button instead of plain muted text.
- `disclosure-bar.css`: New `.pi-disclosure-bar__settings-link` style (muted, dotted underline, hover darkens).
- `init.ts`: Passes `onOpenSettings: () => void showSettingsDialog()` when creating the bar.

## Verification

- `npm run check` ✅

Part of #272.
