### PR TITLE
feat(proxy): add help popover for status bar indicator

### DIFF
--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -129,10 +129,11 @@ import {
 } from "./tab-layout.js";
 import { createTabLayoutPersistence } from "./tab-layout-persistence.js";
 import { injectStatusBar } from "./status-bar.js";
-import { startProxyPolling } from "./proxy-status.js";
+import { dismissProxyStatus, startProxyPolling } from "./proxy-status.js";
 import {
   closeStatusPopover,
   toggleContextPopover,
+  toggleProxyPopover,
   toggleThinkingPopover,
 } from "./status-popovers.js";
 import { showWelcomeLogin } from "./welcome-login.js";
@@ -1728,10 +1729,21 @@ export async function initTaskpane(opts: {
       return;
     }
 
-    // Proxy status — "no helper" click opens settings
-    if (el.closest(".pi-status-proxy--missing")) {
-      closeStatusPopover();
-      void showSettingsDialog();
+    // Proxy status — "no helper" click shows help popover
+    const proxyTrigger = el.closest(".pi-status-proxy--missing");
+    if (proxyTrigger) {
+      toggleProxyPopover({
+        anchor: proxyTrigger,
+        onDismiss: () => {
+          dismissProxyStatus();
+          // Re-render status bar to hide the "no helper" indicator
+          const statusBar = document.getElementById("pi-status-bar");
+          if (statusBar) {
+            const proxyEl = statusBar.querySelector(".pi-status-proxy--missing");
+            proxyEl?.remove();
+          }
+        },
+      });
       return;
     }
 

--- a/src/taskpane/status-popovers.ts
+++ b/src/taskpane/status-popovers.ts
@@ -6,7 +6,7 @@ import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 
 export type StatusCommandName = "compact" | "new";
 
-type StatusPopoverKind = "thinking" | "context";
+type StatusPopoverKind = "thinking" | "context" | "proxy";
 
 interface ActivePopoverState {
   kind: StatusPopoverKind;
@@ -288,4 +288,83 @@ export function toggleContextPopover(opts: ContextPopoverOptions): void {
 
   popover.append(title, description, actions);
   mountPopover("context", opts.anchor, popover);
+}
+
+// ── Proxy helper popover ──────────────────────────────────────────────
+
+const PROXY_COMMAND = "npx pi-for-excel-proxy";
+const INSTALL_GUIDE_URL = "https://pi.dev/excel#connect";
+
+export interface ProxyPopoverOptions {
+  anchor: Element;
+  onDismiss: () => void;
+}
+
+export function toggleProxyPopover(opts: ProxyPopoverOptions): void {
+  if (shouldToggle("proxy", opts.anchor)) {
+    closeStatusPopover();
+    return;
+  }
+
+  const popover = createPopoverBase("proxy");
+  popover.classList.add("pi-proxy-popover");
+
+  const title = document.createElement("div");
+  title.className = "pi-proxy-popover__title";
+  title.textContent = "Local helper not running";
+
+  const body = document.createElement("div");
+  body.className = "pi-proxy-popover__text";
+  body.textContent =
+    "Some features (web search, sign-in, external services) need a small local helper. Start it with:";
+
+  const cmdRow = document.createElement("div");
+  cmdRow.className = "pi-proxy-popover__cmd";
+
+  const code = document.createElement("code");
+  code.textContent = PROXY_COMMAND;
+
+  const copyBtn = document.createElement("button");
+  copyBtn.type = "button";
+  copyBtn.className = "pi-proxy-popover__copy";
+  copyBtn.title = "Copy";
+  copyBtn.textContent = "⧉";
+  copyBtn.addEventListener("click", () => {
+    void navigator.clipboard.writeText(PROXY_COMMAND).then(() => {
+      copyBtn.textContent = "✓";
+      setTimeout(() => {
+        copyBtn.textContent = "⧉";
+      }, 1500);
+    });
+  });
+
+  cmdRow.append(code, copyBtn);
+
+  const hint = document.createElement("div");
+  hint.className = "pi-proxy-popover__text";
+  hint.textContent = "Keep it running while using Pi.";
+
+  const footer = document.createElement("div");
+  footer.className = "pi-proxy-popover__footer";
+
+  const guideLink = document.createElement("a");
+  guideLink.className = "pi-proxy-popover__link";
+  guideLink.href = INSTALL_GUIDE_URL;
+  guideLink.target = "_blank";
+  guideLink.rel = "noopener noreferrer";
+  guideLink.textContent = "No Node.js? See install guide →";
+
+  const dismissBtn = document.createElement("button");
+  dismissBtn.type = "button";
+  dismissBtn.className = "pi-proxy-popover__dismiss";
+  dismissBtn.textContent = "Don't show again";
+  dismissBtn.addEventListener("click", () => {
+    opts.onDismiss();
+    closeStatusPopover();
+  });
+
+  footer.append(guideLink, dismissBtn);
+
+  popover.append(title, body, cmdRow, hint, footer);
+  mountPopover("proxy", opts.anchor, popover);
 }

--- a/src/ui/theme/components/status-bar.css
+++ b/src/ui/theme/components/status-bar.css
@@ -565,4 +565,88 @@
   color: var(--foreground);
 }
 
+/* ── Proxy helper popover ────────────────────────────── */
+
+.pi-proxy-popover {
+  max-width: 320px;
+  padding: 14px 16px;
+  font-family: var(--font-sans);
+}
+
+.pi-proxy-popover__title {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--foreground);
+  margin-bottom: 4px;
+}
+
+.pi-proxy-popover__text {
+  font-size: var(--text-sm);
+  color: var(--muted-foreground);
+  line-height: 1.45;
+  margin-bottom: 8px;
+}
+
+.pi-proxy-popover__cmd {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--radius-xs);
+  background: var(--alpha-4);
+  border: 1px solid var(--alpha-8);
+  margin-bottom: 8px;
+}
+
+.pi-proxy-popover__cmd code {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--foreground);
+}
+
+.pi-proxy-popover__copy {
+  background: none;
+  border: none;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  padding: 0;
+  font-size: 14px;
+}
+
+.pi-proxy-popover__copy:hover {
+  color: var(--foreground);
+}
+
+.pi-proxy-popover__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--text-xs);
+}
+
+.pi-proxy-popover__link {
+  color: var(--primary);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.pi-proxy-popover__link:hover {
+  text-decoration: underline;
+}
+
+.pi-proxy-popover__dismiss {
+  background: none;
+  border: none;
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  padding: 0;
+}
+
+.pi-proxy-popover__dismiss:hover {
+  color: var(--foreground);
+}
+
 


### PR DESCRIPTION
## Summary

Adds the help popover that the spec describes for the "no helper" proxy status indicator. Previously, clicking "no helper" opened the full Settings overlay. Now it shows a lightweight floating card with setup instructions.

## Popover contents (matching prototype section 10)

- **Title:** "Local helper not running"
- **Body:** "Some features (web search, sign-in, external services) need a small local helper. Start it with:"
- **Code block:** `npx pi-for-excel-proxy` with copy button (⧉) — shows ✓ on success
- **Hint:** "Keep it running while using Pi."
- **Footer:** "No Node.js? See install guide →" link + "Don't show again" dismiss

## Implementation

- Adds `toggleProxyPopover()` to `status-popovers.ts`, following the same pattern as thinking and context popovers (positioning, outside-click close, Escape close).
- CSS from prototype (`pi-proxy-popover__*` classes) added to `status-bar.css`.
- "Don't show again" calls `dismissProxyStatus()` and removes the indicator from the DOM.

## Verification

- `npm run check` ✅

Part of #272.
