### PR TITLE
refactor(files): flat section headers, rename CSS classes to spec

### DIFF
--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -405,8 +405,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
 
   const createFileRow = (file: WorkspaceFileEntry): HTMLElement => {
     const row = document.createElement("div");
-    row.className = "pi-files-dialog__row";
-    row.style.cursor = "pointer";
+    row.className = "pi-files-row";
     row.tabIndex = 0;
     row.setAttribute("role", "button");
     row.setAttribute("aria-label", `Open ${file.path}`);
@@ -414,44 +413,44 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     const fileIcon = file.kind === "text" ? "📄" : isImageMimeType(file.mimeType) ? "🖼" : "📎";
 
     const info = document.createElement("div");
-    info.className = "pi-files-dialog__info";
+    info.className = "pi-files-row__info";
 
     const nameRow = document.createElement("div");
-    nameRow.className = "pi-files-dialog__name-row";
+    nameRow.className = "pi-files-row__name-row";
 
     const iconEl = document.createElement("span");
-    iconEl.className = "pi-files-dialog__icon";
+    iconEl.className = "pi-files-row__icon";
     iconEl.textContent = fileIcon;
 
     const name = document.createElement("div");
-    name.className = "pi-files-dialog__name";
+    name.className = "pi-files-row__name";
     name.textContent = file.path;
 
     nameRow.append(iconEl, name);
 
     if (file.sourceKind === "builtin-doc") {
       const sourceBadge = document.createElement("span");
-      sourceBadge.className = "pi-files-dialog__source-badge";
+      sourceBadge.className = "pi-files-row__badge pi-files-row__badge--info";
       sourceBadge.textContent = "Built-in";
       nameRow.appendChild(sourceBadge);
     }
 
     if (file.workbookTag) {
       const workbookTag = document.createElement("span");
-      workbookTag.className = "pi-files-dialog__workbook-tag";
+      workbookTag.className = "pi-files-row__badge pi-files-row__badge--ok";
       workbookTag.textContent = file.workbookTag.workbookLabel;
       nameRow.appendChild(workbookTag);
     }
 
     const meta = document.createElement("div");
-    meta.className = "pi-files-dialog__meta";
+    meta.className = "pi-files-row__meta";
     meta.textContent = `${formatBytes(file.size)} · ${file.kind} · ${formatRelativeDate(file.modifiedAt)}`;
 
     info.append(nameRow, meta);
 
     // Click or keyboard activate row to open viewer
     const activateRow = (event: Event) => {
-      if ((event.target as HTMLElement).closest(".pi-files-dialog__overflow")) return;
+      if ((event.target as HTMLElement).closest(".pi-files-row__overflow")) return;
       if ((event.target as HTMLElement).closest(".pi-files-overflow-menu")) return;
       void openViewer(file);
     };
@@ -466,7 +465,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     // Overflow menu (⋯)
     const overflowBtn = document.createElement("button");
     overflowBtn.type = "button";
-    overflowBtn.className = "pi-files-dialog__overflow";
+    overflowBtn.className = "pi-files-row__overflow";
     overflowBtn.textContent = "⋯";
     overflowBtn.title = "File actions";
 
@@ -560,53 +559,44 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     folder: FilesDialogFolderNode,
     collapseKey: string,
   ): void => {
-    const folderCard = document.createElement("section");
-    folderCard.className = "pi-files-dialog__folder";
+    const section = document.createElement("section");
+    section.className = "pi-files-section";
 
-    const folderHeader = document.createElement("button");
-    folderHeader.type = "button";
-    folderHeader.className = "pi-files-dialog__folder-header";
+    const header = document.createElement("button");
+    header.type = "button";
+    header.className = "pi-files-section__header";
 
-    const folderHeaderStart = document.createElement("span");
-    folderHeaderStart.className = "pi-files-dialog__folder-header-start";
-
-    const caret = document.createElement("span");
-    caret.className = "pi-files-dialog__folder-caret";
-
-    const name = document.createElement("span");
-    name.className = "pi-files-dialog__folder-name";
-    name.textContent = folder.folderName;
-
-    folderHeaderStart.append(caret, name);
+    const label = document.createElement("span");
+    label.className = "pi-files-section__label";
+    label.textContent = folder.folderName.toUpperCase();
 
     const count = document.createElement("span");
-    count.className = "pi-files-dialog__folder-count";
+    count.className = "pi-files-section__count";
     count.textContent = formatFileCountLabel(folder.totalFileCount);
 
-    folderHeader.append(folderHeaderStart, count);
+    header.append(label, count);
 
-    const folderChildren = document.createElement("div");
-    folderChildren.className = "pi-files-dialog__folder-children";
+    const body = document.createElement("div");
+    body.className = "pi-files-section__body";
 
     const applyCollapsedState = (isCollapsed: boolean): void => {
-      folderCard.classList.toggle("is-collapsed", isCollapsed);
-      folderHeader.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
-      folderChildren.hidden = isCollapsed;
-      caret.textContent = isCollapsed ? "▸" : "▾";
+      section.classList.toggle("is-collapsed", isCollapsed);
+      header.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
+      body.hidden = isCollapsed;
     };
 
     let isCollapsed = collapsedFolderPaths.has(collapseKey);
     applyCollapsedState(isCollapsed);
 
     for (const file of folder.files) {
-      folderChildren.appendChild(createFileRow(file));
+      body.appendChild(createFileRow(file));
     }
 
     for (const childFolder of folder.children) {
-      appendFolderNode(folderChildren, childFolder, getFolderCollapseKey(childFolder.folderPath));
+      appendFolderNode(body, childFolder, getFolderCollapseKey(childFolder.folderPath));
     }
 
-    folderHeader.addEventListener("click", () => {
+    header.addEventListener("click", () => {
       isCollapsed = !isCollapsed;
       if (isCollapsed) {
         collapsedFolderPaths.add(collapseKey);
@@ -617,8 +607,8 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
       applyCollapsedState(isCollapsed);
     });
 
-    folderCard.append(folderHeader, folderChildren);
-    container.appendChild(folderCard);
+    section.append(header, body);
+    container.appendChild(section);
   };
 
   const renderList = async () => {

--- a/src/ui/theme/components/files.css
+++ b/src/ui/theme/components/files.css
@@ -97,113 +97,94 @@
   gap: 8px;
 }
 
-.pi-files-dialog__folder {
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-sm);
-  background: var(--white-alpha-40);
-  box-shadow: inset 0 1px 0 0 var(--white-alpha-60);
-  padding: 6px;
+/* ── Section headers (flat, uppercase) ─────────────── */
+
+.pi-files-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.pi-files-dialog__folder-header {
-  border: 1px solid var(--alpha-10);
-  border-radius: var(--radius-xs);
-  width: 100%;
-  background: linear-gradient(
-    90deg,
-    var(--white-alpha-65) 0%,
-    var(--green-alpha-6) 100%
-  );
-  color: var(--foreground);
-  padding: 6px 8px;
-  cursor: pointer;
+.pi-files-section__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 100%;
   font-family: var(--font-sans);
-  transition: border-color var(--duration-fast), background var(--duration-fast);
 }
 
-.pi-files-dialog__folder-header:hover {
-  border-color: var(--green-alpha-25);
-  background: linear-gradient(
-    90deg,
-    var(--white-alpha-70) 0%,
-    var(--green-alpha-12) 100%
-  );
+.pi-files-section__header:hover .pi-files-section__label {
+  color: var(--foreground);
 }
 
-.pi-files-dialog__folder-header-start {
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.pi-files-dialog__folder-caret {
-  flex-shrink: 0;
-  color: var(--muted-foreground);
-  font-size: var(--text-sm);
-}
-
-.pi-files-dialog__folder-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-}
-
-.pi-files-dialog__folder-count {
-  flex-shrink: 0;
-  border: 1px solid var(--alpha-10);
-  border-radius: 999px;
-  background: var(--white-alpha-70);
-  color: var(--muted-foreground);
+.pi-files-section__label {
   font-size: var(--text-xs);
-  padding: 1px 7px;
+  font-weight: 600;
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition: color var(--duration-fast);
 }
 
-.pi-files-dialog__folder-children {
-  margin-top: 8px;
-  margin-left: 8px;
-  padding-left: 10px;
-  border-left: 1px dashed var(--alpha-12);
+.pi-files-section__count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted-foreground);
+}
+
+.pi-files-section__body {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
-.pi-files-dialog__row {
+.pi-files-section.is-collapsed .pi-files-section__body {
+  display: none;
+}
+
+/* ── File rows ────────────────────────────────────── */
+
+.pi-files-row {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
   gap: 10px;
-  padding: 8px;
+  padding: 7px 8px;
   position: relative;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--alpha-8);
-  background: var(--white-alpha-55);
+  cursor: pointer;
+  transition: background var(--duration-fast);
 }
 
-.pi-files-dialog__info {
+.pi-files-row:hover {
+  background: var(--alpha-4);
+}
+
+.pi-files-row__info {
   min-width: 0;
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
 }
 
-.pi-files-dialog__name-row {
+.pi-files-row__name-row {
   display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
 }
 
-.pi-files-dialog__name {
+.pi-files-row__icon {
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+}
+
+.pi-files-row__name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -213,37 +194,30 @@
   color: var(--foreground);
 }
 
-.pi-files-dialog__workbook-tag {
+.pi-files-row__badge {
   flex-shrink: 0;
   padding: 1px 6px;
   border-radius: 999px;
   font-family: var(--font-sans);
   font-size: var(--text-xs);
+}
+
+.pi-files-row__badge--ok {
   color: var(--pi-green);
   background: var(--pi-green-light);
 }
 
-.pi-files-dialog__source-badge {
-  flex-shrink: 0;
-  padding: 1px 6px;
-  border-radius: 999px;
-  font-family: var(--font-sans);
-  font-size: var(--text-xs);
+.pi-files-row__badge--info {
   color: var(--pi-blue, oklch(0.57 0.14 246));
   background: color-mix(in oklch, var(--pi-blue, oklch(0.57 0.14 246)) 14%, white);
 }
 
-.pi-files-dialog__meta {
+.pi-files-row__meta {
   font-family: var(--font-sans);
   font-size: var(--text-xs);
   color: var(--muted-foreground);
 }
 
-.pi-files-dialog__actions {
-  display: flex;
-  gap: 6px;
-  flex-shrink: 0;
-}
 
 .pi-files-dialog__viewer {
   border: var(--pi-divider);
@@ -338,17 +312,9 @@
   padding: 8px;
 }
 
-/* ── File icon ──────────────────────────────────────── */
-
-.pi-files-dialog__icon {
-  flex-shrink: 0;
-  font-size: var(--text-base);
-  margin-right: 6px;
-}
-
 /* ── Overflow menu button ───────────────────────────── */
 
-.pi-files-dialog__overflow {
+.pi-files-row__overflow {
   appearance: none;
   -webkit-appearance: none;
   background: none;
@@ -364,11 +330,11 @@
   transition: opacity 0.1s ease;
 }
 
-.pi-files-dialog__row:hover .pi-files-dialog__overflow {
+.pi-files-row:hover .pi-files-row__overflow {
   opacity: 1;
 }
 
-.pi-files-dialog__overflow:hover {
+.pi-files-row__overflow:hover {
   background: var(--alpha-6);
   color: var(--foreground);
 }


### PR DESCRIPTION
## Summary

Aligns the Files overlay with the spec's flat section header pattern. Replaces nested bordered folder cards with uppercase section headers matching the prototype's `.pi-section-header` component.

## Visual change

**Before:** Nested folder cards with borders, dashed left-border, carets (▸/▾)
```
┌────────────────────────────────┐
│ ▾ skills              2 files │
│ ┌──────────────────────────┐   │
│ │ 📄 SKILL.md    4KB      │   │
│ └──────────────────────────┘   │
└────────────────────────────────┘
```

**After:** Flat uppercase section headers with count, hover-bg file rows
```
SKILLS                    2 files
  📄 skills/SKILL.md
     4.34 KB · text · 4h ago  ⋯
```

## CSS class renames

All classes renamed from `pi-files-dialog__*` to `pi-files-row__*` / `pi-files-section__*` per spec.

| Old | New |
|---|---|
| `pi-files-dialog__folder` | `pi-files-section` |
| `pi-files-dialog__row` | `pi-files-row` |
| `pi-files-dialog__name` | `pi-files-row__name` |
| `pi-files-dialog__source-badge` | `pi-files-row__badge--info` |
| `pi-files-dialog__workbook-tag` | `pi-files-row__badge--ok` |

## Verification

- `npm run check` ✅

Part of #272.
