### PR TITLE
feat(extensions): add unified Extensions hub overlay

### DIFF
--- a/src/commands/builtins/addons.ts
+++ b/src/commands/builtins/addons.ts
@@ -2,11 +2,11 @@
  * Builtin commands for unified extensions management UI.
  */
 
-import type { AddonsSection } from "./addons-overlay.js";
+import type { ExtensionsHubTab } from "./extensions-hub-overlay.js";
 import type { SlashCommand } from "../types.js";
 
 export interface AddonsCommandActions {
-  openAddonsManager: (section?: AddonsSection) => void | Promise<void>;
+  openExtensionsHub: (tab?: ExtensionsHubTab) => void | Promise<void>;
 }
 
 export function createAddonsCommands(actions: AddonsCommandActions): SlashCommand[] {
@@ -16,7 +16,7 @@ export function createAddonsCommands(actions: AddonsCommandActions): SlashComman
       description: "Open Extensions (connections, plugins, skills)",
       source: "builtin",
       execute: () => {
-        void actions.openAddonsManager();
+        void actions.openExtensionsHub();
       },
     },
   ];

--- a/src/commands/builtins/extensions-hub-connections.ts
+++ b/src/commands/builtins/extensions-hub-connections.ts
@@ -1,0 +1,551 @@
+/**
+ * Extensions hub — Connections tab.
+ *
+ * External tools master toggle, web search config, MCP server management,
+ * and bridge URLs.
+ */
+
+import { INTEGRATION_IDS } from "../../integrations/catalog.js";
+import type { IntegrationSettingsStore } from "../../integrations/store.js";
+import type { WebSearchConfigStore } from "../../tools/web-search-config.js";
+import type { McpConfigStore, McpServerConfig } from "../../tools/mcp-config.js";
+import {
+  getExternalToolsEnabled,
+  getSessionIntegrationIds,
+  getWorkbookIntegrationIds,
+  setExternalToolsEnabled,
+  setIntegrationEnabledInScope,
+} from "../../integrations/store.js";
+import {
+  getApiKeyForProvider,
+  isApiKeyRequired,
+  loadWebSearchProviderConfig,
+  maskSecret,
+  saveWebSearchApiKey,
+  saveWebSearchProvider,
+  clearWebSearchApiKey,
+  WEB_SEARCH_PROVIDER_INFO,
+  type WebSearchProvider,
+} from "../../tools/web-search-config.js";
+import { validateWebSearchApiKey } from "../../tools/web-search.js";
+import {
+  createMcpServerConfig,
+  loadMcpServers,
+  saveMcpServers,
+} from "../../tools/mcp-config.js";
+import { getEnabledProxyBaseUrl } from "../../tools/external-fetch.js";
+import { validateOfficeProxyUrl } from "../../auth/proxy-validation.js";
+import { dispatchExperimentalToolConfigChanged } from "../../experiments/events.js";
+import {
+  PYTHON_BRIDGE_URL_SETTING_KEY,
+  TMUX_BRIDGE_URL_SETTING_KEY,
+} from "../../tools/experimental-tool-gates.js";
+import { isExperimentalFeatureEnabled } from "../../experiments/flags.js";
+import { probeMcpServer } from "./integrations-overlay-mcp-probe.js";
+import { showToast } from "../../ui/toast.js";
+import {
+  createToggleRow,
+  createSectionHeader,
+  createItemCard,
+  createConfigRow,
+  createConfigInput,
+  createConfigValue,
+  createAddForm,
+  createAddFormRow,
+  createAddFormInput,
+  createEmptyInline,
+  createActionsRow,
+  createButton,
+  createToggle,
+} from "../../ui/extensions-hub-components.js";
+import type { ExtensionsHubDependencies } from "./extensions-hub-overlay.js";
+
+type SettingsStore = IntegrationSettingsStore & WebSearchConfigStore & McpConfigStore & {
+  delete?: (key: string) => Promise<void>;
+};
+
+// ── Helpers ─────────────────────────────────────────
+
+function normalizeProvider(value: string): WebSearchProvider {
+  if (value === "jina" || value === "serper" || value === "tavily" || value === "brave") return value;
+  return "jina";
+}
+
+function getStatusBadge(ok: boolean, label: string): { text: string; tone: "ok" | "warn" | "muted" } {
+  return ok ? { text: label, tone: "ok" } : { text: label, tone: "muted" };
+}
+
+// ── Main render ─────────────────────────────────────
+
+export async function renderConnectionsTab(args: {
+  container: HTMLElement;
+  settings: SettingsStore;
+  deps: ExtensionsHubDependencies;
+  isBusy: () => boolean;
+  runMutation: (action: () => Promise<void>, reason: "toggle" | "scope" | "external-toggle" | "config", msg?: string) => Promise<void>;
+}): Promise<void> {
+  const { container, settings, deps, isBusy, runMutation } = args;
+
+  const sessionId = deps.getActiveSessionId();
+  const workbookContext = await deps.resolveWorkbookContext();
+  const workbookId = workbookContext.workbookId;
+
+  // Load state
+  const [
+    externalEnabled,
+    sessionIntegrationIds,
+    workbookIntegrationIds,
+    webSearchConfig,
+    mcpServers,
+    pythonUrlRaw,
+    tmuxUrlRaw,
+  ] = await Promise.all([
+    getExternalToolsEnabled(settings),
+    sessionId
+      ? getSessionIntegrationIds(settings, sessionId, INTEGRATION_IDS, {
+        applyDefaultsWhenUnconfigured: workbookId === null,
+      })
+      : Promise.resolve<string[]>([]),
+    workbookId
+      ? getWorkbookIntegrationIds(settings, workbookId, INTEGRATION_IDS)
+      : Promise.resolve<string[]>([]),
+    loadWebSearchProviderConfig(settings),
+    loadMcpServers(settings),
+    settings.get(PYTHON_BRIDGE_URL_SETTING_KEY),
+    settings.get(TMUX_BRIDGE_URL_SETTING_KEY),
+  ]);
+
+  const pythonUrl = typeof pythonUrlRaw === "string" ? pythonUrlRaw.trim() : "";
+  const tmuxUrl = typeof tmuxUrlRaw === "string" ? tmuxUrlRaw.trim() : "";
+  const selectedProvider = webSearchConfig.provider;
+  const providerInfo = WEB_SEARCH_PROVIDER_INFO[selectedProvider];
+  const apiKey = getApiKeyForProvider(webSearchConfig);
+  const webSearchSessionEnabled = sessionIntegrationIds.includes("web_search");
+  const webSearchWorkbookEnabled = workbookIntegrationIds.includes("web_search");
+  const webSearchEnabled = webSearchSessionEnabled || webSearchWorkbookEnabled;
+
+  container.replaceChildren();
+
+  // ── Master toggle ─────────────────────────────
+  const surface = document.createElement("div");
+  surface.className = "pi-overlay-surface";
+
+  const masterToggle = createToggleRow({
+    label: "External tools",
+    sublabel: "Allow Pi to search the web and call external services",
+    checked: externalEnabled,
+    onChange: (checked) => {
+      void runMutation(
+        () => setExternalToolsEnabled(settings, checked),
+        "external-toggle",
+        `External tools ${checked ? "enabled" : "disabled"}`,
+      );
+    },
+  });
+  surface.appendChild(masterToggle.root);
+  container.appendChild(surface);
+
+  // ── Web search section ────────────────────────
+  container.appendChild(createSectionHeader({ label: "Web search" }));
+
+  const webBadgeText = !webSearchEnabled
+    ? "Off"
+    : apiKey
+      ? "Connected"
+      : (isApiKeyRequired(selectedProvider) ? "No API key" : "Ready");
+  const webBadgeTone = !webSearchEnabled
+    ? "muted"
+    : (apiKey || !isApiKeyRequired(selectedProvider) ? "ok" : "warn");
+
+  const webCard = createItemCard({
+    icon: "🔍",
+    iconColor: "green",
+    name: providerInfo.title,
+    description: providerInfo.shortDescription,
+    expandable: true,
+    badges: [{ text: webBadgeText, tone: webBadgeTone }],
+  });
+
+  // Provider picker
+  const providerSelect = document.createElement("select");
+  providerSelect.className = "pi-item-card__config-input pi-item-card__config-select";
+  for (const [key, info] of Object.entries(WEB_SEARCH_PROVIDER_INFO)) {
+    const option = document.createElement("option");
+    option.value = key;
+    option.textContent = info.title;
+    if (key === selectedProvider) option.selected = true;
+    providerSelect.appendChild(option);
+  }
+  providerSelect.addEventListener("change", () => {
+    const provider = normalizeProvider(providerSelect.value);
+    void runMutation(
+      () => saveWebSearchProvider(settings, provider),
+      "config",
+      `Web search provider set to ${WEB_SEARCH_PROVIDER_INFO[provider].title}`,
+    );
+  });
+
+  webCard.body.appendChild(createConfigRow("Provider", providerSelect));
+
+  // API key row
+  const apiKeyInput = createConfigInput({
+    placeholder: providerInfo.apiKeyLabel,
+    type: "password",
+    value: apiKey ? maskSecret(apiKey) : "",
+  });
+
+  const apiKeyRow = document.createElement("div");
+  apiKeyRow.className = "pi-item-card__config-row";
+
+  const apiKeyLabel = document.createElement("span");
+  apiKeyLabel.className = "pi-item-card__config-label";
+  apiKeyLabel.textContent = "API key";
+
+  const apiKeyControls = document.createElement("div");
+  apiKeyControls.className = "pi-hub-inline-row";
+
+  const validateBtn = createButton("Validate", {
+    compact: true,
+    onClick: () => {
+      if (isBusy()) return;
+      const key = apiKeyInput.value.trim();
+      void (async () => {
+        try {
+          const config = await loadWebSearchProviderConfig(settings);
+          const testKey = key.length > 0 ? key : (getApiKeyForProvider(config) ?? "");
+          if (!testKey) { showToast("No API key to validate."); return; }
+          const proxyBaseUrl = await getEnabledProxyBaseUrl(settings);
+          const result = await validateWebSearchApiKey({ provider: selectedProvider, apiKey: testKey, proxyBaseUrl });
+          showToast(result.ok ? `✓ ${result.message}` : `✗ ${result.message}`);
+        } catch (err: unknown) {
+          showToast(`✗ ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })();
+    },
+  });
+
+  const saveKeyBtn = createButton("Save", {
+    primary: true,
+    compact: true,
+    onClick: () => {
+      const key = apiKeyInput.value.trim();
+      if (!key) { showToast("Enter an API key first."); return; }
+      void runMutation(
+        () => saveWebSearchApiKey(settings, selectedProvider, key),
+        "config",
+        `Saved ${providerInfo.apiKeyLabel}`,
+      );
+    },
+  });
+
+  const clearKeyBtn = createButton("Clear", {
+    compact: true,
+    onClick: () => {
+      void runMutation(
+        () => clearWebSearchApiKey(settings, selectedProvider),
+        "config",
+        `Cleared ${providerInfo.apiKeyLabel}`,
+      );
+    },
+  });
+
+  apiKeyControls.append(apiKeyInput, validateBtn, saveKeyBtn, clearKeyBtn);
+  apiKeyRow.append(apiKeyLabel, apiKeyControls);
+  webCard.body.appendChild(apiKeyRow);
+
+  const sessionToggleRow = createToggleRow({
+    label: "Enable for this session",
+    checked: webSearchSessionEnabled,
+    onChange: (checked) => {
+      if (!sessionId) {
+        showToast("No active session");
+        return;
+      }
+      void runMutation(async () => {
+        await setIntegrationEnabledInScope({
+          settings,
+          scope: "session",
+          identifier: sessionId,
+          integrationId: "web_search",
+          enabled: checked,
+          knownIntegrationIds: INTEGRATION_IDS,
+        });
+      }, "scope", `Web search ${checked ? "enabled" : "disabled"} for this session`);
+    },
+  });
+  sessionToggleRow.input.disabled = isBusy() || !sessionId;
+  webCard.body.appendChild(sessionToggleRow.root);
+
+  const workbookToggleRow = createToggleRow({
+    label: workbookId
+      ? `Enable for workbook (${workbookContext.workbookLabel})`
+      : "Workbook scope unavailable",
+    checked: webSearchWorkbookEnabled,
+    onChange: (checked) => {
+      if (!workbookId) {
+        showToast("Workbook scope unavailable");
+        return;
+      }
+      void runMutation(async () => {
+        await setIntegrationEnabledInScope({
+          settings,
+          scope: "workbook",
+          identifier: workbookId,
+          integrationId: "web_search",
+          enabled: checked,
+          knownIntegrationIds: INTEGRATION_IDS,
+        });
+      }, "scope", `Web search ${checked ? "enabled" : "disabled"} for this workbook`);
+    },
+  });
+  workbookToggleRow.input.disabled = isBusy() || !workbookId;
+  webCard.body.appendChild(workbookToggleRow.root);
+
+  container.appendChild(webCard.root);
+
+  // ── MCP servers section ───────────────────────
+  const mcpAddForm = createAddForm();
+  const mcpAddVisible = { value: false };
+
+  const mcpHeader = createSectionHeader({
+    label: "MCP servers",
+    actionLabel: "+ Add server",
+    onAction: () => {
+      mcpAddVisible.value = !mcpAddVisible.value;
+      mcpAddForm.hidden = !mcpAddVisible.value;
+    },
+  });
+  container.appendChild(mcpHeader);
+
+  const mcpList = document.createElement("div");
+  mcpList.className = "pi-hub-stack";
+
+  if (mcpServers.length === 0) {
+    mcpList.appendChild(createEmptyInline("⚡", "No MCP servers configured.\nAdd one to connect external tools."));
+  } else {
+    for (const server of mcpServers) {
+      mcpList.appendChild(renderMcpServerCard(server, settings, isBusy, runMutation));
+    }
+  }
+  container.appendChild(mcpList);
+
+  // MCP add form (hidden by default)
+  const nameInput = createAddFormInput("Server name");
+  const urlInput = createAddFormInput("https://server-url/rpc");
+  const tokenInput = createAddFormInput("Bearer token (optional)");
+  tokenInput.type = "password";
+
+  const addRow = createAddFormRow();
+  addRow.append(nameInput, urlInput);
+
+  const tokenRow = createAddFormRow();
+  tokenRow.append(tokenInput, createButton("Add", {
+    primary: true,
+    compact: true,
+    onClick: () => {
+      void runMutation(async () => {
+        const servers = await loadMcpServers(settings);
+        const next = createMcpServerConfig({
+          name: nameInput.value,
+          url: urlInput.value,
+          token: tokenInput.value,
+          enabled: true,
+        });
+        await saveMcpServers(settings, [...servers, next]);
+        nameInput.value = "";
+        urlInput.value = "";
+        tokenInput.value = "";
+      }, "config", "Added MCP server");
+    },
+  }));
+
+  mcpAddForm.append(addRow, tokenRow);
+  mcpAddForm.hidden = true;
+  container.appendChild(mcpAddForm);
+
+  // ── Bridges section ───────────────────────────
+  // Python bridge is always available; tmux bridge requires the experimental flag
+  const showPython = true;
+  const showTmux = isExperimentalFeatureEnabled("tmux_bridge") || tmuxUrl.length > 0;
+
+  if (showPython || showTmux) {
+    container.appendChild(createSectionHeader({ label: "Bridges" }));
+
+    const bridgeList = document.createElement("div");
+    bridgeList.className = "pi-hub-stack";
+
+    if (showPython) {
+      bridgeList.appendChild(renderBridgeCard({
+        icon: "🐍",
+        name: "Python bridge",
+        description: "Execute Python code in a local environment",
+        settingKey: PYTHON_BRIDGE_URL_SETTING_KEY,
+        placeholder: "http://localhost:3340",
+        currentUrl: pythonUrl,
+        settings,
+        isBusy,
+        runMutation,
+      }));
+    }
+
+    if (showTmux) {
+      bridgeList.appendChild(renderBridgeCard({
+        icon: "🖥",
+        name: "tmux bridge",
+        description: "Remote shell sessions via tmux",
+        settingKey: TMUX_BRIDGE_URL_SETTING_KEY,
+        placeholder: "http://localhost:3341",
+        currentUrl: tmuxUrl,
+        settings,
+        isBusy,
+        runMutation,
+      }));
+    }
+
+    container.appendChild(bridgeList);
+  }
+}
+
+// ── MCP server card ─────────────────────────────────
+
+function renderMcpServerCard(
+  server: McpServerConfig,
+  settings: SettingsStore,
+  isBusy: () => boolean,
+  runMutation: (action: () => Promise<void>, reason: "toggle" | "scope" | "external-toggle" | "config", msg?: string) => Promise<void>,
+): HTMLElement {
+  const toolLabel = server.enabled ? "Enabled" : "Disabled";
+  const card = createItemCard({
+    icon: "⚡",
+    iconColor: "blue",
+    name: server.name,
+    meta: server.url,
+    expandable: true,
+    badges: [getStatusBadge(server.enabled, toolLabel)],
+  });
+
+  // URL
+  card.body.appendChild(createConfigRow("URL", createConfigValue(server.url)));
+
+  // Token
+  const tokenValue = server.token ? maskSecret(server.token) : "(none)";
+  card.body.appendChild(createConfigRow("Token", createConfigValue(tokenValue)));
+
+  // Enabled toggle
+  const enabledRow = document.createElement("div");
+  enabledRow.className = "pi-item-card__config-row";
+  const enabledLabel = document.createElement("span");
+  enabledLabel.className = "pi-item-card__config-label";
+  enabledLabel.textContent = "Enabled";
+  const enabledToggle = createToggle({
+    checked: server.enabled,
+    onChange: (checked) => {
+      void runMutation(async () => {
+        const servers = await loadMcpServers(settings);
+        const updated = servers.map((s) =>
+          s.id === server.id ? { ...s, enabled: checked } : s,
+        );
+        await saveMcpServers(settings, updated);
+      }, "config", `${server.name}: ${checked ? "enabled" : "disabled"}`);
+    },
+  });
+  enabledRow.append(enabledLabel, enabledToggle.root);
+  card.body.appendChild(enabledRow);
+
+  // Actions
+  const testBtn = createButton("Test", {
+    compact: true,
+    onClick: () => {
+      if (isBusy()) return;
+      void (async () => {
+        try {
+          const result = await probeMcpServer(server, settings);
+          const transport = result.proxied ? "proxy" : "direct";
+          showToast(`${server.name}: reachable (${result.toolCount} tool${result.toolCount === 1 ? "" : "s"}, ${transport})`);
+        } catch (err: unknown) {
+          showToast(`${server.name}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })();
+    },
+  });
+
+  const removeBtn = createButton("Remove", {
+    danger: true,
+    compact: true,
+    onClick: () => {
+      void runMutation(async () => {
+        const servers = await loadMcpServers(settings);
+        await saveMcpServers(settings, servers.filter((s) => s.id !== server.id));
+      }, "config", `Removed MCP server: ${server.name}`);
+    },
+  });
+
+  card.body.appendChild(createActionsRow(testBtn, removeBtn));
+
+  return card.root;
+}
+
+// ── Bridge card ─────────────────────────────────────
+
+function renderBridgeCard(args: {
+  icon: string;
+  name: string;
+  description: string;
+  settingKey: string;
+  placeholder: string;
+  currentUrl: string;
+  settings: SettingsStore;
+  isBusy: () => boolean;
+  runMutation: (action: () => Promise<void>, reason: "toggle" | "scope" | "external-toggle" | "config", msg?: string) => Promise<void>;
+}): HTMLElement {
+  const connected = args.currentUrl.length > 0;
+  const card = createItemCard({
+    icon: args.icon,
+    iconColor: "amber",
+    name: args.name,
+    description: args.description,
+    expandable: true,
+    badges: [connected
+      ? { text: "Configured", tone: "ok" as const }
+      : { text: "Not connected", tone: "muted" as const },
+    ],
+  });
+
+  const urlInput = createConfigInput({
+    value: args.currentUrl,
+    placeholder: args.placeholder,
+  });
+  card.body.appendChild(createConfigRow("Bridge URL", urlInput));
+
+  const saveBridgeUrl = (clear: boolean): void => {
+    const raw = clear ? "" : urlInput.value.trim();
+
+    if (raw.length > 0) {
+      try {
+        validateOfficeProxyUrl(raw);
+      } catch (err: unknown) {
+        showToast(`Invalid URL: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+      }
+    }
+
+    void args.runMutation(async () => {
+      if (raw.length === 0) {
+        if (typeof args.settings.delete === "function") {
+          await args.settings.delete(args.settingKey);
+        } else {
+          await args.settings.set(args.settingKey, "");
+        }
+      } else {
+        await args.settings.set(args.settingKey, raw);
+      }
+      dispatchExperimentalToolConfigChanged({ configKey: args.settingKey });
+    }, "config", raw.length > 0 ? `${args.name} URL saved` : `${args.name} URL cleared`);
+  };
+
+  const saveBtn = createButton("Save", { compact: true, onClick: () => saveBridgeUrl(false) });
+  const clearBtn = createButton("Clear", { compact: true, onClick: () => saveBridgeUrl(true) });
+  card.body.appendChild(createActionsRow(saveBtn, clearBtn));
+
+  return card.root;
+}

--- a/src/commands/builtins/extensions-hub-overlay.ts
+++ b/src/commands/builtins/extensions-hub-overlay.ts
@@ -1,0 +1,224 @@
+/**
+ * Extensions hub overlay — unified 3-tab overlay replacing the old
+ * addons-overlay, integrations-overlay, extensions-overlay, and skills-overlay.
+ *
+ * Tabs: Connections | Plugins | Skills
+ */
+
+import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.js";
+import type { ExtensionRuntimeManager } from "../../extensions/runtime-manager.js";
+import { dispatchIntegrationsChanged } from "../../integrations/events.js";
+import {
+  closeOverlayById,
+  createOverlayDialog,
+  createOverlayHeader,
+} from "../../ui/overlay-dialog.js";
+import { ADDONS_OVERLAY_ID } from "../../ui/overlay-ids.js";
+import { showToast } from "../../ui/toast.js";
+import type { WorkbookContextSnapshot } from "./integrations-overlay-types.js";
+import { renderConnectionsTab } from "./extensions-hub-connections.js";
+import { renderPluginsTab } from "./extensions-hub-plugins.js";
+import { renderSkillsTab } from "./extensions-hub-skills.js";
+
+export type ExtensionsHubTab = "connections" | "plugins" | "skills";
+
+export interface ExtensionsHubDependencies {
+  getActiveSessionId: () => string | null;
+  resolveWorkbookContext: () => Promise<WorkbookContextSnapshot>;
+  extensionManager: ExtensionRuntimeManager;
+  onChanged?: () => Promise<void> | void;
+}
+
+const TABS: ReadonlyArray<{ id: ExtensionsHubTab; label: string }> = [
+  { id: "connections", label: "Connections" },
+  { id: "plugins", label: "Plugins" },
+  { id: "skills", label: "Skills" },
+];
+
+let openInFlight: Promise<void> | null = null;
+let pendingTab: ExtensionsHubTab | null = null;
+
+function activateTab(overlay: HTMLElement, tabId: ExtensionsHubTab): void {
+  for (const btn of overlay.querySelectorAll<HTMLButtonElement>("[data-hub-tab]")) {
+    const active = btn.dataset.hubTab === tabId;
+    btn.classList.toggle("is-active", active);
+    btn.setAttribute("aria-selected", active ? "true" : "false");
+  }
+  for (const panel of overlay.querySelectorAll<HTMLElement>("[data-hub-panel]")) {
+    panel.hidden = panel.dataset.hubPanel !== tabId;
+  }
+}
+
+export async function showExtensionsHubDialog(
+  deps: ExtensionsHubDependencies,
+  options?: { tab?: ExtensionsHubTab },
+): Promise<void> {
+  // Toggle or switch tab on existing overlay
+  const existing = document.getElementById(ADDONS_OVERLAY_ID);
+  if (existing instanceof HTMLElement) {
+    if (options?.tab) {
+      activateTab(existing, options.tab);
+      return;
+    }
+    closeOverlayById(ADDONS_OVERLAY_ID);
+    return;
+  }
+
+  // Debounce concurrent opens
+  if (openInFlight) {
+    if (options?.tab) pendingTab = options.tab;
+    await openInFlight;
+    const mounted = document.getElementById(ADDONS_OVERLAY_ID);
+    if (mounted instanceof HTMLElement && options?.tab) activateTab(mounted, options.tab);
+    return;
+  }
+
+  pendingTab = options?.tab ?? pendingTab;
+
+  openInFlight = (async () => {
+    const settings = getAppStorage().settings;
+
+    const dialog = createOverlayDialog({
+      overlayId: ADDONS_OVERLAY_ID,
+      cardClassName: "pi-welcome-card pi-overlay-card pi-overlay-card--l",
+    });
+
+    const { header } = createOverlayHeader({
+      onClose: dialog.close,
+      closeLabel: "Close extensions",
+      title: "Extensions",
+      subtitle: "Connections, plugins, and skills that extend Pi",
+    });
+
+    // ── Tab bar ────────────────────────────────────
+    const tabBar = document.createElement("div");
+    tabBar.className = "pi-overlay-tabs";
+    tabBar.setAttribute("role", "tablist");
+    tabBar.setAttribute("aria-label", "Extensions tabs");
+
+    for (const tab of TABS) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "pi-overlay-tab";
+      btn.textContent = tab.label;
+      btn.dataset.hubTab = tab.id;
+      btn.setAttribute("role", "tab");
+      btn.setAttribute("aria-selected", "false");
+      btn.addEventListener("click", () => activateTab(dialog.overlay, tab.id));
+      tabBar.appendChild(btn);
+    }
+
+    // ── Panels ─────────────────────────────────────
+    const connectionsPanel = document.createElement("div");
+    connectionsPanel.dataset.hubPanel = "connections";
+    connectionsPanel.setAttribute("role", "tabpanel");
+    connectionsPanel.className = "pi-hub-stack pi-hub-stack--lg";
+
+    const pluginsPanel = document.createElement("div");
+    pluginsPanel.dataset.hubPanel = "plugins";
+    pluginsPanel.setAttribute("role", "tabpanel");
+    pluginsPanel.className = "pi-hub-stack pi-hub-stack--lg";
+
+    const skillsPanel = document.createElement("div");
+    skillsPanel.dataset.hubPanel = "skills";
+    skillsPanel.setAttribute("role", "tabpanel");
+    skillsPanel.className = "pi-hub-stack pi-hub-stack--lg";
+
+    const body = document.createElement("div");
+    body.className = "pi-overlay-body";
+    body.append(tabBar, connectionsPanel, pluginsPanel, skillsPanel);
+    dialog.card.append(header, body);
+
+    let disposed = false;
+    dialog.addCleanup(() => { disposed = true; });
+
+    // ── Shared mutation helper ─────────────────────
+    let busy = false;
+
+    const runMutation = async (
+      action: () => Promise<void>,
+      reason: "toggle" | "scope" | "external-toggle" | "config",
+      successMsg?: string,
+    ): Promise<void> => {
+      if (busy || disposed) return;
+      busy = true;
+      try {
+        await action();
+        dispatchIntegrationsChanged({ reason });
+        if (deps.onChanged) await deps.onChanged();
+        if (successMsg) showToast(successMsg);
+      } catch (err: unknown) {
+        showToast(`Extensions: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        busy = false;
+        if (!disposed) void refreshAll();
+      }
+    };
+
+    const isBusy = (): boolean => busy;
+
+    // ── Render each tab ────────────────────────────
+    const refreshConnections = async (): Promise<void> => {
+      if (disposed) return;
+      await renderConnectionsTab({
+        container: connectionsPanel,
+        settings,
+        deps,
+        isBusy,
+        runMutation,
+      });
+    };
+
+    const refreshPlugins = (): void => {
+      if (disposed) return;
+      renderPluginsTab({
+        container: pluginsPanel,
+        manager: deps.extensionManager,
+        isBusy,
+        onChanged: async () => {
+          if (deps.onChanged) await deps.onChanged();
+        },
+      });
+    };
+
+    const refreshSkills = async (): Promise<void> => {
+      if (disposed) return;
+      await renderSkillsTab({
+        container: skillsPanel,
+        settings,
+        isBusy,
+        runMutation,
+      });
+    };
+
+    const refreshAll = async (): Promise<void> => {
+      await Promise.all([
+        refreshConnections(),
+        Promise.resolve(refreshPlugins()),
+        refreshSkills(),
+      ]);
+    };
+
+    // ── Mount & initial render ─────────────────────
+    try {
+      await refreshAll();
+    } catch (err: unknown) {
+      showToast(`Extensions: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    dialog.mount();
+
+    const initialTab = pendingTab ?? "connections";
+    pendingTab = null;
+    requestAnimationFrame(() => {
+      const el = document.getElementById(ADDONS_OVERLAY_ID);
+      if (el instanceof HTMLElement) activateTab(el, initialTab);
+    });
+  })();
+
+  try {
+    await openInFlight;
+  } finally {
+    openInFlight = null;
+  }
+}

--- a/src/commands/builtins/extensions-hub-plugins.ts
+++ b/src/commands/builtins/extensions-hub-plugins.ts
@@ -1,0 +1,385 @@
+/**
+ * Extensions hub — Plugins tab.
+ *
+ * Installed plugins, install from URL / code, and advanced settings.
+ */
+
+import type {
+  ExtensionRuntimeManager,
+  ExtensionRuntimeStatus,
+} from "../../extensions/runtime-manager.js";
+import {
+  describeExtensionCapability,
+  getDefaultPermissionsForTrust,
+  isExtensionCapabilityAllowed,
+  listAllExtensionCapabilities,
+  listGrantedExtensionCapabilities,
+  type ExtensionCapability,
+} from "../../extensions/permissions.js";
+import { requestConfirmationDialog } from "../../ui/confirm-dialog.js";
+import { showToast } from "../../ui/toast.js";
+import {
+  createSectionHeader,
+  createItemCard,
+  createConfigRow,
+  createConfigValue,
+  createCallout,
+  createToggle,
+  createToggleRow,
+  createAddForm,
+  createAddFormRow,
+  createAddFormInput,
+  createEmptyInline,
+  createActionsRow,
+  createButton,
+} from "../../ui/extensions-hub-components.js";
+
+// ── Constants ───────────────────────────────────────
+
+const HIGH_RISK_CAPABILITIES = new Set<ExtensionCapability>([
+  "tools.register",
+  "agent.read",
+  "agent.events.read",
+  "llm.complete",
+  "http.fetch",
+  "agent.context.write",
+  "agent.steer",
+  "agent.followup",
+  "skills.write",
+]);
+
+// ── Helpers ─────────────────────────────────────────
+
+function getHighRiskGranted(status: ExtensionRuntimeStatus): ExtensionCapability[] {
+  return listAllExtensionCapabilities().filter(
+    (cap) => HIGH_RISK_CAPABILITIES.has(cap) && isExtensionCapabilityAllowed(status.permissions, cap),
+  );
+}
+
+async function confirmEnable(status: ExtensionRuntimeStatus): Promise<boolean> {
+  if (status.trust === "builtin") return true;
+  const risky = getHighRiskGranted(status);
+  if (risky.length === 0) return true;
+
+  return requestConfirmationDialog({
+    title: `Enable plugin "${status.name}"?`,
+    message: [
+      "Granted higher-risk permissions:",
+      ...risky.map((c) => `- ${describeExtensionCapability(c)}`),
+      "",
+      `Source: ${status.trustLabel}`,
+    ].join("\n"),
+    confirmLabel: "Enable",
+    cancelLabel: "Cancel",
+    confirmButtonTone: "danger",
+    restoreFocusOnClose: false,
+  });
+}
+
+async function confirmInstall(name: string, sourceLabel: string, capabilities: readonly ExtensionCapability[]): Promise<boolean> {
+  const risky = capabilities.filter((c) => HIGH_RISK_CAPABILITIES.has(c));
+  return requestConfirmationDialog({
+    title: `Install plugin "${name}"?`,
+    message: [
+      `Source: ${sourceLabel}`,
+      "",
+      "Default permissions:",
+      ...(capabilities.length > 0
+        ? capabilities.map((c) => `- ${describeExtensionCapability(c)}`)
+        : ["- (none)"]),
+      ...(risky.length > 0
+        ? ["", "Higher-risk:", ...risky.map((c) => `- ${describeExtensionCapability(c)}`)]
+        : []),
+    ].join("\n"),
+    confirmLabel: "Install",
+    cancelLabel: "Cancel",
+    confirmButtonTone: risky.length > 0 ? "danger" : "primary",
+    restoreFocusOnClose: false,
+  });
+}
+
+// ── Main render ─────────────────────────────────────
+
+export function renderPluginsTab(args: {
+  container: HTMLElement;
+  manager: ExtensionRuntimeManager;
+  isBusy: () => boolean;
+  onChanged: () => Promise<void>;
+}): void {
+  const { container, manager, isBusy, onChanged } = args;
+  container.replaceChildren();
+
+  const statuses = manager.list();
+
+  // ── Installed section ─────────────────────────
+  container.appendChild(createSectionHeader({
+    label: "Installed",
+    count: statuses.length,
+  }));
+
+  if (statuses.length === 0) {
+    container.appendChild(createEmptyInline("🧩", "No plugins installed.\nInstall from a URL or paste code."));
+  } else {
+    const list = document.createElement("div");
+    list.className = "pi-hub-stack";
+
+    for (const status of statuses) {
+      list.appendChild(renderPluginCard(status, manager, isBusy, onChanged, () => {
+        renderPluginsTab(args);
+      }));
+    }
+    container.appendChild(list);
+  }
+
+  // ── Install section ───────────────────────────
+  container.appendChild(createSectionHeader({ label: "Install" }));
+
+  const installForm = createAddForm();
+
+  // URL install
+  const urlRow = createAddFormRow();
+  const urlInput = createAddFormInput("Extension URL (https://… or file:///…)");
+  urlRow.append(
+    urlInput,
+    createButton("Install", {
+      primary: true,
+      compact: true,
+      onClick: () => {
+        if (isBusy()) return;
+        const url = urlInput.value.trim();
+        if (!url) { showToast("Enter a URL first."); return; }
+        void installFromUrl(url, manager, onChanged, () => renderPluginsTab(args));
+        urlInput.value = "";
+      },
+    }),
+  );
+  installForm.appendChild(urlRow);
+
+  // Code install toggle
+  const codeArea = document.createElement("textarea");
+  codeArea.className = "pi-overlay-input pi-hub-textarea";
+  codeArea.placeholder = "// Paste extension source code…";
+  codeArea.hidden = true;
+
+  const codeActions = document.createElement("div");
+  codeActions.className = "pi-hub-actions-end";
+  codeActions.hidden = true;
+
+  codeActions.appendChild(createButton("Install from code", {
+    primary: true,
+    compact: true,
+    onClick: () => {
+      if (isBusy()) return;
+      const code = codeArea.value.trim();
+      if (!code) { showToast("Paste code first."); return; }
+      void installFromCode(code, manager, onChanged, () => renderPluginsTab(args));
+      codeArea.value = "";
+    },
+  }));
+
+  const toggleCodeLink = document.createElement("button");
+  toggleCodeLink.type = "button";
+  toggleCodeLink.className = "pi-section-header__action";
+  toggleCodeLink.className = "pi-section-header__action pi-hub-code-toggle";
+  toggleCodeLink.textContent = "Or paste code directly…";
+  toggleCodeLink.addEventListener("click", () => {
+    const show = codeArea.hidden;
+    codeArea.hidden = !show;
+    codeActions.hidden = !show;
+    toggleCodeLink.textContent = show ? "Hide code editor" : "Or paste code directly…";
+  });
+
+  installForm.append(toggleCodeLink, codeArea, codeActions);
+  container.appendChild(installForm);
+
+  // ── Advanced section ──────────────────────────
+  const details = document.createElement("details");
+  
+
+  const summary = document.createElement("summary");
+  summary.className = "pi-hub-advanced-summary";
+  summary.textContent = "Advanced";
+
+  const advancedBody = document.createElement("div");
+  advancedBody.className = "pi-hub-advanced-body";
+
+  advancedBody.appendChild(createToggleRow({
+    label: "Allow remote URLs",
+    sublabel: "Install extensions from external URLs (requires trust)",
+    checked: false, // Read from settings if available
+  }).root);
+
+  advancedBody.appendChild(createToggleRow({
+    label: "LLM prompt template",
+    sublabel: "Custom system prompt preamble",
+    checked: false,
+  }).root);
+
+  details.append(summary, advancedBody);
+  container.appendChild(details);
+}
+
+// ── Plugin card ─────────────────────────────────────
+
+function renderPluginCard(
+  status: ExtensionRuntimeStatus,
+  manager: ExtensionRuntimeManager,
+  isBusy: () => boolean,
+  onChanged: () => Promise<void>,
+  refresh: () => void,
+): HTMLElement {
+  const enableToggle = createToggle({
+    checked: status.enabled,
+    stopPropagation: true,
+    onChange: (checked) => {
+      if (isBusy()) return;
+      void (async () => {
+        if (checked && !status.enabled && !(await confirmEnable(status))) {
+          enableToggle.input.checked = false;
+          return;
+        }
+        try {
+          await manager.setExtensionEnabled(status.id, checked);
+          await onChanged();
+          showToast(`${status.name}: ${checked ? "enabled" : "disabled"}`);
+          refresh();
+        } catch (err: unknown) {
+          showToast(`Plugins: ${err instanceof Error ? err.message : String(err)}`);
+          refresh();
+        }
+      })();
+    },
+  });
+
+  const card = createItemCard({
+    icon: "🧩",
+    iconColor: "purple",
+    name: status.name,
+    description: `${status.sourceLabel} · ${status.runtimeLabel}`,
+    expandable: true,
+    rightContent: enableToggle.root,
+  });
+
+  // Commands
+  if (status.commandNames.length > 0) {
+    const cmds = status.commandNames.map((c: string) => `/${c}`).join(", ");
+    card.body.appendChild(createConfigRow("Commands", createConfigValue(cmds)));
+  }
+
+  // Permissions grid
+  const allCaps = listAllExtensionCapabilities();
+  if (allCaps.length > 0) {
+    card.body.appendChild(createSectionHeader({ label: "Permissions" }));
+
+    const grid = document.createElement("div");
+    grid.className = "pi-item-card__permissions";
+
+    for (const cap of allCaps) {
+      const allowed = isExtensionCapabilityAllowed(status.permissions, cap);
+      const row = createToggleRow({
+        label: describeExtensionCapability(cap),
+        checked: allowed,
+        onChange: (checked) => {
+          void (async () => {
+            try {
+              await manager.setExtensionCapability(status.id, cap, checked);
+              showToast(`${status.name}: ${describeExtensionCapability(cap)} ${checked ? "granted" : "revoked"}`);
+              refresh();
+            } catch (err: unknown) {
+              showToast(`Plugins: ${err instanceof Error ? err.message : String(err)}`);
+              refresh();
+            }
+          })();
+        },
+      });
+      // Use sublabel styling for compact grid
+      const labelEl = row.root.querySelector(".pi-toggle-row__label");
+      if (labelEl) {
+        labelEl.className = "pi-toggle-row__sublabel";
+      }
+      grid.appendChild(row.root);
+    }
+    card.body.appendChild(grid);
+  }
+
+  // Uninstall
+  card.body.appendChild(createActionsRow(
+    createButton("Uninstall", {
+      danger: true,
+      compact: true,
+      onClick: () => {
+        if (isBusy()) return;
+        void (async () => {
+          const ok = await requestConfirmationDialog({
+            title: `Uninstall "${status.name}"?`,
+            message: "This removes the plugin and its settings.",
+            confirmLabel: "Uninstall",
+            cancelLabel: "Cancel",
+            confirmButtonTone: "danger",
+            restoreFocusOnClose: false,
+          });
+          if (!ok) return;
+          try {
+            await manager.uninstallExtension(status.id);
+            await onChanged();
+            showToast(`Uninstalled: ${status.name}`);
+            refresh();
+          } catch (err: unknown) {
+            showToast(`Plugins: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        })();
+      },
+    }),
+  ));
+
+  // Error callout
+  if (status.lastError) {
+    card.body.appendChild(createCallout("warn", "⚠", `Error: ${status.lastError}`, { compact: true }));
+  }
+
+  return card.root;
+}
+
+// ── Install helpers ─────────────────────────────────
+
+async function installFromUrl(
+  url: string,
+  manager: ExtensionRuntimeManager,
+  onChanged: () => Promise<void>,
+  refresh: () => void,
+): Promise<void> {
+  try {
+    const name = window.prompt("Extension name:", "") ?? "";
+    if (!name.trim()) return;
+    const perms = getDefaultPermissionsForTrust("remote-url");
+    const caps = listGrantedExtensionCapabilities(perms);
+    if (!(await confirmInstall(name, url, caps))) return;
+    await manager.installFromUrl(name, url);
+    await onChanged();
+    showToast(`Installed: ${name}`);
+    refresh();
+  } catch (err: unknown) {
+    showToast(`Install failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function installFromCode(
+  code: string,
+  manager: ExtensionRuntimeManager,
+  onChanged: () => Promise<void>,
+  refresh: () => void,
+): Promise<void> {
+  try {
+    const name = window.prompt("Extension name:", "my-extension") ?? "";
+    if (!name.trim()) return;
+    const perms = getDefaultPermissionsForTrust("inline-code");
+    const caps = listGrantedExtensionCapabilities(perms);
+    if (!(await confirmInstall(name, "inline code", caps))) return;
+    await manager.installFromCode(name, code);
+    await onChanged();
+    showToast(`Installed: ${name}`);
+    refresh();
+  } catch (err: unknown) {
+    showToast(`Install failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/src/commands/builtins/extensions-hub-skills.ts
+++ b/src/commands/builtins/extensions-hub-skills.ts
@@ -1,0 +1,330 @@
+/**
+ * Extensions hub — Skills tab.
+ *
+ * Bundled skills (read-only cards), external skills (expandable with remove),
+ * and install form for pasting SKILL.md content.
+ */
+
+import { getFilesWorkspace } from "../../files/workspace.js";
+import { listAgentSkills, mergeAgentSkillDefinitions } from "../../skills/catalog.js";
+import {
+  filterAgentSkillsByEnabledState,
+  loadDisabledSkillNamesFromSettings,
+  setSkillEnabledInSettings,
+  type SkillActivationMutableSettingsStore,
+} from "../../skills/activation-store.js";
+import {
+  loadExternalAgentSkillsFromWorkspace,
+  removeExternalAgentSkillFromWorkspace,
+  upsertExternalAgentSkillInWorkspace,
+} from "../../skills/external-store.js";
+import { dispatchSkillsChanged } from "../../skills/events.js";
+import type { AgentSkillDefinition } from "../../skills/types.js";
+import { showToast } from "../../ui/toast.js";
+import {
+  createSectionHeader,
+  createItemCard,
+  createConfigRow,
+  createConfigValue,
+  createAddForm,
+  createEmptyInline,
+  createButton,
+  createActionsRow,
+  createToggle,
+} from "../../ui/extensions-hub-components.js";
+
+// ── Types ───────────────────────────────────────────
+
+interface SkillsSnapshot {
+  bundled: AgentSkillDefinition[];
+  external: AgentSkillDefinition[];
+  active: AgentSkillDefinition[];
+  disabledNames: Set<string>;
+  externalLoadError: string | null;
+  activationLoadError: string | null;
+}
+
+// ── Snapshot builder ────────────────────────────────
+
+async function buildSnapshot(settings: SkillActivationMutableSettingsStore): Promise<SkillsSnapshot> {
+  const bundled = listAgentSkills();
+  let external: AgentSkillDefinition[] = [];
+  let externalLoadError: string | null = null;
+  let disabledNames = new Set<string>();
+  let activationLoadError: string | null = null;
+
+  try {
+    external = await loadExternalAgentSkillsFromWorkspace(getFilesWorkspace());
+  } catch (err: unknown) {
+    externalLoadError = err instanceof Error ? err.message : "Unknown error";
+  }
+
+  try {
+    disabledNames = await loadDisabledSkillNamesFromSettings(settings);
+  } catch (err: unknown) {
+    activationLoadError = err instanceof Error ? err.message : "Unknown error";
+  }
+
+  const all = mergeAgentSkillDefinitions(bundled, external);
+  const active = filterAgentSkillsByEnabledState({ skills: all, disabledSkillNames: disabledNames });
+
+  return { bundled, external, active, disabledNames, externalLoadError, activationLoadError };
+}
+
+function normalizeSkillName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+// ── Main render ─────────────────────────────────────
+
+export async function renderSkillsTab(args: {
+  container: HTMLElement;
+  settings: SkillActivationMutableSettingsStore;
+  isBusy: () => boolean;
+  runMutation: (action: () => Promise<void>, reason: "toggle" | "scope" | "external-toggle" | "config", msg?: string) => Promise<void>;
+}): Promise<void> {
+  const { container, settings, isBusy, runMutation } = args;
+
+  let snapshot: SkillsSnapshot;
+  try {
+    snapshot = await buildSnapshot(settings);
+  } catch (err: unknown) {
+    container.replaceChildren();
+    const msg = document.createElement("p");
+    msg.className = "pi-overlay-hint";
+    msg.textContent = `Failed to load skills: ${err instanceof Error ? err.message : String(err)}`;
+    container.appendChild(msg);
+    return;
+  }
+
+  const bundledNames = new Set(snapshot.bundled.map((s) => normalizeSkillName(s.name)));
+  const disabledNames = snapshot.disabledNames;
+  const activeBundledCount = snapshot.active.filter((skill) => skill.sourceKind === "bundled").length;
+  const activeExternalCount = snapshot.active.filter((skill) => skill.sourceKind === "external").length;
+
+  const isSkillEnabled = (skillName: string): boolean => !disabledNames.has(normalizeSkillName(skillName));
+
+  const toggleSkill = (skillName: string, enabled: boolean): void => {
+    if (isBusy()) return;
+
+    void runMutation(async () => {
+      const result = await setSkillEnabledInSettings({
+        settings,
+        name: skillName,
+        enabled,
+      });
+      if (result.changed) {
+        dispatchSkillsChanged({ reason: "activation" });
+      }
+    }, "toggle", `${enabled ? "Enabled" : "Disabled"} skill: ${skillName}`);
+  };
+
+  container.replaceChildren();
+
+  const statusLine = document.createElement("p");
+  statusLine.className = "pi-overlay-hint";
+  statusLine.textContent = `${snapshot.active.length} skills active (${activeBundledCount} bundled, ${activeExternalCount} external)`;
+  container.appendChild(statusLine);
+
+  // ── Bundled section ───────────────────────────
+  container.appendChild(createSectionHeader({
+    label: "Bundled skills",
+    count: snapshot.bundled.length,
+  }));
+
+  if (snapshot.bundled.length === 0) {
+    container.appendChild(createEmptyInline("📋", "No bundled skills in this build."));
+  } else {
+    const list = document.createElement("div");
+    list.className = "pi-hub-stack";
+
+    for (const skill of snapshot.bundled) {
+      list.appendChild(renderBundledSkillCard({
+        skill,
+        enabled: isSkillEnabled(skill.name),
+        busy: isBusy(),
+        onToggle: (enabled) => {
+          toggleSkill(skill.name, enabled);
+        },
+      }));
+    }
+    container.appendChild(list);
+  }
+
+  // ── External section ──────────────────────────
+  container.appendChild(createSectionHeader({
+    label: "External skills",
+    count: snapshot.external.length,
+  }));
+
+  if (snapshot.external.length === 0) {
+    container.appendChild(createEmptyInline("📋", "No external skills installed.\nPaste a SKILL.md below to add one."));
+  } else {
+    const list = document.createElement("div");
+    list.className = "pi-hub-stack";
+
+    for (const skill of snapshot.external) {
+      const shadowed = bundledNames.has(normalizeSkillName(skill.name));
+      list.appendChild(renderExternalSkillCard({
+        skill,
+        enabled: isSkillEnabled(skill.name),
+        shadowed,
+        busy: isBusy(),
+        onToggle: (enabled) => {
+          toggleSkill(skill.name, enabled);
+        },
+        onRemove: () => {
+          if (isBusy()) return;
+          void runMutation(async () => {
+            const removed = await removeExternalAgentSkillFromWorkspace({
+              workspace: getFilesWorkspace(),
+              name: skill.name,
+            });
+            if (removed) {
+              dispatchSkillsChanged({ reason: "catalog" });
+            } else {
+              throw new Error(`External skill not found: ${skill.name}`);
+            }
+          }, "config", `Removed external skill: ${skill.name}`);
+        },
+      }));
+    }
+    container.appendChild(list);
+  }
+
+  // Warnings
+  if (snapshot.externalLoadError) {
+    const warn = document.createElement("p");
+    warn.className = "pi-overlay-hint pi-hub-warn-text";
+    warn.textContent = `External skills load failed: ${snapshot.externalLoadError}`;
+    container.appendChild(warn);
+  }
+
+  if (snapshot.activationLoadError) {
+    const warn = document.createElement("p");
+    warn.className = "pi-overlay-hint pi-hub-warn-text";
+    warn.textContent = `Skill activation state unavailable: ${snapshot.activationLoadError}`;
+    container.appendChild(warn);
+  }
+
+  // ── Install section ───────────────────────────
+  container.appendChild(createSectionHeader({ label: "Install skill" }));
+
+  const installForm = createAddForm();
+
+  const hint = document.createElement("p");
+  hint.className = "pi-overlay-hint";
+  hint.textContent = "Paste a SKILL.md document below to install an external skill.";
+  installForm.appendChild(hint);
+
+  const textarea = document.createElement("textarea");
+  textarea.className = "pi-overlay-input pi-hub-textarea";
+  textarea.placeholder = "---\nname: my-skill\ndescription: What this skill does\n---\n\nInstructions for the agent...";
+  installForm.appendChild(textarea);
+
+  const installActions = document.createElement("div");
+  installActions.className = "pi-hub-actions-end";
+  installActions.appendChild(createButton("Install skill", {
+    primary: true,
+    compact: true,
+    onClick: () => {
+      if (isBusy()) return;
+      const md = textarea.value.trim();
+      if (!md) { showToast("Paste a SKILL.md document first."); return; }
+
+      void runMutation(async () => {
+        const result = await upsertExternalAgentSkillInWorkspace({
+          workspace: getFilesWorkspace(),
+          markdown: md,
+        });
+        showToast(`Saved external skill: ${result.name}`);
+        textarea.value = "";
+        dispatchSkillsChanged({ reason: "catalog" });
+      }, "config");
+    },
+  }));
+  installForm.appendChild(installActions);
+  container.appendChild(installForm);
+
+  // Footer hint
+  const footer = document.createElement("p");
+  footer.className = "pi-overlay-hint";
+  footer.textContent = "Skills are instruction documents the AI reads on-demand to learn new workflows. They don't run code — they teach.";
+  container.appendChild(footer);
+}
+
+// ── Bundled skill card ──────────────────────────────
+
+function renderBundledSkillCard(args: {
+  skill: AgentSkillDefinition;
+  enabled: boolean;
+  busy: boolean;
+  onToggle: (enabled: boolean) => void;
+}): HTMLElement {
+  const toggle = createToggle({
+    checked: args.enabled,
+    onChange: args.onToggle,
+    stopPropagation: true,
+  });
+  toggle.input.disabled = args.busy;
+
+  const card = createItemCard({
+    icon: "📋",
+    iconColor: "amber",
+    name: args.skill.name,
+    description: args.skill.description,
+    badges: [{ text: "Bundled", tone: "muted" }],
+    rightContent: toggle.root,
+  });
+
+  return card.root;
+}
+
+// ── External skill card (expandable) ────────────────
+
+function renderExternalSkillCard(args: {
+  skill: AgentSkillDefinition;
+  enabled: boolean;
+  shadowed: boolean;
+  busy: boolean;
+  onToggle: (enabled: boolean) => void;
+  onRemove: () => void;
+}): HTMLElement {
+  const badges: Array<{ text: string; tone: "ok" | "warn" | "muted" | "info" }> = [
+    { text: "External", tone: "info" },
+  ];
+  if (args.shadowed) {
+    badges.push({ text: "Shadowed", tone: "warn" });
+  }
+
+  const toggle = createToggle({
+    checked: args.enabled,
+    onChange: args.onToggle,
+    stopPropagation: true,
+  });
+  toggle.input.disabled = args.busy || args.shadowed;
+
+  const card = createItemCard({
+    icon: "📋",
+    iconColor: "amber",
+    name: args.skill.name,
+    description: args.skill.description,
+    expandable: true,
+    badges,
+    rightContent: toggle.root,
+  });
+
+  // Location
+  card.body.appendChild(createConfigRow("Location", createConfigValue(args.skill.location)));
+
+  // Remove button
+  card.body.appendChild(createActionsRow(
+    createButton("Remove", {
+      danger: true,
+      compact: true,
+      onClick: args.onRemove,
+    }),
+  ));
+
+  return card.root;
+}

--- a/src/commands/builtins/extensions.ts
+++ b/src/commands/builtins/extensions.ts
@@ -2,11 +2,11 @@
  * Builtin command for plugin management UI.
  */
 
-import type { AddonsSection } from "./addons-overlay.js";
+import type { ExtensionsHubTab } from "./extensions-hub-overlay.js";
 import type { SlashCommand } from "../types.js";
 
 export interface ExtensionsCommandActions {
-  openAddonsManager: (section?: AddonsSection) => void | Promise<void>;
+  openExtensionsHub: (tab?: ExtensionsHubTab) => void | Promise<void>;
 }
 
 export function createExtensionsCommands(actions: ExtensionsCommandActions): SlashCommand[] {
@@ -16,7 +16,7 @@ export function createExtensionsCommands(actions: ExtensionsCommandActions): Sla
       description: "Manage installed plugins (alias for /extensions plugins)",
       source: "builtin",
       execute: () => {
-        void actions.openAddonsManager("plugins");
+        void actions.openExtensionsHub("plugins");
       },
     },
   ];

--- a/src/commands/builtins/integrations.ts
+++ b/src/commands/builtins/integrations.ts
@@ -6,11 +6,11 @@ import {
   INTEGRATIONS_MANAGER_LABEL_LOWER,
   TOOLS_COMMAND_NAME,
 } from "../../integrations/naming.js";
-import type { AddonsSection } from "./addons-overlay.js";
+import type { ExtensionsHubTab } from "./extensions-hub-overlay.js";
 import type { SlashCommand } from "../types.js";
 
 export interface IntegrationsCommandActions {
-  openAddonsManager: (section?: AddonsSection) => void | Promise<void>;
+  openExtensionsHub: (tab?: ExtensionsHubTab) => void | Promise<void>;
 }
 
 export function createIntegrationsCommands(actions: IntegrationsCommandActions): SlashCommand[] {
@@ -20,7 +20,7 @@ export function createIntegrationsCommands(actions: IntegrationsCommandActions):
       description: `Manage ${INTEGRATIONS_MANAGER_LABEL_LOWER} (alias for /extensions connections)`,
       source: "builtin",
       execute: () => {
-        void actions.openAddonsManager("connections");
+        void actions.openExtensionsHub("connections");
       },
     },
   ];

--- a/src/commands/builtins/skills.ts
+++ b/src/commands/builtins/skills.ts
@@ -2,11 +2,11 @@
  * Builtin command for skills catalog UI.
  */
 
-import type { AddonsSection } from "./addons-overlay.js";
+import type { ExtensionsHubTab } from "./extensions-hub-overlay.js";
 import type { SlashCommand } from "../types.js";
 
 export interface SkillsCommandActions {
-  openAddonsManager: (section?: AddonsSection) => void | Promise<void>;
+  openExtensionsHub: (tab?: ExtensionsHubTab) => void | Promise<void>;
 }
 
 export function createSkillsCommands(actions: SkillsCommandActions): SlashCommand[] {
@@ -16,7 +16,7 @@ export function createSkillsCommands(actions: SkillsCommandActions): SlashComman
       description: "Browse available skills (alias for /extensions skills)",
       source: "builtin",
       execute: () => {
-        void actions.openAddonsManager("skills");
+        void actions.openExtensionsHub("skills");
       },
     },
   ];

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -39,10 +39,7 @@ import {
   withWorkbookCoordinator,
 } from "../tools/with-workbook-coordinator.js";
 import { registerBuiltins } from "../commands/builtins.js";
-import { showAddonsDialog, type AddonsSection } from "../commands/builtins/addons-overlay.js";
-import { showExtensionsDialog } from "../commands/builtins/extensions-overlay.js";
-import { showIntegrationsDialog } from "../commands/builtins/integrations-overlay.js";
-import { showSkillsDialog } from "../commands/builtins/skills-overlay.js";
+import { showExtensionsHubDialog, type ExtensionsHubTab } from "../commands/builtins/extensions-hub-overlay.js";
 import { ExtensionRuntimeManager } from "../extensions/runtime-manager.js";
 import type { ResumeDialogTarget } from "../commands/builtins/resume-target.js";
 import {
@@ -1276,29 +1273,8 @@ export async function initTaskpane(opts: {
     }
   });
 
-  const openIntegrationsManager = () => {
-    showIntegrationsDialog({
-      getActiveSessionId: () => getActiveRuntime()?.persistence.getSessionId() ?? null,
-      resolveWorkbookContext: async () => {
-        const workbookContext = await resolveWorkbookContext();
-        return {
-          workbookId: workbookContext.workbookId,
-          workbookLabel: formatWorkbookLabel(workbookContext),
-        };
-      },
-    });
-  };
-
-  const openExtensionsManager = () => {
-    showExtensionsDialog(extensionManager);
-  };
-
-  const openSkillsManager = () => {
-    showSkillsDialog();
-  };
-
-  const openAddonsManager = (section?: AddonsSection) => {
-    void showAddonsDialog(
+  const openExtensionsHub = (tab?: ExtensionsHubTab): void => {
+    void showExtensionsHubDialog(
       {
         getActiveSessionId: () => getActiveRuntime()?.persistence.getSessionId() ?? null,
         resolveWorkbookContext: async () => {
@@ -1308,14 +1284,10 @@ export async function initTaskpane(opts: {
             workbookLabel: formatWorkbookLabel(workbookContext),
           };
         },
+        extensionManager,
         onChanged: refreshCapabilitiesForAllRuntimes,
-        openIntegrationsManager,
-        openSkillsManager,
-        openExtensionsManager,
-        listExtensions: () => extensionManager.list(),
-        setExtensionEnabled: (entryId: string, enabled: boolean) => extensionManager.setExtensionEnabled(entryId, enabled),
       },
-      { section },
+      { tab },
     );
   };
 
@@ -1400,7 +1372,7 @@ export async function initTaskpane(opts: {
     },
     getExecutionMode: () => Promise.resolve(getExecutionMode()),
     setExecutionMode,
-    openAddonsManager,
+    openExtensionsHub,
     openFilesWorkspace: () => {
       void showFilesWorkspaceDialog();
     },
@@ -1484,7 +1456,7 @@ export async function initTaskpane(opts: {
     void openRulesEditor();
   };
   sidebar.onOpenExtensions = () => {
-    openAddonsManager();
+    openExtensionsHub();
   };
   sidebar.onOpenSettings = () => {
     void showSettingsDialog();

--- a/src/ui/extensions-hub-components.ts
+++ b/src/ui/extensions-hub-components.ts
@@ -1,0 +1,380 @@
+/**
+ * DOM helpers for the Extensions hub overlay components.
+ *
+ * Each function creates a small DOM subtree matching the CSS classes
+ * in `extensions-hub.css`. They are intentionally thin — the overlay
+ * tab builders compose them and wire event listeners.
+ */
+
+// ── Chevron SVG (shared across item cards) ──────────
+
+const CHEVRON_SVG = `<svg class="pi-item-card__chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6 4l4 4-4 4"/></svg>`;
+
+// ── Toggle switch ───────────────────────────────────
+
+export interface ToggleOptions {
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+  stopPropagation?: boolean;
+}
+
+/**
+ * Creates an iOS-style toggle switch.
+ * Uses the shared `.pi-toggle` CSS from toggle.css.
+ */
+export function createToggle(opts: ToggleOptions = {}): {
+  root: HTMLLabelElement;
+  input: HTMLInputElement;
+} {
+  const label = document.createElement("label");
+  label.className = "pi-toggle";
+
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.className = "pi-toggle__input";
+  if (opts.checked) input.checked = true;
+
+  const track = document.createElement("span");
+  track.className = "pi-toggle__track";
+
+  const thumb = document.createElement("span");
+  thumb.className = "pi-toggle__thumb";
+
+  label.append(input, track, thumb);
+
+  if (opts.stopPropagation) {
+    label.addEventListener("click", (e) => e.stopPropagation());
+  }
+
+  if (opts.onChange) {
+    const handler = opts.onChange;
+    input.addEventListener("change", () => handler(input.checked));
+  }
+
+  return { root: label, input };
+}
+
+// ── Toggle row ──────────────────────────────────────
+
+export interface ToggleRowOptions {
+  label: string;
+  sublabel?: string;
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+}
+
+/**
+ * Creates a label + toggle row.
+ */
+export function createToggleRow(opts: ToggleRowOptions): {
+  root: HTMLDivElement;
+  input: HTMLInputElement;
+} {
+  const row = document.createElement("div");
+  row.className = "pi-toggle-row";
+
+  const labels = document.createElement("div");
+  labels.className = "pi-toggle-row__labels";
+
+  const labelEl = document.createElement("div");
+  labelEl.className = "pi-toggle-row__label";
+  labelEl.textContent = opts.label;
+  labels.appendChild(labelEl);
+
+  if (opts.sublabel) {
+    const sub = document.createElement("div");
+    sub.className = "pi-toggle-row__sublabel";
+    sub.textContent = opts.sublabel;
+    labels.appendChild(sub);
+  }
+
+  const toggle = createToggle({
+    checked: opts.checked,
+    onChange: opts.onChange,
+  });
+
+  row.append(labels, toggle.root);
+  return { root: row, input: toggle.input };
+}
+
+// ── Section header ──────────────────────────────────
+
+export interface SectionHeaderOptions {
+  label: string;
+  count?: number;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export function createSectionHeader(opts: SectionHeaderOptions): HTMLDivElement {
+  const header = document.createElement("div");
+  header.className = "pi-section-header";
+
+  const label = document.createElement("span");
+  label.className = "pi-section-header__label";
+  label.textContent = opts.label;
+  header.appendChild(label);
+
+  if (opts.count != null) {
+    const count = document.createElement("span");
+    count.className = "pi-section-header__count";
+    count.textContent = `${opts.count} ${opts.count === 1 ? "skill" : "skills"}`;
+    header.appendChild(count);
+  }
+
+  if (opts.actionLabel && opts.onAction) {
+    const action = document.createElement("button");
+    action.type = "button";
+    action.className = "pi-section-header__action";
+    action.textContent = opts.actionLabel;
+    action.addEventListener("click", opts.onAction);
+    header.appendChild(action);
+  }
+
+  return header;
+}
+
+// ── Item card ───────────────────────────────────────
+
+export type ItemCardIconColor = "green" | "blue" | "purple" | "amber";
+
+export interface ItemCardOptions {
+  icon: string;
+  iconColor?: ItemCardIconColor;
+  name: string;
+  description?: string;
+  meta?: string;
+  expandable?: boolean;
+  expanded?: boolean;
+  badges?: Array<{ text: string; tone: "ok" | "warn" | "muted" | "info" }>;
+  /** Content for the right side of the header (before chevron). */
+  rightContent?: HTMLElement;
+}
+
+export interface ItemCardResult {
+  root: HTMLDivElement;
+  header: HTMLDivElement;
+  body: HTMLDivElement;
+  setExpanded: (expanded: boolean) => void;
+}
+
+/**
+ * Creates an expandable item card.
+ */
+export function createItemCard(opts: ItemCardOptions): ItemCardResult {
+  const card = document.createElement("div");
+  card.className = "pi-item-card";
+  if (opts.expanded) card.setAttribute("data-expanded", "");
+
+  // Header
+  const header = document.createElement("div");
+  header.className = `pi-item-card__header${opts.expandable ? " pi-item-card__header--expandable" : ""}`;
+
+  const iconEl = document.createElement("div");
+  iconEl.className = `pi-item-card__icon${opts.iconColor ? ` pi-item-card__icon--${opts.iconColor}` : ""}`;
+  iconEl.textContent = opts.icon;
+
+  const text = document.createElement("div");
+  text.className = "pi-item-card__text";
+
+  const nameEl = document.createElement("div");
+  nameEl.className = "pi-item-card__name";
+  nameEl.textContent = opts.name;
+  text.appendChild(nameEl);
+
+  if (opts.description) {
+    const desc = document.createElement("div");
+    desc.className = "pi-item-card__desc";
+    desc.textContent = opts.description;
+    text.appendChild(desc);
+  }
+
+  if (opts.meta) {
+    const meta = document.createElement("div");
+    meta.className = "pi-item-card__meta";
+    meta.textContent = opts.meta;
+    text.appendChild(meta);
+  }
+
+  header.append(iconEl, text);
+
+  // Right side
+  const right = document.createElement("div");
+  right.className = "pi-item-card__right";
+
+  if (opts.rightContent) {
+    right.appendChild(opts.rightContent);
+  }
+
+  if (opts.badges) {
+    for (const badge of opts.badges) {
+      const badgeEl = document.createElement("span");
+      badgeEl.className = `pi-overlay-badge pi-overlay-badge--${badge.tone}`;
+      badgeEl.textContent = badge.text;
+      right.appendChild(badgeEl);
+    }
+  }
+
+  if (opts.expandable) {
+    const chevron = document.createElement("span");
+    chevron.innerHTML = CHEVRON_SVG;
+    // The SVG is the first child, extract it
+    const svg = chevron.firstElementChild;
+    if (svg) right.appendChild(svg);
+  }
+
+  header.appendChild(right);
+
+  // Body
+  const body = document.createElement("div");
+  body.className = "pi-item-card__body";
+
+  // Expand/collapse
+  if (opts.expandable) {
+    header.addEventListener("click", () => {
+      card.toggleAttribute("data-expanded");
+    });
+  }
+
+  card.append(header, body);
+
+  return {
+    root: card,
+    header,
+    body,
+    setExpanded: (expanded: boolean) => {
+      if (expanded) {
+        card.setAttribute("data-expanded", "");
+      } else {
+        card.removeAttribute("data-expanded");
+      }
+    },
+  };
+}
+
+// ── Config row (inside item card body) ──────────────
+
+export function createConfigRow(label: string, content: HTMLElement): HTMLDivElement {
+  const row = document.createElement("div");
+  row.className = "pi-item-card__config-row";
+
+  const labelEl = document.createElement("span");
+  labelEl.className = "pi-item-card__config-label";
+  labelEl.textContent = label;
+
+  row.append(labelEl, content);
+  return row;
+}
+
+export function createConfigValue(text: string): HTMLSpanElement {
+  const el = document.createElement("span");
+  el.className = "pi-item-card__config-value";
+  el.textContent = text;
+  el.title = text;
+  return el;
+}
+
+export function createConfigInput(opts: {
+  value?: string;
+  placeholder?: string;
+  type?: string;
+  onChange?: (value: string) => void;
+}): HTMLInputElement {
+  const input = document.createElement("input");
+  input.className = "pi-item-card__config-input";
+  input.type = opts.type ?? "text";
+  if (opts.value) input.value = opts.value;
+  if (opts.placeholder) input.placeholder = opts.placeholder;
+  if (opts.onChange) {
+    const handler = opts.onChange;
+    input.addEventListener("change", () => handler(input.value));
+  }
+  return input;
+}
+
+// ── Callout ─────────────────────────────────────────
+
+export function createCallout(
+  tone: "info" | "warn" | "success",
+  icon: string,
+  message: string,
+  opts?: { compact?: boolean },
+): HTMLDivElement {
+  const callout = document.createElement("div");
+  callout.className = `pi-callout pi-callout--${tone}${opts?.compact ? " pi-callout--compact" : ""}`;
+
+  const iconEl = document.createElement("span");
+  iconEl.className = "pi-callout__icon";
+  iconEl.textContent = icon;
+
+  const body = document.createElement("div");
+  body.className = "pi-callout__body";
+  body.textContent = message;
+
+  callout.append(iconEl, body);
+  return callout;
+}
+
+// ── Add form ────────────────────────────────────────
+
+export function createAddForm(): HTMLDivElement {
+  const form = document.createElement("div");
+  form.className = "pi-add-form";
+  return form;
+}
+
+export function createAddFormRow(): HTMLDivElement {
+  const row = document.createElement("div");
+  row.className = "pi-add-form__row";
+  return row;
+}
+
+export function createAddFormInput(placeholder: string): HTMLInputElement {
+  const input = document.createElement("input");
+  input.className = "pi-add-form__input";
+  input.placeholder = placeholder;
+  return input;
+}
+
+// ── Empty inline ────────────────────────────────────
+
+export function createEmptyInline(icon: string, text: string): HTMLDivElement {
+  const el = document.createElement("div");
+  el.className = "pi-empty-inline";
+
+  const iconEl = document.createElement("span");
+  iconEl.className = "pi-empty-inline__icon";
+  iconEl.textContent = icon;
+
+  const textEl = document.createElement("span");
+  textEl.className = "pi-empty-inline__text";
+  textEl.textContent = text;
+
+  el.append(iconEl, textEl);
+  return el;
+}
+
+// ── Action buttons row ──────────────────────────────
+
+export function createActionsRow(...buttons: HTMLElement[]): HTMLDivElement {
+  const row = document.createElement("div");
+  row.className = "pi-overlay-actions";
+  row.append(...buttons);
+  return row;
+}
+
+export function createButton(
+  label: string,
+  opts?: { primary?: boolean; danger?: boolean; compact?: boolean; onClick?: () => void },
+): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  const classes = ["pi-overlay-btn"];
+  if (opts?.primary) classes.push("pi-overlay-btn--primary");
+  if (opts?.danger) classes.push("pi-overlay-btn--danger");
+  if (opts?.compact) classes.push("pi-overlay-btn--compact");
+  btn.className = classes.join(" ");
+  btn.textContent = label;
+  if (opts?.onClick) btn.addEventListener("click", opts.onClick);
+  return btn;
+}

--- a/src/ui/theme/components.css
+++ b/src/ui/theme/components.css
@@ -18,3 +18,4 @@
 @import "./components/welcome-login.css";
 @import "./components/toggle.css";
 @import "./components/disclosure-bar.css";
+@import "./components/extensions-hub.css";

--- a/src/ui/theme/components/extensions-hub.css
+++ b/src/ui/theme/components/extensions-hub.css
@@ -1,0 +1,420 @@
+/* ═══════════════════════════════════════════════════════
+   Extensions hub — shared components
+   
+   Item cards, section headers, callouts, add forms,
+   empty states used by the Extensions hub overlay tabs.
+   
+   Used by: extensions-hub-overlay, -connections, -plugins, -skills
+   ═══════════════════════════════════════════════════════ */
+
+/* ── Item card (connection / plugin / skill) ────────── */
+
+.pi-item-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--alpha-8);
+  background: var(--white-alpha-35);
+  border-radius: 10px;
+  overflow: hidden;
+  transition: border-color var(--duration-fast);
+}
+
+.pi-item-card:hover {
+  border-color: var(--alpha-12);
+}
+
+.pi-item-card__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: default;
+}
+
+.pi-item-card__header--expandable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.pi-item-card__header--expandable:hover {
+  background: var(--alpha-3);
+}
+
+.pi-item-card__icon {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--alpha-6);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.pi-item-card__icon--green {
+  background: var(--green-alpha-12);
+  color: var(--pi-green);
+}
+
+.pi-item-card__icon--blue {
+  background: oklch(0.55 0.12 250 / 0.10);
+  color: oklch(0.45 0.10 250);
+}
+
+.pi-item-card__icon--purple {
+  background: oklch(0.55 0.12 300 / 0.10);
+  color: oklch(0.45 0.10 300);
+}
+
+.pi-item-card__icon--amber {
+  background: oklch(0.72 0.16 84 / 0.12);
+  color: oklch(0.55 0.14 84);
+}
+
+.pi-item-card__text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+}
+
+.pi-item-card__name {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  font-weight: 500;
+  color: var(--foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pi-item-card__desc {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pi-item-card__meta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pi-item-card__right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.pi-item-card__chevron {
+  width: 16px;
+  height: 16px;
+  color: var(--muted-foreground);
+  transition: transform var(--duration-fast);
+  flex-shrink: 0;
+}
+
+.pi-item-card[data-expanded] .pi-item-card__chevron {
+  transform: rotate(90deg);
+}
+
+.pi-item-card__body {
+  display: none;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 12px 12px;
+  border-top: var(--pi-divider);
+}
+
+.pi-item-card[data-expanded] .pi-item-card__body {
+  display: flex;
+}
+
+/* Config rows inside expanded cards */
+.pi-item-card__config-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.pi-item-card__config-label {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+
+.pi-item-card__config-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--foreground);
+  background: var(--alpha-4);
+  padding: 3px 7px;
+  border-radius: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 260px;
+}
+
+.pi-item-card__config-input {
+  flex: 1;
+  max-width: 260px;
+  border: 1px solid var(--alpha-10);
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  background: var(--white-alpha-65);
+  color: var(--foreground);
+  outline: none;
+}
+
+.pi-item-card__config-input:focus {
+  border-color: var(--green-alpha-25);
+  box-shadow: 0 0 0 2px var(--pi-green-lighter);
+}
+
+/* Permissions grid */
+.pi-item-card__permissions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.pi-item-card__permissions .pi-toggle-row {
+  min-height: 22px;
+}
+
+/* ── Section header ─────────────────────────────────── */
+
+.pi-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-bottom: 4px;
+}
+
+.pi-section-header__label {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.pi-section-header__count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--muted-foreground);
+}
+
+.pi-section-header__action {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.pi-section-header__action:hover {
+  text-decoration: underline;
+}
+
+/* ── Callout / notice ───────────────────────────────── */
+
+.pi-callout {
+  display: flex;
+  gap: 10px;
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+}
+
+.pi-callout--info {
+  background: oklch(0.55 0.12 250 / 0.06);
+  border: 1px solid oklch(0.55 0.12 250 / 0.15);
+  color: oklch(0.35 0.08 250);
+}
+
+.pi-callout--warn {
+  background: oklch(0.72 0.16 84 / 0.08);
+  border: 1px solid oklch(0.72 0.16 84 / 0.20);
+  color: oklch(0.45 0.10 84);
+}
+
+.pi-callout--success {
+  background: var(--green-alpha-6);
+  border: 1px solid var(--green-alpha-14);
+  color: oklch(0.35 0.10 160);
+}
+
+.pi-callout--compact {
+  padding: 6px 10px;
+}
+
+.pi-callout__icon {
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.pi-callout__body {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Add form (dashed border) ───────────────────────── */
+
+.pi-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px dashed var(--alpha-12);
+  border-radius: 10px;
+  background: var(--alpha-2);
+}
+
+.pi-add-form__row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.pi-add-form__input {
+  flex: 1;
+  border: 1px solid var(--alpha-10);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  background: var(--white-alpha-70);
+  color: var(--foreground);
+  outline: none;
+}
+
+.pi-add-form__input:focus {
+  border-color: var(--green-alpha-25);
+  box-shadow: 0 0 0 2px var(--pi-green-lighter);
+}
+
+.pi-add-form__input::placeholder {
+  color: var(--muted-foreground);
+}
+
+/* ── Empty state (inline) ───────────────────────────── */
+
+.pi-empty-inline {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 20px 12px;
+  text-align: center;
+  border: 1px dashed var(--alpha-8);
+  border-radius: 10px;
+}
+
+.pi-empty-inline__icon {
+  font-size: 20px;
+  opacity: 0.4;
+}
+
+.pi-empty-inline__text {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--muted-foreground);
+}
+
+/* ── Layout helpers (avoiding inline styles) ────────── */
+
+.pi-hub-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pi-hub-stack--lg {
+  gap: 12px;
+}
+
+.pi-hub-inline-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex: 1;
+  max-width: 260px;
+}
+
+.pi-hub-actions-end {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.pi-hub-code-toggle {
+  font-size: var(--text-xs);
+  display: block;
+  text-align: center;
+  width: 100%;
+}
+
+.pi-hub-textarea {
+  min-height: 80px;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.pi-hub-advanced-summary {
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  user-select: none;
+}
+
+.pi-hub-advanced-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.pi-hub-warn-text {
+  color: var(--destructive);
+}
+
+.pi-item-card__config-select {
+  max-width: 180px;
+}
+
+/* ── Reduced motion ─────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .pi-item-card,
+  .pi-item-card__chevron {
+    transition: none;
+  }
+}

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -151,7 +151,7 @@ void test("extensions builtins expose /extensions without /addons alias", async 
 
   assert.match(source, /name:\s*"extensions"/);
   assert.doesNotMatch(source, /name:\s*"addons"/);
-  assert.match(source, /openAddonsManager/);
+  assert.match(source, /openExtensionsHub/);
 });
 
 void test("add-ons connections section links to detailed Tools & MCP manager", async () => {
@@ -177,16 +177,12 @@ void test("taskpane init wires Files workspace opener", async () => {
 void test("taskpane init wires extensions menu opener", async () => {
   const initSource = await readFile(new URL("../src/taskpane/init.ts", import.meta.url), "utf8");
 
-  assert.match(initSource, /const openAddonsManager = \(section\?: AddonsSection\) =>/);
-  assert.match(initSource, /showAddonsDialog\(/);
-  assert.match(initSource, /listExtensions:\s*\(\)\s*=>\s*extensionManager\.list\(\)/);
-  assert.match(initSource, /setExtensionEnabled:\s*\(entryId: string, enabled: boolean\)\s*=>\s*extensionManager\.setExtensionEnabled\(entryId, enabled\)/);
-  assert.match(initSource, /openIntegrationsManager/);
-  assert.match(initSource, /openSkillsManager/);
-  assert.match(initSource, /openExtensionsManager/);
+  assert.match(initSource, /const openExtensionsHub = \(tab\?: ExtensionsHubTab\): void =>/);
+  assert.match(initSource, /showExtensionsHubDialog\(/);
+  assert.match(initSource, /extensionManager/);
   assert.match(initSource, /configureSettingsDialogDependencies/);
-  assert.match(initSource, /registerBuiltins\([\s\S]*openAddonsManager/);
-  assert.match(initSource, /sidebar\.onOpenExtensions\s*=\s*\(\)\s*=>\s*\{\s*openAddonsManager\(\);\s*\};/);
+  assert.match(initSource, /registerBuiltins\([\s\S]*openExtensionsHub/);
+  assert.match(initSource, /sidebar\.onOpenExtensions\s*=\s*\(\)\s*=>\s*\{\s*openExtensionsHub\(\);\s*\};/);
 });
 
 void test("taskpane init wires gear settings to unified settings overlay", async () => {
@@ -208,28 +204,28 @@ void test("sidebar utilities menu includes extensions label", async () => {
   assert.doesNotMatch(sidebarSource, /Add-ons…/);
 });
 
-void test("extensions overlay groups connections, plugins, and skills with tabs", async () => {
-  const addonsSource = await readFile(new URL("../src/commands/builtins/addons-overlay.ts", import.meta.url), "utf8");
+void test("extensions hub groups connections, plugins, and skills with tabs", async () => {
+  const hubSource = await readFile(new URL("../src/commands/builtins/extensions-hub-overlay.ts", import.meta.url), "utf8");
   const connectionsSource = await readFile(
-    new URL("../src/commands/builtins/addons-overlay-connections.ts", import.meta.url),
+    new URL("../src/commands/builtins/extensions-hub-connections.ts", import.meta.url),
     "utf8",
   );
-  const extensionsSource = await readFile(
-    new URL("../src/commands/builtins/addons-overlay-extensions.ts", import.meta.url),
+  const pluginsSource = await readFile(
+    new URL("../src/commands/builtins/extensions-hub-plugins.ts", import.meta.url),
     "utf8",
   );
   const skillsSource = await readFile(
-    new URL("../src/commands/builtins/addons-overlay-skills.ts", import.meta.url),
+    new URL("../src/commands/builtins/extensions-hub-skills.ts", import.meta.url),
     "utf8",
   );
 
-  assert.match(addonsSource, /Connections, plugins, and skills in one place/);
-  assert.match(addonsSource, /data-extensions-tab/);
-  assert.match(connectionsSource, /dataset\.addonsSection = "connections"/);
-  assert.match(connectionsSource, /configured \(blocked\)/);
-  assert.match(extensionsSource, /dataset\.addonsSection = "plugins"/);
-  assert.match(extensionsSource, /renderPluginsSection/);
-  assert.match(skillsSource, /dataset\.addonsSection = "skills"/);
+  assert.match(hubSource, /title:\s*"Extensions"/);
+  assert.match(hubSource, /Connections, plugins, and skills that extend Pi/);
+  assert.match(hubSource, /dataset\.hubTab/);
+  assert.match(hubSource, /dataset\.hubPanel/);
+  assert.match(connectionsSource, /Web search/);
+  assert.match(pluginsSource, /Installed/);
+  assert.match(skillsSource, /Bundled skills/);
 });
 
 void test("context pill headers expose expanded state and controlled body", async () => {
@@ -299,7 +295,7 @@ void test("provider and experimental overlays are aliases into settings sections
   assert.match(experimentalSource, /buildExperimentalFeatureContent/);
 });
 
-void test("extensions and alias commands deep-link to extensions sections", async () => {
+void test("extensions and alias commands deep-link to hub tabs", async () => {
   const addonsSource = await readFile(new URL("../src/commands/builtins/addons.ts", import.meta.url), "utf8");
   const integrationsSource = await readFile(new URL("../src/commands/builtins/integrations.ts", import.meta.url), "utf8");
   const extensionsSource = await readFile(new URL("../src/commands/builtins/extensions.ts", import.meta.url), "utf8");
@@ -307,11 +303,11 @@ void test("extensions and alias commands deep-link to extensions sections", asyn
 
   assert.match(addonsSource, /name:\s*"extensions"/);
   assert.doesNotMatch(addonsSource, /name:\s*"addons"/);
-  assert.match(addonsSource, /openAddonsManager\(\)/);
+  assert.match(addonsSource, /openExtensionsHub\(\)/);
 
-  assert.match(integrationsSource, /openAddonsManager\("connections"\)/);
-  assert.match(extensionsSource, /openAddonsManager\("plugins"\)/);
-  assert.match(skillsSource, /openAddonsManager\("skills"\)/);
+  assert.match(integrationsSource, /openExtensionsHub\("connections"\)/);
+  assert.match(extensionsSource, /openExtensionsHub\("plugins"\)/);
+  assert.match(skillsSource, /openExtensionsHub\("skills"\)/);
 });
 
 void test("settings overlay serializes open flow and tolerates provider storage lookup failure", async () => {


### PR DESCRIPTION
## Summary

Implements PR 6a for #272: a unified **Extensions hub** overlay with three tabs (**Connections / Plugins / Skills**) and shared component primitives.

This is additive wiring: legacy standalone overlays are kept in-tree as dead code for rollback safety and will be deleted in PR 6b.

## What changed

### New shared UI primitives
- Added `src/ui/theme/components/extensions-hub.css`
  - `pi-item-card`, `pi-section-header`, `pi-callout`, `pi-add-form`, `pi-empty-inline`
  - small layout helper classes for builtins (no inline styles)
- Added `src/ui/extensions-hub-components.ts`
  - DOM helpers for toggle rows, item cards, section headers, config rows/inputs, callouts, actions

### New hub overlay + tabs
- Added `src/commands/builtins/extensions-hub-overlay.ts`
  - Reuses `ADDONS_OVERLAY_ID`
  - Title: `Extensions`
  - Subtitle: `Connections, plugins, and skills that extend Pi`
  - Tab switching via `data-hub-tab` / `data-hub-panel`

- Added `src/commands/builtins/extensions-hub-connections.ts`
  - External tools master toggle
  - Web Search card: provider picker, API key save/clear/validate, per-scope enable toggles (session/workbook)
  - MCP servers: list, add, remove, enable toggle, test connection
  - Bridges: Python + tmux bridge cards with URL save/clear

- Added `src/commands/builtins/extensions-hub-plugins.ts`
  - Installed plugins list as expandable cards
  - Header enable toggle, permissions toggles, uninstall action
  - Install form from URL or pasted code
  - Advanced collapsible section

- Added `src/commands/builtins/extensions-hub-skills.ts`
  - Status line: active totals
  - Bundled + external skill sections
  - Enable/disable toggles
  - External skill remove
  - Install external SKILL.md form

### Wiring updates
- `src/taskpane/init.ts`
  - Sidebar **Extensions…** now opens `showExtensionsHubDialog()`
  - Builtins wired to `openExtensionsHub` tab deep-links
  - Removed old live standalone-overlay opener wiring from init

- Updated builtins command wrappers:
  - `src/commands/builtins/addons.ts`
  - `src/commands/builtins/integrations.ts`
  - `src/commands/builtins/extensions.ts`
  - `src/commands/builtins/skills.ts`

- Imported new CSS in `src/ui/theme/components.css`

### Tests
- Updated `tests/builtins-registry.test.ts` expectations to reflect hub wiring and deep-links.

## Verification
- `npm run check` ✅
- `npm run build` ✅
- `npm run test:context` ✅ (475/475)

Part of #272.
