### PR TITLE
fix(files): make download and rename actions reliable

### DIFF
--- a/src/ui/overlay-ids.ts
+++ b/src/ui/overlay-ids.ts
@@ -12,5 +12,6 @@ export const FILES_WORKSPACE_OVERLAY_ID = "pi-files-workspace-overlay";
 export const WELCOME_LOGIN_OVERLAY_ID = "pi-welcome-login-overlay";
 export const PROVIDER_PROMPT_OVERLAY_ID = "pi-prompt-overlay";
 export const CONFIRM_DIALOG_OVERLAY_ID = "pi-confirm-dialog-overlay";
+export const TEXT_INPUT_DIALOG_OVERLAY_ID = "pi-text-input-dialog-overlay";
 export const TOOL_APPROVAL_OVERLAY_ID = "pi-tool-approval-overlay";
 export const EXTENSION_OVERLAY_ID = "pi-ext-overlay";

--- a/src/ui/text-input-dialog.ts
+++ b/src/ui/text-input-dialog.ts
@@ -1,0 +1,145 @@
+import {
+  closeOverlayById,
+  createOverlayButton,
+  createOverlayDialog,
+  createOverlayHeader,
+  createOverlayInput,
+} from "./overlay-dialog.js";
+import { TEXT_INPUT_DIALOG_OVERLAY_ID } from "./overlay-ids.js";
+
+const TEXT_INPUT_UI_UNAVAILABLE_ERROR =
+  "Text input UI is unavailable in this environment.";
+
+export interface TextInputDialogOptions {
+  title: string;
+  message?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  placeholder?: string;
+  initialValue?: string;
+  overlayId?: string;
+  restoreFocusOnClose?: boolean;
+  cardClassName?: string;
+}
+
+function canRenderTextInputDialog(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.body instanceof HTMLElement;
+}
+
+export function requestTextInputDialog(options: TextInputDialogOptions): Promise<string | null> {
+  if (!canRenderTextInputDialog()) {
+    return Promise.reject(new Error(TEXT_INPUT_UI_UNAVAILABLE_ERROR));
+  }
+
+  const overlayId = options.overlayId ?? TEXT_INPUT_DIALOG_OVERLAY_ID;
+  closeOverlayById(overlayId);
+
+  return new Promise((resolve) => {
+    const dialog = createOverlayDialog({
+      overlayId,
+      cardClassName: options.cardClassName ?? "pi-welcome-card pi-overlay-card pi-overlay-card--s",
+      restoreFocusOnClose: options.restoreFocusOnClose,
+    });
+
+    let settled = false;
+
+    const settle = (value: string | null): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve(value);
+    };
+
+    const cancel = (): void => {
+      settle(null);
+      dialog.close();
+    };
+
+    const { header } = createOverlayHeader({
+      onClose: cancel,
+      closeLabel: options.cancelLabel ?? "Cancel",
+      title: options.title,
+    });
+
+    const body = document.createElement("div");
+    body.className = "pi-overlay-body";
+
+    if (options.message) {
+      const message = document.createElement("p");
+      message.className = "pi-overlay-subtitle pi-confirm-dialog__message";
+      message.textContent = options.message;
+      body.appendChild(message);
+    }
+
+    const input = createOverlayInput({
+      placeholder: options.placeholder ?? "",
+    });
+    input.value = options.initialValue ?? "";
+    input.setAttribute("autocomplete", "off");
+    body.appendChild(input);
+
+    const submit = (): void => {
+      settle(input.value);
+      dialog.close();
+    };
+
+    const onInputKeydown = (event: KeyboardEvent): void => {
+      if (event.key !== "Enter") {
+        return;
+      }
+
+      event.preventDefault();
+      submit();
+    };
+
+    input.addEventListener("keydown", onInputKeydown);
+
+    const actions = document.createElement("div");
+    actions.className = "pi-overlay-actions";
+
+    const cancelButton = createOverlayButton({
+      text: options.cancelLabel ?? "Cancel",
+    });
+
+    const confirmButton = createOverlayButton({
+      text: options.confirmLabel ?? "Save",
+      className: "pi-overlay-btn--primary",
+    });
+
+    cancelButton.addEventListener("click", cancel);
+    confirmButton.addEventListener("click", submit);
+
+    dialog.addCleanup(() => {
+      input.removeEventListener("keydown", onInputKeydown);
+      cancelButton.removeEventListener("click", cancel);
+      confirmButton.removeEventListener("click", submit);
+      settle(null);
+    });
+
+    actions.append(cancelButton, confirmButton);
+    dialog.card.append(header, body, actions);
+    dialog.mount();
+
+    const focusInput = (): void => {
+      if (typeof input.focus === "function") {
+        input.focus();
+      }
+
+      if (typeof input.select === "function") {
+        input.select();
+      }
+    };
+
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(focusInput);
+    } else {
+      focusInput();
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the remaining action failures from #316 in the Files dialog:

- Replace `window.prompt()` rename with an in-app text input overlay (`requestTextInputDialog`) so rename works in Office WebView contexts where prompt dialogs are blocked.
- Improve rename UX by treating bare filenames as “rename in same folder” while still allowing full-path moves.
- Improve binary preview copy for unsupported formats (e.g. `.docx`) to make the fallback explicit.
- Harden `workspace.downloadFile()` by pre-opening a blank window synchronously (before async I/O) and navigating it after blob creation; this preserves user activation in WKWebView and avoids silent failures.
- Update empty-state copy to remove the stale “create a text file” instruction.

## Testing

- `npm run check`
- `npm run build`
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/overlay-dialog.test.ts tests/files-workspace.test.ts`

Closes #316
