### PR TITLE
fix(ui): polish remaining extensions-hub parity gaps

### DIFF
--- a/src/commands/builtins/extensions-hub-plugins.ts
+++ b/src/commands/builtins/extensions-hub-plugins.ts
@@ -177,19 +177,31 @@ export function renderPluginsTab(args: {
     },
   }));
 
+  const codeAreaId = "pi-plugin-install-code";
+  codeArea.id = codeAreaId;
+
   const toggleCodeLink = document.createElement("button");
   toggleCodeLink.type = "button";
-  toggleCodeLink.className = "pi-section-header__action";
   toggleCodeLink.className = "pi-section-header__action pi-hub-code-toggle";
   toggleCodeLink.textContent = "Or paste code directly…";
+  toggleCodeLink.setAttribute("aria-controls", codeAreaId);
+  toggleCodeLink.setAttribute("aria-expanded", "false");
   toggleCodeLink.addEventListener("click", () => {
     const show = codeArea.hidden;
     codeArea.hidden = !show;
     codeActions.hidden = !show;
     toggleCodeLink.textContent = show ? "Hide code editor" : "Or paste code directly…";
+    toggleCodeLink.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) {
+      codeArea.focus();
+    }
   });
 
-  installForm.append(toggleCodeLink, codeArea, codeActions);
+  const codeToggleRow = document.createElement("div");
+  codeToggleRow.className = "pi-hub-code-toggle-row";
+  codeToggleRow.appendChild(toggleCodeLink);
+
+  installForm.append(codeToggleRow, codeArea, codeActions);
   container.appendChild(installForm);
 
   // ── Advanced section ──────────────────────────

--- a/src/ui/theme/components/extensions-hub.css
+++ b/src/ui/theme/components/extensions-hub.css
@@ -371,11 +371,17 @@
   justify-content: flex-end;
 }
 
+.pi-hub-code-toggle-row {
+  display: flex;
+  justify-content: flex-start;
+}
+
 .pi-hub-code-toggle {
-  font-size: var(--text-xs);
-  display: block;
-  text-align: center;
-  width: 100%;
+  font-size: var(--text-sm);
+  display: inline-flex;
+  align-items: center;
+  text-align: left;
+  width: auto;
 }
 
 .pi-hub-textarea {
@@ -400,6 +406,16 @@
   flex-direction: column;
   gap: 8px;
   margin-top: 10px;
+}
+
+.pi-hub-scope-disclosure {
+  border-top: var(--pi-divider);
+  margin-top: 2px;
+  padding-top: 8px;
+}
+
+.pi-hub-scope-disclosure > summary {
+  margin-bottom: 6px;
 }
 
 .pi-hub-warn-text {

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -98,6 +98,8 @@ void test("builtins registry wires /addons, /experimental, /extensions, /integra
   assert.match(extensionsHubPluginsSource, /createSectionHeader\(\{ label: "Permissions" \}\)/);
   assert.match(extensionsHubPluginsSource, /installFromUrl\(/);
   assert.match(extensionsHubPluginsSource, /installFromCode\(/);
+  assert.match(extensionsHubPluginsSource, /pi-hub-code-toggle-row/);
+  assert.match(extensionsHubPluginsSource, /aria-expanded/);
   assert.match(extensionsHubPluginsSource, /summary\.textContent = "Advanced"/);
 
   const extensionsDocsSource = await readFile(new URL("../docs/extensions.md", import.meta.url), "utf8");
@@ -154,6 +156,8 @@ void test("extensions hub connections tab includes MCP test flow", async () => {
 
   assert.match(source, /label: "MCP servers"/);
   assert.match(source, /\+ Add server/);
+  assert.match(source, /createConfigRow\("Availability"/);
+  assert.match(source, /scopeSummary\.textContent = "Scope controls"/);
   assert.match(source, /probeMcpServer/);
 });
 


### PR DESCRIPTION
## Summary
- add a compact "Availability" row to the Web search card and move session/workbook scope toggles into a collapsed "Scope controls" disclosure
- keep scope behavior intact while reducing default visual noise in the Connections tab
- improve the Plugins install form link visibility and a11y for "Or paste code directly…" (row layout, aria-expanded/controls, focus when opened)
- add regression assertions in `tests/builtins-registry.test.ts` for the new scope/code-toggle structure

## Validation
- `npm run check`
- `npm run build`
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/builtins-registry.test.ts tests/extension-overlay-integration.test.ts tests/integrations-store.test.ts`

Follow-up for #340
