### PR TITLE
fix(execute_office_js): skip approval prompt in Auto mode

### DIFF
--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -670,6 +670,7 @@ export async function initTaskpane(opts: {
       }).filter(isRuntimeAgentTool);
 
       const gatedCoreTools = await applyExperimentalToolGates(coreTools, {
+        getExecutionMode: () => Promise.resolve(getExecutionMode()),
         requestOfficeJsExecuteApproval: (request) => {
           return requestRuntimeToolApproval({
             title: "Allow direct Office.js execution?",

--- a/src/tools/experimental-tool-gates/types.ts
+++ b/src/tools/experimental-tool-gates/types.ts
@@ -70,4 +70,6 @@ export interface ExperimentalToolGateDependencies extends
   getApprovedPythonBridgeUrl?: () => Promise<string | undefined>;
   setApprovedPythonBridgeUrl?: (bridgeUrl: string) => Promise<void>;
   requestOfficeJsExecuteApproval?: (request: OfficeJsExecuteApprovalRequest) => Promise<boolean>;
+  /** When provided, Auto mode skips the Office.js approval prompt. */
+  getExecutionMode?: () => Promise<"yolo" | "safe">;
 }

--- a/src/tools/experimental-tool-gates/wrappers.ts
+++ b/src/tools/experimental-tool-gates/wrappers.ts
@@ -157,9 +157,13 @@ function wrapExecuteOfficeJsToolWithHardGate(
     execute: async (toolCallId, params, signal, onUpdate) => {
       throwIfAborted(signal);
 
-      const approved = await requestApproval(getOfficeJsExecuteApprovalRequest(params));
-      if (!approved) {
-        throw new Error("Office.js execution cancelled by user.");
+      // Auto mode trusts Office.js — skip approval prompt.
+      const mode = await (dependencies.getExecutionMode?.() ?? Promise.resolve("safe" as const));
+      if (mode !== "yolo") {
+        const approved = await requestApproval(getOfficeJsExecuteApprovalRequest(params));
+        if (!approved) {
+          throw new Error("Office.js execution cancelled by user.");
+        }
       }
 
       throwIfAborted(signal);


### PR DESCRIPTION
Auto (yolo) mode now trusts `execute_office_js` the same way it trusts other mutating tools — no per-call confirmation dialog.

Confirm (safe) mode still prompts "Allow once" on every call, unchanged.

## Changes

- **`src/tools/experimental-tool-gates/types.ts`** — added optional `getExecutionMode` to `ExperimentalToolGateDependencies`
- **`src/tools/experimental-tool-gates/wrappers.ts`** — `wrapExecuteOfficeJsToolWithHardGate` checks execution mode; skips approval when `"yolo"`
- **`src/taskpane/init.ts`** — passes `getExecutionMode` into `applyExperimentalToolGates`

Default fallback is `"safe"` when `getExecutionMode` is not provided (backwards compatible — tests and standalone usage still prompt).

## Behavior

| Mode | Office.js approval |
|---|---|
| **Auto** | Skipped — runs immediately |
| **Confirm** | Prompted every call (unchanged) |

Closes #303
