### PR TITLE
docs(proxy): replace helper wording with proxy copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ The dev manifest points to `https://localhost:3000`. The production manifest (`m
 | `npm run test:models` | Unit tests — model ordering |
 | `npm run test:context` | Unit tests — tools, context, sessions, extensions, integrations |
 | `npm run test:security` | Security policy tests — proxy, CORS, sandbox, OAuth |
-| `npm run proxy:https` | CORS proxy helper for OAuth flows (default `https://localhost:3003`) |
+| `npm run proxy:https` | CORS proxy for OAuth flows (default `https://localhost:3003`) |
 | `npm run validate` | Validate the Office add-in manifest |
 
-### CORS proxy helper
+### CORS proxy
 
 Some OAuth token endpoints are blocked by CORS inside Office webviews. If OAuth login fails:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -72,7 +72,7 @@ If you get a response, install is complete.
 
 ### Recommended (easiest): API key
 
-For most users, API keys are the smoothest setup and usually do **not** need the proxy helper.
+For most users, API keys are the smoothest setup and usually do **not** need the proxy.
 
 1. In Pi, run `/login` (or use the welcome screen)
 2. Expand a provider row (OpenAI, Google Gemini, Anthropic, etc.)
@@ -91,7 +91,7 @@ If login fails with a CORS/network error, follow the next section.
 
 ---
 
-## OAuth logins and CORS helper
+## OAuth logins and CORS proxy
 
 Some OAuth/token endpoints are blocked by CORS inside Office webviews (especially on macOS WKWebView).
 
@@ -102,7 +102,7 @@ Typical symptoms:
 
 ### What to do
 
-1. Run a local HTTPS proxy helper on the same machine as Excel (defaults to `https://localhost:3003`):
+1. Run a local HTTPS proxy on the same machine as Excel (defaults to `https://localhost:3003`):
 
 If you already have Node.js:
 
@@ -119,7 +119,7 @@ curl -fsSL https://piforexcel.com/proxy | sh
 If the user is non-technical, a teammate/admin can run this step for them on their machine.
 
 2. In Pi, open `/settings` → **Proxy**:
-   - enable **Use CORS Proxy**
+   - enable **Proxy**
    - set URL to `https://localhost:3003`
 
 3. Retry OAuth login

--- a/src/auth/proxy-validation.ts
+++ b/src/auth/proxy-validation.ts
@@ -8,7 +8,7 @@
 
 export const DEFAULT_LOCAL_PROXY_URL = "https://localhost:3003";
 export const PROXY_HELPER_DOCS_URL =
-  "https://github.com/tmustier/pi-for-excel/blob/main/docs/install.md#oauth-logins-and-cors-helper";
+  "https://github.com/tmustier/pi-for-excel/blob/main/docs/install.md#oauth-logins-and-cors-proxy";
 
 export function normalizeProxyUrl(url: string): string {
   return url.trim().replace(/\/+$/, "");
@@ -37,7 +37,7 @@ export function validateOfficeProxyUrl(url: string): string {
   if (typeof window !== "undefined" && window.location?.protocol === "https:" && parsed.protocol === "http:") {
     throw new Error(
       `Proxy URL is HTTP (${normalized}) but the add-in is served over HTTPS. Office webviews may block this as mixed content. ` +
-        `Use ${DEFAULT_LOCAL_PROXY_URL} and run a local HTTPS proxy helper. See ${PROXY_HELPER_DOCS_URL}.`,
+        `Use ${DEFAULT_LOCAL_PROXY_URL} and run a local HTTPS proxy. See ${PROXY_HELPER_DOCS_URL}.`,
     );
   }
 

--- a/src/taskpane/welcome-login.ts
+++ b/src/taskpane/welcome-login.ts
@@ -154,7 +154,7 @@ export async function showWelcomeLogin(providerKeys: ProviderKeysStore): Promise
     proxyHint.append(
       "Needed only when OAuth login is blocked by CORS. Keep this URL at ",
       proxyCode,
-      ", run a local HTTPS proxy helper, then enable this toggle. ",
+      ", run a local HTTPS proxy, then enable this toggle. ",
       proxyGuideLink,
       ".",
     );

--- a/src/ui/provider-login.ts
+++ b/src/ui/provider-login.ts
@@ -431,7 +431,7 @@ export function buildProviderRow(
           if (isLikelyCors) {
             errorEl.textContent =
               "Login was blocked by browser CORS. Enable /settings → Proxy with " +
-              `${DEFAULT_LOCAL_PROXY_URL} (local HTTPS proxy helper running), then retry. ` +
+              `${DEFAULT_LOCAL_PROXY_URL} (local HTTPS proxy running), then retry. ` +
               `Guide: ${PROXY_HELPER_DOCS_URL}`;
           } else {
             errorEl.textContent = msg || "Login failed";


### PR DESCRIPTION
## Summary
- replace remaining user-facing "proxy helper" wording with "proxy" in install/developer docs and login guidance
- update the install-doc anchor used in proxy validation errors after renaming the section to **OAuth logins and CORS proxy**
- keep behavior unchanged; this is copy/docs alignment so shipped UI and docs match current proxy terminology

## Notes
- `.research/` is gitignored in this repo, so prototype-file edits are not committable here.
- This PR closes the tracked/docs side of #340 P1 by syncing source-of-truth docs + runtime copy.

## Validation
- `npm run check`
- `npm run build`

Follow-up for #340
