### PR TITLE
fix(ui): improve keyboard shortcuts kbd contrast

### DIFF
--- a/src/ui/theme/overlays/provider-resume-shortcuts.css
+++ b/src/ui/theme/overlays/provider-resume-shortcuts.css
@@ -135,8 +135,11 @@
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   padding: 2px 6px;
-  background: var(--alpha-5);
+  background: var(--alpha-6);
+  border: 1px solid var(--alpha-10);
   border-radius: var(--radius-xs);
+  box-shadow: 0 1px 0 var(--alpha-6);
+  color: var(--foreground);
   white-space: nowrap;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Problem

The keyboard shortcut `kbd` badges in the shortcuts overlay are nearly invisible. They use `alpha-5` (5% opacity) background with no border and no explicit text color, rendering them unreadable against the glass card background.

**Before:** Key badges are washed out — light gray on light gray with no visual boundaries.

## Fix

Improve `.pi-shortcuts-key` contrast using existing design tokens:

- **Background:** `alpha-5` → `alpha-6` (slightly stronger)
- **Border:** add `1px solid var(--alpha-10)` to define key edges
- **Shadow:** add `0 1px 0 var(--alpha-6)` for keycap depth
- **Color:** set explicit `var(--foreground)` for text contrast

All tokens are theme-aware, so both light and dark modes benefit. The styling follows the same pattern as the landing page's `kbd` elements.
