### PR TITLE
fix(files): hide connect-folder action when unsupported

### DIFF
--- a/src/ui/files-dialog-filtering.ts
+++ b/src/ui/files-dialog-filtering.ts
@@ -189,9 +189,9 @@ export function resolveFilesDialogConnectFolderButtonState(
 ): FilesDialogConnectFolderButtonState {
   if (!backendStatus || !backendStatus.nativeSupported) {
     return {
-      hidden: false,
+      hidden: true,
       disabled: true,
-      label: "Folder unavailable",
+      label: "Connect folder",
     };
   }
 

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -934,10 +934,10 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     const connectState = resolveFilesDialogConnectFolderButtonState(backendStatus);
     connectFolderButton.hidden = connectState.hidden;
     connectFolderButton.disabled = connectState.disabled;
-    if (connectState.label === "Connected ✓") {
+    if (connectState.hidden) {
+      connectFolderButton.title = "";
+    } else if (connectState.label === "Connected ✓") {
       connectFolderButton.title = "Folder already connected";
-    } else if (connectState.label === "Folder unavailable") {
-      connectFolderButton.title = "Native folder picker is not available in this environment";
     } else {
       connectFolderButton.title = "Connect local folder";
     }

--- a/tests/files-dialog-filtering.test.ts
+++ b/tests/files-dialog-filtering.test.ts
@@ -173,9 +173,9 @@ void test("resolveFilesDialogSourceLabel maps each source", () => {
 
 void test("resolveFilesDialogConnectFolderButtonState reflects backend status", () => {
   assert.deepEqual(resolveFilesDialogConnectFolderButtonState(null), {
-    hidden: false,
+    hidden: true,
     disabled: true,
-    label: "Folder unavailable",
+    label: "Connect folder",
   });
 
   assert.deepEqual(resolveFilesDialogConnectFolderButtonState({
@@ -184,9 +184,9 @@ void test("resolveFilesDialogConnectFolderButtonState reflects backend status", 
     nativeSupported: false,
     nativeConnected: false,
   }), {
-    hidden: false,
+    hidden: true,
     disabled: true,
-    label: "Folder unavailable",
+    label: "Connect folder",
   });
 
   assert.deepEqual(resolveFilesDialogConnectFolderButtonState({


### PR DESCRIPTION
## Summary
- hide the **Connect folder** button in Files when native directory picker support is unavailable
- keep current behavior when supported:
  - `Connect folder` when available + disconnected
  - disabled `Connected ✓` when connected
- remove stale UI branch that assumed visible `Folder unavailable` state
- update filtering tests to reflect hidden-when-unsupported behavior

## Why
In unsupported Excel hosts (e.g. macOS desktop WKWebView), showing a disabled `Folder unavailable` action is confusing and looks like a broken feature.

## Validation
- `npm run check`
- `npm run build`
- `npm run test:context`

## Related
- #360
