### PR TITLE
refactor(files): centralize connect-folder button state copy

### DIFF
--- a/src/ui/files-dialog-filtering.ts
+++ b/src/ui/files-dialog-filtering.ts
@@ -182,6 +182,7 @@ export interface FilesDialogConnectFolderButtonState {
   hidden: boolean;
   disabled: boolean;
   label: string;
+  title: string;
 }
 
 export function resolveFilesDialogConnectFolderButtonState(
@@ -192,6 +193,7 @@ export function resolveFilesDialogConnectFolderButtonState(
       hidden: true,
       disabled: true,
       label: "Connect folder",
+      title: "",
     };
   }
 
@@ -200,6 +202,7 @@ export function resolveFilesDialogConnectFolderButtonState(
       hidden: false,
       disabled: true,
       label: "Connected ✓",
+      title: "Folder already connected",
     };
   }
 
@@ -207,5 +210,6 @@ export function resolveFilesDialogConnectFolderButtonState(
     hidden: false,
     disabled: false,
     label: "Connect folder",
+    title: "Connect local folder",
   };
 }

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -934,13 +934,7 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     const connectState = resolveFilesDialogConnectFolderButtonState(backendStatus);
     connectFolderButton.hidden = connectState.hidden;
     connectFolderButton.disabled = connectState.disabled;
-    if (connectState.hidden) {
-      connectFolderButton.title = "";
-    } else if (connectState.label === "Connected ✓") {
-      connectFolderButton.title = "Folder already connected";
-    } else {
-      connectFolderButton.title = "Connect local folder";
-    }
+    connectFolderButton.title = connectState.title;
     connectFolderButton.setAttribute("aria-label", connectState.label);
 
     if (connectFolderButton.lastChild) {

--- a/tests/files-dialog-filtering.test.ts
+++ b/tests/files-dialog-filtering.test.ts
@@ -176,6 +176,7 @@ void test("resolveFilesDialogConnectFolderButtonState reflects backend status", 
     hidden: true,
     disabled: true,
     label: "Connect folder",
+    title: "",
   });
 
   assert.deepEqual(resolveFilesDialogConnectFolderButtonState({
@@ -187,6 +188,7 @@ void test("resolveFilesDialogConnectFolderButtonState reflects backend status", 
     hidden: true,
     disabled: true,
     label: "Connect folder",
+    title: "",
   });
 
   assert.deepEqual(resolveFilesDialogConnectFolderButtonState({
@@ -198,11 +200,13 @@ void test("resolveFilesDialogConnectFolderButtonState reflects backend status", 
     hidden: false,
     disabled: false,
     label: "Connect folder",
+    title: "Connect local folder",
   });
 
   assert.deepEqual(resolveFilesDialogConnectFolderButtonState(connectedBackendStatus), {
     hidden: false,
     disabled: true,
     label: "Connected ✓",
+    title: "Folder already connected",
   });
 });


### PR DESCRIPTION
## Summary
- refactor Files connect-folder button state to include `title` metadata directly in `resolveFilesDialogConnectFolderButtonState`
- remove UI string-branching in `files-dialog.ts` based on button label text
- keep behavior unchanged:
  - hidden when unsupported
  - disabled `Connected ✓` when already connected
  - enabled `Connect folder` when available
- expand filtering tests to assert full button state copy (`label` + `title`)

## Why
`files-dialog.ts` previously inferred behavior from display text (`label === "Connected ✓"`), which couples control flow to UI copy. This refactor keeps behavior in one place and makes future copy updates safer.

## Validation
- `npm run check`
- `npm run build`
- `npm run test:context`
