### PR TITLE
fix: stub Ajv to prevent CSP unsafe-eval violation in Office webview

### DIFF
--- a/src/stubs/ajv-formats.ts
+++ b/src/stubs/ajv-formats.ts
@@ -1,0 +1,10 @@
+/**
+ * Stub for ajv-formats in the Office Add-in environment.
+ *
+ * ajv-formats is a companion to Ajv that registers string format validators.
+ * Since Ajv itself is stubbed out (see ./ajv.ts), this is a no-op.
+ */
+
+export default function addFormats() {
+  // no-op — Ajv is stubbed, so there's nothing to register formats on.
+}

--- a/src/stubs/ajv.ts
+++ b/src/stubs/ajv.ts
@@ -1,0 +1,23 @@
+/**
+ * Stub for Ajv in the Office Add-in environment.
+ *
+ * Ajv v8 uses `new Function()` internally when compiling JSON schemas.
+ * The Office webview enforces a strict CSP (`script-src 'self' ...`) that
+ * blocks `unsafe-eval`, so Ajv.compile() always throws at runtime.
+ *
+ * pi-ai's validation.js already has a fallback path: when `ajv` is null it
+ * skips schema validation and trusts the LLM output directly. But the guard
+ * only checks for Chrome extensions, not Office Add-ins.
+ *
+ * This stub ensures `new Ajv()` construction fails gracefully so the
+ * existing fallback in pi-ai kicks in. We throw during construction so the
+ * try/catch in validation.js sets `ajv = null`.
+ */
+
+class AjvStub {
+  constructor() {
+    throw new Error("Ajv disabled: Office Add-in CSP does not allow unsafe-eval");
+  }
+}
+
+export default AjvStub;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -291,6 +291,14 @@ export default defineConfig({
     alias: {
       stream: path.resolve(__dirname, "src/stubs/stream.ts"),
 
+      // Ajv v8 uses `new Function()` to compile JSON schema validators.
+      // The Office Add-in webview enforces a strict CSP without 'unsafe-eval',
+      // so Ajv.compile() always throws. Stubbing the import makes the
+      // constructor throw, which triggers pi-ai's existing fallback path
+      // (skip validation, trust the LLM output).
+      ajv: path.resolve(__dirname, "src/stubs/ajv.ts"),
+      "ajv-formats": path.resolve(__dirname, "src/stubs/ajv-formats.ts"),
+
       // pi-web-ui only exports "." + "./app.css". We deep-import from its dist
       // modules to avoid pulling the entire barrel (ChatPanel, artifacts, etc.).
       // This alias bypasses package.json "exports" restrictions.


### PR DESCRIPTION
## Problem

Every tool call fails in the hosted (non-dev) install path with:

> Refused to evaluate a string as JavaScript because `unsafe-eval` or `trusted-types-eval` is not an allowed source of script in the following Content Security Policy directive: `script-src 'self' https://appsforoffice.microsoft.com`

**Root cause:** `@mariozechner/pi-ai` uses Ajv v8 for tool parameter validation. Ajv compiles JSON schemas into validator functions using `new Function()` — its core mechanism with no opt-out. The Office Add-in webview enforces a strict CSP without `unsafe-eval`, so `ajv.compile()` is blocked on every tool call.

pi-ai already has a fallback path that skips validation when `ajv` is null, but the guard only detects Chrome extensions (`chrome.runtime.id`), not Office Add-in webviews. The `try/catch` wraps the Ajv constructor (which succeeds fine), not the `.compile()` call where `new Function()` actually fires.

## Fix

Add Vite resolve aliases that replace `ajv` and `ajv-formats` with lightweight stubs:

- **`src/stubs/ajv.ts`** — throws on construction → triggers pi-ai's existing try/catch → `ajv = null` → validation skipped
- **`src/stubs/ajv-formats.ts`** — no-op companion stub
- **`vite.config.ts`** — added resolve aliases for both

## Results

- ✅ Zero `new Function` / `eval()` in the production bundle
- ✅ Bundle shrinks ~130 KB (all Ajv code tree-shaken out)
- ✅ All 497 existing tests pass
- ✅ Tool validation degrades gracefully — LLM output is trusted directly (same as the Chrome extension path)