### PR TITLE
refactor: centralize browser aliases + add Ajv stub regression guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ src/
 ├── audit/             # Workbook change audit log
 ├── messages/          # Message conversion helpers
 ├── debug/             # Debug mode utilities
-├── stubs/             # Browser stubs for Node-only deps (Bedrock, stream, etc.)
+├── stubs/             # Browser stubs for CSP/Node-only deps (Ajv, Bedrock, stream, etc.)
 ├── compat/            # Compatibility patches (Lit, marked, model selector)
 └── utils/             # Shared helpers (HTML escape, type guards, errors)
 

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -79,6 +79,7 @@ Hosted taskpane is protected with CSP in `vercel.json` (scripts/styles/fonts/con
 - Capability policy enforcement is opt-in (`extension-permissions` flag) in current rollout.
 - Sandbox runtime intentionally limits API surface (for example, no raw `api.agent` in sandbox).
 - Host-specific CSP behavior still needs smoke testing across Excel macOS/Windows/Web.
+- Tool-argument schema validation is intentionally disabled in Office builds (Ajv uses runtime code generation blocked by Office CSP, so the browser build aliases Ajv to stubs).
 
 ## Operational guidance
 


### PR DESCRIPTION
## Summary

Follow-up to #364 to harden and simplify the Ajv CSP workaround.

- Refactor vite.config.ts to centralize browser aliases in buildBrowserAliasMap().
- Add regression tests ensuring Ajv aliases stay wired to local stubs.
- Add regression tests ensuring Ajv stub behavior remains explicit.
- Document the Office CSP/Ajv limitation in security docs.
- Clarify README stubs section to mention Ajv.

## Why

#364 fixes the production blocker (tool calls failing under Office CSP). This PR makes that fix easier to maintain and less likely to regress during future Vite/config cleanups.

## Validation

- npm run check
- npm run test:models
- npm run test:security
- npm run build
- Verified no new Function/eval tokens in the built taskpane bundle.
