### PR TITLE
fix: resume overlay checkbox wrapping and session list space

### DIFF
--- a/src/commands/builtins/resume-overlay.ts
+++ b/src/commands/builtins/resume-overlay.ts
@@ -158,7 +158,7 @@ export async function showResumeDialog(opts: {
     onClose: closeOverlay,
     closeLabel: "Close resume sessions",
     title: "Resume Session",
-    subtitle: "Pick a previous session and choose whether to open it in a new tab or replace the current tab.",
+    subtitle: "Pick a session to resume in a new tab or the current one.",
   });
 
   const targetControls = document.createElement("div");

--- a/src/ui/theme/overlays/provider-resume-shortcuts.css
+++ b/src/ui/theme/overlays/provider-resume-shortcuts.css
@@ -15,11 +15,16 @@
 }
 
 .pi-resume-body {
-  gap: 12px;
+  gap: 10px;
 }
 
 .pi-resume-section {
   gap: 6px;
+}
+
+.pi-resume-section[data-resume-section="saved"] {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .pi-resume-section-hint {
@@ -29,7 +34,8 @@
 .pi-resume-target-controls {
   display: flex;
   gap: 6px;
-  margin: 0 0 8px;
+  margin: 0 0 4px;
+  flex-shrink: 0;
 }
 
 .pi-resume-target-btn.is-active {
@@ -38,27 +44,35 @@
 }
 
 .pi-resume-target-hint {
-  margin: 0 0 10px;
+  margin: 0 0 4px;
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   color: var(--muted-foreground);
+  flex-shrink: 0;
 }
 
 .pi-resume-workbook-filter {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 0 0 10px;
+  gap: 6px;
+  margin: 0 0 4px;
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   color: var(--muted-foreground);
   user-select: none;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .pi-resume-workbook-filter__hint {
   margin-left: auto;
   font-family: var(--font-mono);
+  font-size: var(--text-xs);
   opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .pi-resume-list {


### PR DESCRIPTION
## Problem

The Resume Session overlay had two UI issues:

1. **Checkbox label wrapping** — "Show sessions from all workbooks" wrapped across 4 lines, with the workbook name hint overflowing behind it
2. **Too little session list space** — header, buttons, hint, and filter consumed most of the viewport, leaving minimal room for actual session cards

## Changes

**CSS (`provider-resume-shortcuts.css`):**
- `white-space: nowrap` on the filter row to keep the checkbox label on one line
- Ellipsis truncation on the workbook hint for long names
- Reduced vertical margins on controls (10px → 4px)
- `flex: 1 1 auto` on the saved sessions section so it stretches to fill remaining space

**Text (`resume-overlay.ts`):**
- Shortened the subtitle to save ~2 lines of vertical space