### PR TITLE
fix(ui): keep footer controls clickable with composer text

### DIFF
--- a/src/ui/theme/components/input.css
+++ b/src/ui/theme/components/input.css
@@ -8,6 +8,7 @@
   border: var(--pill-border);
   background: var(--pill-bg);
   box-shadow: var(--pill-shadow);
+  overflow: hidden;
 }
 
 .pi-input-card:focus-within {
@@ -54,7 +55,7 @@
   outline: none;
   overflow-y: auto;
   overflow-x: hidden;
-  field-sizing: content;
+  /* JS auto-grow in pi-input.ts keeps sizing consistent across Office WebViews. */
 }
 
 .pi-input-textarea:placeholder-shown {


### PR DESCRIPTION
## Summary
- remove `field-sizing: content` from the composer textarea and rely on the existing JS auto-grow logic
- clip composer overflow so its hitbox cannot spill into the footer controls area
- keep footer status controls interactive while the composer contains text

## Testing
- `npm run check`
- `npm run build`
- agent-browser smoke:
  - open taskpane
  - type into composer
  - click footer status controls (model/thinking/context)

Closes #374
