### PR TITLE
fix(ui): stabilize footer status tooltips

### DIFF
--- a/src/ui/theme/components/status-bar.css
+++ b/src/ui/theme/components/status-bar.css
@@ -354,7 +354,6 @@
   z-index: 200;
 }
 .pi-status-bar [data-tooltip]:hover::after {
-  pointer-events: auto;
   visibility: visible;
   opacity: 1;
   transition: opacity var(--duration-fast) ease;
@@ -401,7 +400,6 @@
 .pi-tooltip--left  { left: 0; transform: none; }
 .pi-tooltip--right { left: auto; right: 0; transform: none; }
 .has-tooltip:hover > .pi-tooltip {
-  pointer-events: auto;
   visibility: visible;
   opacity: 1;
   transition: opacity var(--duration-fast) ease;


### PR DESCRIPTION
## Summary
- remove the hover gap between footer status controls and their tooltips
- keep tooltip hit-testing active while visible so tiny pointer jitter does not drop hover
- apply the same behavior to both simple `data-tooltip` and rich `.pi-tooltip` variants

## Testing
- npm run check
- npm run build

Closes #373
