### PR TITLE
refactor(files): extract detail actions and share blob safety

### DIFF
--- a/src/files/blob-url-safety.ts
+++ b/src/files/blob-url-safety.ts
@@ -1,5 +1,5 @@
 /**
- * MIME helpers for Files dialog open/download actions.
+ * Blob URL safety helpers shared by file open/download flows.
  */
 
 const ACTIVE_CONTENT_MIME_TYPES = new Set<string>([
@@ -13,7 +13,7 @@ const ACTIVE_CONTENT_MIME_TYPES = new Set<string>([
 /**
  * Returns a MIME type safe to open via blob URL under the add-in origin.
  */
-export function resolveSafeFilesDialogBlobMimeType(mimeType: string): string {
+export function resolveSafeBlobUrlMimeType(mimeType: string): string {
   const trimmed = mimeType.trim();
   if (trimmed.length === 0) {
     return "application/octet-stream";

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -242,7 +242,7 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
 - **Audit trail:** persisted locally (list/read/write/delete/rename/import/backend switches) including actor, source, timestamp, and workbook label. Not shown in the Files dialog UI — available via `/export audit` for debugging.
 - **Download fix:** uses `window.open(blobUrl)` instead of `<a download>` + `anchor.click()` for reliable binary file downloads in Office Add-in WebView (WKWebView on macOS silently ignores programmatic anchor clicks).
 - **Detail actions:** file detail view exposes `Open ↗` + `Download` for all files, and writable files also expose `Rename` + `Delete`.
-- **Open safety:** `Open ↗` sanitizes script-capable MIME types (`text/html`, `image/svg+xml`, JavaScript, etc.) to `application/octet-stream` before opening blob URLs.
+- **Open safety:** `Open ↗` and file downloads both sanitize script-capable MIME types (`text/html`, `image/svg+xml`, JavaScript, etc.) to `application/octet-stream` via shared blob-URL safety helpers.
 - **Rename safety:** if a rename input omits an extension, preserve the current extension (`report.xlsx` + `report-final` → `report-final.xlsx`) unless the user explicitly types a dotted name.
 - **Preview UX:** Files dialog supports inline text editing plus image/PDF preview; other binaries fall back to metadata + download. Built-in docs are marked read-only in the UI.
 - **Filter UX:** Files dialog includes workbook-tag filtering (`all`, `current workbook`, `untagged`, and per-tag options) without changing underlying shared storage.

--- a/src/ui/files-dialog-actions.ts
+++ b/src/ui/files-dialog-actions.ts
@@ -1,0 +1,255 @@
+import { base64ToBytes } from "../files/encoding.js";
+import { resolveSafeBlobUrlMimeType } from "../files/blob-url-safety.js";
+import type { WorkspaceFileEntry, WorkspaceFileLocationKind, WorkspaceFileReadResult } from "../files/types.js";
+import type {
+  FilesWorkspaceAuditContext,
+  WorkspaceMutationOptions,
+  WorkspaceReadOptions,
+} from "../files/workspace.js";
+import { getErrorMessage } from "../utils/errors.js";
+import { requestConfirmationDialog } from "./confirm-dialog.js";
+import { isFilesDialogBuiltInDoc } from "./files-dialog-filtering.js";
+import { resolveRenameDestinationPath } from "./files-dialog-paths.js";
+import { requestTextInputDialog } from "./text-input-dialog.js";
+import { showToast } from "./toast.js";
+
+export interface FilesDialogDetailActionFileRef {
+  path: string;
+  locationKind: WorkspaceFileLocationKind;
+}
+
+export interface FilesDialogDetailActionsWorkspace {
+  readFile(path: string, opts?: WorkspaceReadOptions): Promise<WorkspaceFileReadResult>;
+  downloadFile(path: string, options?: { locationKind?: WorkspaceFileLocationKind }): Promise<void>;
+  renameFile(oldPath: string, newPath: string, options?: WorkspaceMutationOptions): Promise<void>;
+  deleteFile(path: string, options?: WorkspaceMutationOptions): Promise<void>;
+}
+
+export interface CreateFilesDialogDetailActionsOptions {
+  file: WorkspaceFileEntry;
+  fileRef: FilesDialogDetailActionFileRef;
+  workspace: FilesDialogDetailActionsWorkspace;
+  auditContext: FilesWorkspaceAuditContext;
+  onAfterRename: (nextPath: string, locationKind: WorkspaceFileLocationKind) => Promise<void>;
+  onAfterDelete: () => Promise<void>;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const out = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(out).set(bytes);
+  return out;
+}
+
+function closeWindowSafely(windowHandle: Window | null): void {
+  if (!windowHandle || windowHandle.closed) {
+    return;
+  }
+
+  try {
+    windowHandle.close();
+  } catch {
+    // Ignore close errors.
+  }
+}
+
+function openBlobInNewTab(blob: Blob, pendingWindow: Window | null): void {
+  const url = URL.createObjectURL(blob);
+  let opened = false;
+
+  if (pendingWindow && !pendingWindow.closed) {
+    try {
+      pendingWindow.location.replace(url);
+      opened = true;
+    } catch {
+      closeWindowSafely(pendingWindow);
+    }
+  }
+
+  if (!opened) {
+    opened = window.open(url, "_blank") !== null;
+  }
+
+  if (!opened) {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.target = "_blank";
+    anchor.rel = "noopener noreferrer";
+    anchor.style.display = "none";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  }
+
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 60_000);
+}
+
+async function openFileInBrowser(options: {
+  file: WorkspaceFileEntry;
+  fileRef: FilesDialogDetailActionFileRef;
+  workspace: FilesDialogDetailActionsWorkspace;
+  auditContext: FilesWorkspaceAuditContext;
+}): Promise<void> {
+  const pendingWindow = window.open("", "_blank");
+
+  try {
+    if (options.file.kind === "text") {
+      const result = await options.workspace.readFile(options.file.path, {
+        mode: "text",
+        maxChars: 16_000_000,
+        audit: options.auditContext,
+        locationKind: options.fileRef.locationKind,
+      });
+
+      if (result.text === undefined || result.truncated) {
+        throw new Error("File is too large to open in a browser tab.");
+      }
+
+      const blob = new Blob([result.text], {
+        type: resolveSafeBlobUrlMimeType(options.file.mimeType || "text/plain"),
+      });
+
+      openBlobInNewTab(blob, pendingWindow);
+      return;
+    }
+
+    const result = await options.workspace.readFile(options.file.path, {
+      mode: "base64",
+      maxChars: 16_000_000,
+      audit: options.auditContext,
+      locationKind: options.fileRef.locationKind,
+    });
+
+    if (!result.base64 || result.truncated) {
+      throw new Error("File is too large to open in a browser tab.");
+    }
+
+    const bytes = base64ToBytes(result.base64);
+    const blob = new Blob([toArrayBuffer(bytes)], {
+      type: resolveSafeBlobUrlMimeType(options.file.mimeType),
+    });
+
+    openBlobInNewTab(blob, pendingWindow);
+  } catch (error: unknown) {
+    closeWindowSafely(pendingWindow);
+    throw error;
+  }
+}
+
+export function createFilesDialogDetailActions(options: CreateFilesDialogDetailActionsOptions): HTMLDivElement {
+  const actions = document.createElement("div");
+  actions.className = "pi-files-detail-actions";
+
+  const openButton = document.createElement("button");
+  openButton.type = "button";
+  openButton.className = options.file.kind === "text"
+    ? "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--compact"
+    : "pi-overlay-btn pi-overlay-btn--primary pi-overlay-btn--compact";
+  openButton.textContent = "Open ↗";
+  openButton.addEventListener("click", () => {
+    void openFileInBrowser({
+      file: options.file,
+      fileRef: options.fileRef,
+      workspace: options.workspace,
+      auditContext: options.auditContext,
+    }).catch((error: unknown) => {
+      showToast(`Open failed: ${getErrorMessage(error)}`);
+    });
+  });
+
+  const downloadButton = document.createElement("button");
+  downloadButton.type = "button";
+  downloadButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--compact";
+  downloadButton.textContent = "Download";
+  downloadButton.addEventListener("click", () => {
+    void options.workspace.downloadFile(options.file.path, {
+      locationKind: options.fileRef.locationKind,
+    }).catch((error: unknown) => {
+      showToast(`Download failed: ${getErrorMessage(error)}`);
+    });
+  });
+
+  actions.append(openButton, downloadButton);
+
+  const isReadOnly = options.file.readOnly || isFilesDialogBuiltInDoc(options.file);
+  if (isReadOnly) {
+    return actions;
+  }
+
+  const renameButton = document.createElement("button");
+  renameButton.type = "button";
+  renameButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--compact";
+  renameButton.textContent = "Rename";
+  renameButton.addEventListener("click", () => {
+    void (async () => {
+      const nextPathInput = await requestTextInputDialog({
+        title: "Rename file",
+        message: `${options.file.path} — leave off the extension to keep it.`,
+        initialValue: options.file.path,
+        placeholder: "folder/file.ext",
+        confirmLabel: "Rename",
+        cancelLabel: "Cancel",
+        restoreFocusOnClose: false,
+      });
+
+      if (nextPathInput === null) {
+        return;
+      }
+
+      const nextPath = resolveRenameDestinationPath(options.file.path, nextPathInput);
+      if (nextPath === options.file.path) {
+        return;
+      }
+
+      await options.workspace.renameFile(options.file.path, nextPath, {
+        audit: options.auditContext,
+        locationKind: options.fileRef.locationKind,
+      });
+
+      showToast(`Renamed to ${nextPath}.`);
+
+      await options.onAfterRename(nextPath, options.fileRef.locationKind);
+    })().catch((error: unknown) => {
+      showToast(`Rename failed: ${getErrorMessage(error)}`);
+    });
+  });
+
+  const spacer = document.createElement("div");
+  spacer.className = "pi-files-detail-actions__spacer";
+
+  const deleteButton = document.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "pi-overlay-btn pi-overlay-btn--danger pi-overlay-btn--compact";
+  deleteButton.textContent = "Delete";
+  deleteButton.addEventListener("click", () => {
+    void (async () => {
+      const confirmed = await requestConfirmationDialog({
+        title: "Delete file?",
+        message: options.file.path,
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        confirmButtonTone: "danger",
+        restoreFocusOnClose: false,
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      await options.workspace.deleteFile(options.file.path, {
+        audit: options.auditContext,
+        locationKind: options.fileRef.locationKind,
+      });
+
+      showToast(`Deleted ${options.file.name}.`);
+
+      await options.onAfterDelete();
+    })().catch((error: unknown) => {
+      showToast(`Delete failed: ${getErrorMessage(error)}`);
+    });
+  });
+
+  actions.append(renameButton, spacer, deleteButton);
+  return actions;
+}

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -13,7 +13,10 @@ import {
 } from "../files/types.js";
 import { type FilesWorkspaceAuditContext, getFilesWorkspace } from "../files/workspace.js";
 import { getErrorMessage } from "../utils/errors.js";
-import { requestConfirmationDialog } from "./confirm-dialog.js";
+import {
+  createFilesDialogDetailActions,
+  type FilesDialogDetailActionFileRef,
+} from "./files-dialog-actions.js";
 import {
   buildFilesDialogSections,
   type FilesDialogFolderGroup,
@@ -33,9 +36,6 @@ import {
   createOverlayHeader,
 } from "./overlay-dialog.js";
 import { FILES_WORKSPACE_OVERLAY_ID } from "./overlay-ids.js";
-import { resolveSafeFilesDialogBlobMimeType } from "./files-dialog-mime.js";
-import { resolveRenameDestinationPath } from "./files-dialog-paths.js";
-import { requestTextInputDialog } from "./text-input-dialog.js";
 import { showToast } from "./toast.js";
 import type { IconContent } from "./extensions-hub-components.js";
 import {
@@ -68,10 +68,7 @@ interface DetailPreviewResult {
   objectUrl: string | null;
 }
 
-interface FilesDialogFileRef {
-  path: string;
-  locationKind: WorkspaceFileLocationKind;
-}
+type FilesDialogFileRef = FilesDialogDetailActionFileRef;
 
 function resolveFileLocationKind(file: WorkspaceFileEntry): WorkspaceFileLocationKind {
   if (file.locationKind) {
@@ -374,51 +371,6 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return out;
 }
 
-function closeWindowSafely(windowHandle: Window | null): void {
-  if (!windowHandle || windowHandle.closed) {
-    return;
-  }
-
-  try {
-    windowHandle.close();
-  } catch {
-    // Ignore close errors.
-  }
-}
-
-function openBlobInNewTab(blob: Blob, pendingWindow: Window | null): void {
-  const url = URL.createObjectURL(blob);
-  let opened = false;
-
-  if (pendingWindow && !pendingWindow.closed) {
-    try {
-      pendingWindow.location.replace(url);
-      opened = true;
-    } catch {
-      closeWindowSafely(pendingWindow);
-    }
-  }
-
-  if (!opened) {
-    opened = window.open(url, "_blank") !== null;
-  }
-
-  if (!opened) {
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.target = "_blank";
-    anchor.rel = "noopener noreferrer";
-    anchor.style.display = "none";
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-  }
-
-  setTimeout(() => {
-    URL.revokeObjectURL(url);
-  }, 60_000);
-}
-
 function createWorkbookTagCallout(workbookTag: WorkspaceFileWorkbookTag): HTMLDivElement {
   const strong = document.createElement("strong");
   strong.textContent = workbookTag.workbookLabel;
@@ -600,172 +552,28 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
     setView("list");
   };
 
-  const openFileInBrowser = async (file: WorkspaceFileEntry): Promise<void> => {
-    const fileRef = toFileRef(file);
-    const pendingWindow = window.open("", "_blank");
-
-    try {
-      if (file.kind === "text") {
-        const result = await workspace.readFile(file.path, {
-          mode: "text",
-          maxChars: 16_000_000,
-          audit: DIALOG_AUDIT_CONTEXT,
-          locationKind: fileRef.locationKind,
-        });
-
-        if (result.text === undefined || result.truncated) {
-          throw new Error("File is too large to open in a browser tab.");
-        }
-
-        const blob = new Blob([result.text], {
-          type: resolveSafeFilesDialogBlobMimeType(file.mimeType || "text/plain"),
-        });
-
-        openBlobInNewTab(blob, pendingWindow);
-        return;
-      }
-
-      const result = await workspace.readFile(file.path, {
-        mode: "base64",
-        maxChars: 16_000_000,
-        audit: DIALOG_AUDIT_CONTEXT,
-        locationKind: fileRef.locationKind,
-      });
-
-      if (!result.base64 || result.truncated) {
-        throw new Error("File is too large to open in a browser tab.");
-      }
-
-      const bytes = base64ToBytes(result.base64);
-      const blob = new Blob([toArrayBuffer(bytes)], {
-        type: resolveSafeFilesDialogBlobMimeType(file.mimeType),
-      });
-
-      openBlobInNewTab(blob, pendingWindow);
-    } catch (error: unknown) {
-      closeWindowSafely(pendingWindow);
-      throw error;
-    }
-  };
-
   const createDetailActions = (file: WorkspaceFileEntry): HTMLDivElement => {
     const fileRef = toFileRef(file);
-    const actions = document.createElement("div");
-    actions.className = "pi-files-detail-actions";
 
-    const openButton = document.createElement("button");
-    openButton.type = "button";
-    openButton.className = file.kind === "text"
-      ? "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--compact"
-      : "pi-overlay-btn pi-overlay-btn--primary pi-overlay-btn--compact";
-    openButton.textContent = "Open ↗";
-    openButton.addEventListener("click", () => {
-      void openFileInBrowser(file).catch((error: unknown) => {
-        showToast(`Open failed: ${getErrorMessage(error)}`);
-      });
-    });
-
-    const downloadButton = document.createElement("button");
-    downloadButton.type = "button";
-    downloadButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--compact";
-    downloadButton.textContent = "Download";
-    downloadButton.addEventListener("click", () => {
-      void workspace.downloadFile(file.path, {
-        locationKind: fileRef.locationKind,
-      }).catch((error: unknown) => {
-        showToast(`Download failed: ${getErrorMessage(error)}`);
-      });
-    });
-
-    actions.append(openButton, downloadButton);
-
-    const isReadOnly = file.readOnly || isFilesDialogBuiltInDoc(file);
-    if (isReadOnly) {
-      return actions;
-    }
-
-    const renameButton = document.createElement("button");
-    renameButton.type = "button";
-    renameButton.className = "pi-overlay-btn pi-overlay-btn--ghost pi-overlay-btn--compact";
-    renameButton.textContent = "Rename";
-    renameButton.addEventListener("click", () => {
-      void (async () => {
-        const nextPathInput = await requestTextInputDialog({
-          title: "Rename file",
-          message: `${file.path} — leave off the extension to keep it.`,
-          initialValue: file.path,
-          placeholder: "folder/file.ext",
-          confirmLabel: "Rename",
-          cancelLabel: "Cancel",
-          restoreFocusOnClose: false,
-        });
-
-        if (nextPathInput === null) {
-          return;
-        }
-
-        const nextPath = resolveRenameDestinationPath(file.path, nextPathInput);
-        if (nextPath === file.path) {
-          return;
-        }
-
-        await workspace.renameFile(file.path, nextPath, {
-          audit: DIALOG_AUDIT_CONTEXT,
-          locationKind: fileRef.locationKind,
-        });
-
-        showToast(`Renamed to ${nextPath}.`);
-
+    return createFilesDialogDetailActions({
+      file,
+      fileRef,
+      workspace,
+      auditContext: DIALOG_AUDIT_CONTEXT,
+      onAfterRename: async (nextPath, locationKind) => {
         await refreshWorkspaceState();
         renderListView();
         await showDetailView({
           path: nextPath,
-          locationKind: fileRef.locationKind,
+          locationKind,
         });
-      })().catch((error: unknown) => {
-        showToast(`Rename failed: ${getErrorMessage(error)}`);
-      });
-    });
-
-    const spacer = document.createElement("div");
-    spacer.className = "pi-files-detail-actions__spacer";
-
-    const deleteButton = document.createElement("button");
-    deleteButton.type = "button";
-    deleteButton.className = "pi-overlay-btn pi-overlay-btn--danger pi-overlay-btn--compact";
-    deleteButton.textContent = "Delete";
-    deleteButton.addEventListener("click", () => {
-      void (async () => {
-        const confirmed = await requestConfirmationDialog({
-          title: "Delete file?",
-          message: file.path,
-          confirmLabel: "Delete",
-          cancelLabel: "Cancel",
-          confirmButtonTone: "danger",
-          restoreFocusOnClose: false,
-        });
-
-        if (!confirmed) {
-          return;
-        }
-
-        await workspace.deleteFile(file.path, {
-          audit: DIALOG_AUDIT_CONTEXT,
-          locationKind: fileRef.locationKind,
-        });
-
-        showToast(`Deleted ${file.name}.`);
-
+      },
+      onAfterDelete: async () => {
         await refreshWorkspaceState();
         renderListView();
         showListView();
-      })().catch((error: unknown) => {
-        showToast(`Delete failed: ${getErrorMessage(error)}`);
-      });
+      },
     });
-
-    actions.append(renameButton, spacer, deleteButton);
-    return actions;
   };
 
   const buildDetailPreview = async (file: WorkspaceFileEntry): Promise<DetailPreviewResult> => {

--- a/tests/files-dialog-actions.test.mjs
+++ b/tests/files-dialog-actions.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createFilesDialogDetailActions } from "../src/ui/files-dialog-actions.ts";
+import { installFakeDom } from "./fake-dom.test.ts";
+
+function makeFile(path, overrides = {}) {
+  return {
+    path,
+    name: path.split("/").at(-1) ?? path,
+    size: 10,
+    modifiedAt: 0,
+    mimeType: "text/plain",
+    kind: "text",
+    sourceKind: "workspace",
+    readOnly: false,
+    ...overrides,
+  };
+}
+
+function buildReadResult(path) {
+  return {
+    ...makeFile(path),
+    text: "hello",
+  };
+}
+
+function createWorkspaceStub() {
+  return {
+    readFile: (path) => Promise.resolve(buildReadResult(path)),
+    downloadFile: () => Promise.resolve(),
+    renameFile: () => Promise.resolve(),
+    deleteFile: () => Promise.resolve(),
+  };
+}
+
+function getButtonLabels(root) {
+  return Array.from(root.querySelectorAll("button"))
+    .map((button) => button.textContent?.trim() ?? "")
+    .filter((text) => text.length > 0);
+}
+
+test("detail actions show open/download only for read-only files", () => {
+  const { restore } = installFakeDom();
+
+  try {
+    const actions = createFilesDialogDetailActions({
+      file: makeFile("assistant-docs/docs/README.md", {
+        sourceKind: "builtin-doc",
+        locationKind: "builtin-doc",
+        readOnly: true,
+      }),
+      fileRef: {
+        path: "assistant-docs/docs/README.md",
+        locationKind: "builtin-doc",
+      },
+      workspace: createWorkspaceStub(),
+      auditContext: {
+        actor: "user",
+        source: "test",
+      },
+      onAfterRename: () => Promise.resolve(),
+      onAfterDelete: () => Promise.resolve(),
+    });
+
+    assert.deepEqual(getButtonLabels(actions), ["Open ↗", "Download"]);
+  } finally {
+    restore();
+  }
+});
+
+test("detail actions include rename/delete for writable files", () => {
+  const { restore } = installFakeDom();
+
+  try {
+    const actions = createFilesDialogDetailActions({
+      file: makeFile("notes/plan.md"),
+      fileRef: {
+        path: "notes/plan.md",
+        locationKind: "workspace",
+      },
+      workspace: createWorkspaceStub(),
+      auditContext: {
+        actor: "user",
+        source: "test",
+      },
+      onAfterRename: () => Promise.resolve(),
+      onAfterDelete: () => Promise.resolve(),
+    });
+
+    assert.deepEqual(getButtonLabels(actions), ["Open ↗", "Download", "Rename", "Delete"]);
+  } finally {
+    restore();
+  }
+});

--- a/tests/files-dialog-filtering.test.ts
+++ b/tests/files-dialog-filtering.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import "./files-dialog-actions.test.mjs";
+import "./files-dialog-mime.test.mjs";
+import "./files-dialog-paths.test.mjs";
+
 import type { WorkspaceBackendStatus, WorkspaceFileEntry } from "../src/files/types.ts";
 import {
   buildFilesDialogSections,
@@ -11,8 +15,6 @@ import {
   resolveFilesDialogConnectFolderButtonState,
   resolveFilesDialogSourceLabel,
 } from "../src/ui/files-dialog-filtering.ts";
-import { resolveSafeFilesDialogBlobMimeType } from "../src/ui/files-dialog-mime.ts";
-import { resolveRenameDestinationPath } from "../src/ui/files-dialog-paths.ts";
 
 function makeFile(path: string, overrides: Partial<WorkspaceFileEntry> = {}): WorkspaceFileEntry {
   return {
@@ -234,55 +236,3 @@ void test("resolveFilesDialogConnectFolderButtonState reflects backend status", 
   });
 });
 
-void test("resolveRenameDestinationPath keeps extension when user omits it", () => {
-  assert.equal(
-    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "revenue-final"),
-    "reports/q1/revenue-final.xlsx",
-  );
-
-  assert.equal(
-    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "archive/revenue-final"),
-    "archive/revenue-final.xlsx",
-  );
-});
-
-void test("resolveRenameDestinationPath respects explicit target extensions", () => {
-  assert.equal(
-    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "revenue-final.csv"),
-    "reports/q1/revenue-final.csv",
-  );
-
-  assert.equal(
-    resolveRenameDestinationPath("reports/q1/revenue.xlsx", ".hidden"),
-    "reports/q1/.hidden",
-  );
-
-  assert.equal(
-    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "revenue."),
-    "reports/q1/revenue.",
-  );
-});
-
-void test("resolveRenameDestinationPath handles empty and trailing-slash input", () => {
-  assert.equal(
-    resolveRenameDestinationPath("reports/q1/revenue.xlsx", ""),
-    "reports/q1/revenue.xlsx",
-  );
-
-  assert.equal(
-    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "archive/"),
-    "reports/q1/revenue.xlsx",
-  );
-});
-
-void test("resolveSafeFilesDialogBlobMimeType downgrades active-content types", () => {
-  assert.equal(resolveSafeFilesDialogBlobMimeType("text/html"), "application/octet-stream");
-  assert.equal(resolveSafeFilesDialogBlobMimeType("image/svg+xml"), "application/octet-stream");
-  assert.equal(resolveSafeFilesDialogBlobMimeType("text/javascript; charset=utf-8"), "application/octet-stream");
-});
-
-void test("resolveSafeFilesDialogBlobMimeType preserves safe types", () => {
-  assert.equal(resolveSafeFilesDialogBlobMimeType("text/plain"), "text/plain");
-  assert.equal(resolveSafeFilesDialogBlobMimeType("application/pdf"), "application/pdf");
-  assert.equal(resolveSafeFilesDialogBlobMimeType(""), "application/octet-stream");
-});

--- a/tests/files-dialog-mime.test.mjs
+++ b/tests/files-dialog-mime.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveSafeBlobUrlMimeType } from "../src/files/blob-url-safety.ts";
+
+test("resolveSafeBlobUrlMimeType downgrades active-content types", () => {
+  assert.equal(resolveSafeBlobUrlMimeType("text/html"), "application/octet-stream");
+  assert.equal(resolveSafeBlobUrlMimeType("image/svg+xml"), "application/octet-stream");
+  assert.equal(resolveSafeBlobUrlMimeType("text/javascript; charset=utf-8"), "application/octet-stream");
+});
+
+test("resolveSafeBlobUrlMimeType preserves safe types", () => {
+  assert.equal(resolveSafeBlobUrlMimeType("text/plain"), "text/plain");
+  assert.equal(resolveSafeBlobUrlMimeType("application/pdf"), "application/pdf");
+  assert.equal(resolveSafeBlobUrlMimeType(""), "application/octet-stream");
+});

--- a/tests/files-dialog-paths.test.mjs
+++ b/tests/files-dialog-paths.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveRenameDestinationPath } from "../src/ui/files-dialog-paths.ts";
+
+test("resolveRenameDestinationPath keeps extension when user omits it", () => {
+  assert.equal(
+    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "revenue-final"),
+    "reports/q1/revenue-final.xlsx",
+  );
+
+  assert.equal(
+    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "archive/revenue-final"),
+    "archive/revenue-final.xlsx",
+  );
+});
+
+test("resolveRenameDestinationPath respects explicit target extensions", () => {
+  assert.equal(
+    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "revenue-final.csv"),
+    "reports/q1/revenue-final.csv",
+  );
+
+  assert.equal(
+    resolveRenameDestinationPath("reports/q1/revenue.xlsx", ".hidden"),
+    "reports/q1/.hidden",
+  );
+
+  assert.equal(
+    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "revenue."),
+    "reports/q1/revenue.",
+  );
+});
+
+test("resolveRenameDestinationPath handles empty and trailing-slash input", () => {
+  assert.equal(
+    resolveRenameDestinationPath("reports/q1/revenue.xlsx", ""),
+    "reports/q1/revenue.xlsx",
+  );
+
+  assert.equal(
+    resolveRenameDestinationPath("reports/q1/revenue.xlsx", "archive/"),
+    "reports/q1/revenue.xlsx",
+  );
+});


### PR DESCRIPTION
## Summary
- extract Files detail action logic (`Open ↗`, `Download`, `Rename`, `Delete`) from `src/ui/files-dialog.ts` into a dedicated `src/ui/files-dialog-actions.ts`
- unify blob MIME hardening used by both UI open flows and workspace downloads by moving the sanitizer into `src/files/blob-url-safety.ts`
- keep `src/ui/files-dialog.ts` focused on layout/rendering and wire post-action refresh callbacks into the extracted action module
- split test concerns:
  - keep filtering tests in `tests/files-dialog-filtering.test.ts`
  - add rename path tests in `tests/files-dialog-paths.test.mjs`
  - add MIME safety tests in `tests/files-dialog-mime.test.mjs`
  - add detail action visibility tests in `tests/files-dialog-actions.test.mjs`
- update `src/tools/DECISIONS.md` to note that both open + download now share blob-URL MIME safety rules

## Testing
- `npm run check`
- `npm run build`
- `npm run test:models`
- `npm run test:context`
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/files-dialog-actions.test.mjs tests/files-dialog-paths.test.mjs tests/files-dialog-mime.test.mjs`
