### PR TITLE
fix(deps): tighten node engines to match eslint 10 requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "vite": "^7.3.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "url": "https://github.com/tmustier/pi-for-excel.git"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": "^20.19.0 || ^22.13.0 || >=24"
   },
   "overrides": {
     "tmp": "0.2.5",


### PR DESCRIPTION
Follow-up to #385.

ESLint 10 declares `engines.node: ^20.19.0 || ^22.13.0 || >=24`. The project's `>=20.0.0` engine constraint allowed Node versions (20.0–20.18, 21.x) that would fail at lint/check time after the ESLint 10 upgrade.

This aligns the `engines` field so `npm install` warns early on unsupported versions.

One-line change in `package.json`:
```diff
- "node": ">=20.0.0"
+ "node": "^20.19.0 || ^22.13.0 || >=24"
```