### PR TITLE
chore(models): refresh pi model registry to 0.54.0

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,6 +1,6 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-02-15
+**Last verified:** 2026-02-20
 
 This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.3-codex`, `claude-opus-4-6`).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.76.0",
-        "@mariozechner/pi-agent-core": "^0.53.0",
-        "@mariozechner/pi-ai": "^0.53.0",
-        "@mariozechner/pi-web-ui": "^0.53.0",
+        "@mariozechner/pi-agent-core": "^0.54.0",
+        "@mariozechner/pi-ai": "^0.54.0",
+        "@mariozechner/pi-web-ui": "^0.54.0",
         "@sinclair/typebox": "^0.34.41",
         "lit": "^3.2.1",
         "marked": "^17.0.3"
@@ -3170,21 +3170,21 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.53.0.tgz",
-      "integrity": "sha512-LswcyVHrW2LfRRGU8xXp69/7oTt6iXCmphZC2w46emPbFNK/lMR10INfkDt1HB59/0UqrLvoZRznutg4wwJriw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.54.0.tgz",
+      "integrity": "sha512-LsPoudpOJLj7JjSpjlAdLM5uA2iy8nP+4nA6Si1ASD3tMqXdjHzNaKNloGSODKJO+3O3yhwPMSbuk78CCnZteQ==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.53.0"
+        "@mariozechner/pi-ai": "^0.54.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.53.0.tgz",
-      "integrity": "sha512-f6dIzxLoVlB7TrT18N48oEUKzyoTw/ujB5zLxklFtpgaCVj9TRVf5manpT+2OYFwq3B6KANJ8X3WfDNCiKBEhA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.54.0.tgz",
+      "integrity": "sha512-XHhMIbFFHCa4mbiYdttfhVg6r3VmFD5tAiW4tjnmf33FhLUCRd76bGMQRc4kLWXPKCi/U4nqAErvaGiZUY4B8A==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -3229,9 +3229,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.53.0.tgz",
-      "integrity": "sha512-ffma5Xj6DTN8FWA+6jM5tDiFicF/NnyNSwPH0vw2oqkXqlXt1zSSM9FymZIbSjDLW+A/f1zMvAHORhFIeQTBJQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.54.0.tgz",
+      "integrity": "sha512-bvFlUohdxDvKcFeQM2xsd5twCGKWxVaYSlHCFljIW0KqMC4vU+/Ts4A1i9iDnm6Xe/MlueKvC0V09YeC8fLIHA==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -3258,14 +3258,14 @@
       }
     },
     "node_modules/@mariozechner/pi-web-ui": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.53.0.tgz",
-      "integrity": "sha512-h9RlbqxTHjd14U9YHPr+TTFXHI45jECtC5ZWsl7PckvorOdc3v+v4/KRmAZelDiSdukBbqPeXCxNDiXaZRbIOw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.54.0.tgz",
+      "integrity": "sha512-zo05Z/G8PPiz6W5qcI08/Fj7Rf+Byw93gOJU6fz6a2BCMVs2iP1BTiWUQiEP6xIOrhvE/n+B8eKsS7NAVja88Q==",
       "license": "MIT",
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
-        "@mariozechner/pi-ai": "^0.53.0",
-        "@mariozechner/pi-tui": "^0.53.0",
+        "@mariozechner/pi-ai": "^0.54.0",
+        "@mariozechner/pi-tui": "^0.54.0",
         "docx-preview": "^0.3.7",
         "jszip": "^3.10.1",
         "lucide": "^0.544.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.76.0",
-    "@mariozechner/pi-agent-core": "^0.53.0",
-    "@mariozechner/pi-ai": "^0.53.0",
-    "@mariozechner/pi-web-ui": "^0.53.0",
+    "@mariozechner/pi-agent-core": "^0.54.0",
+    "@mariozechner/pi-ai": "^0.54.0",
+    "@mariozechner/pi-web-ui": "^0.54.0",
     "@sinclair/typebox": "^0.34.41",
     "lit": "^3.2.1",
     "marked": "^17.0.3"


### PR DESCRIPTION
## Summary
- bump `@mariozechner/pi-ai`, `@mariozechner/pi-web-ui`, and `@mariozechner/pi-agent-core` from `0.53.0` to `0.54.0`
- refresh lockfile to the same Pi release line
- update `docs/model-updates.md` verification date to `2026-02-20`

## Why this is enough
Model selection/order logic in this repo is pattern-based (not pinned to exact IDs), so newly published registry entries for already-supported providers are picked up automatically after the dependency bump.

From `pi-ai 0.53.0 -> 0.54.0`, relevant provider deltas are:
- `google`: `gemini-3.1-pro-preview`, `gemini-3.1-pro-preview-customtools`
- `google-antigravity`: `claude-opus-4-6-thinking`
- `github-copilot`: `claude-sonnet-4.6`, `gemini-3.1-pro-preview`

No ordering/default-selection code changes were required for these additions.

## Validation
- `npm run test:models`
- `npm run check`
- `npm run build`
