### PR TITLE
fix(files-ui): avoid workbook labels appearing as filename chips

### DIFF
--- a/src/ui/files-dialog-filtering.ts
+++ b/src/ui/files-dialog-filtering.ts
@@ -3,6 +3,7 @@ import type { WorkspaceBackendStatus, WorkspaceFileEntry } from "../files/types.
 export interface FilesDialogBadge {
   tone: "ok" | "muted" | "info";
   label: string;
+  title?: string;
 }
 
 export interface FilesDialogFolderGroup {
@@ -45,7 +46,16 @@ export function resolveFilesDialogBadge(file: WorkspaceFileEntry): FilesDialogBa
   }
 
   if (file.workbookTag) {
-    return { tone: "ok", label: file.workbookTag.workbookLabel };
+    const workbookLabel = file.workbookTag.workbookLabel.trim();
+    if (workbookLabel.length > 0) {
+      return {
+        tone: "muted",
+        label: "Workbook",
+        title: `Tagged to ${workbookLabel}`,
+      };
+    }
+
+    return { tone: "muted", label: "Workbook" };
   }
 
   if (isAgentWrittenNotesFilePath(file.path)) {

--- a/src/ui/files-dialog.ts
+++ b/src/ui/files-dialog.ts
@@ -760,6 +760,9 @@ export async function showFilesWorkspaceDialog(): Promise<void> {
       const badgeElement = document.createElement("span");
       badgeElement.className = `pi-overlay-badge pi-overlay-badge--${badge.tone}`;
       badgeElement.textContent = badge.label;
+      if (badge.title) {
+        badgeElement.title = badge.title;
+      }
       nameRow.appendChild(badgeElement);
     }
 

--- a/tests/files-dialog-filtering.test.ts
+++ b/tests/files-dialog-filtering.test.ts
@@ -172,7 +172,23 @@ void test("resolveFilesDialogBadge follows priority rules", () => {
       taggedAt: 1,
     },
   });
-  assert.deepEqual(resolveFilesDialogBadge(tagged), { tone: "ok", label: "Budget.xlsx" });
+  assert.deepEqual(resolveFilesDialogBadge(tagged), {
+    tone: "muted",
+    label: "Workbook",
+    title: "Tagged to Budget.xlsx",
+  });
+
+  const taggedWithoutLabel = makeFile("uploads/plan.md", {
+    workbookTag: {
+      workbookId: "wb-a",
+      workbookLabel: "   ",
+      taggedAt: 1,
+    },
+  });
+  assert.deepEqual(resolveFilesDialogBadge(taggedWithoutLabel), {
+    tone: "muted",
+    label: "Workbook",
+  });
 
   const agentNotes = makeFile("notes/today.md");
   assert.deepEqual(resolveFilesDialogBadge(agentNotes), { tone: "muted", label: "Agent" });


### PR DESCRIPTION
## Summary
- change workbook-tag badges in Files list rows to a stable `Workbook` label instead of reusing workbook names
- downgrade workbook-tag badge tone to muted and move the full workbook name into the badge tooltip
- keep filename text rendering as the primary row label (no workbook-name chip competing with it)

## Testing
- npm run check
- npm run build
- npm run test:models
- npm run test:context

Closes #375
