### PR TITLE
fix(ui): smooth streaming auto-follow and tune pause threshold

### DIFF
--- a/src/ui/theme/components/tabs.css
+++ b/src/ui/theme/components/tabs.css
@@ -381,10 +381,12 @@
   overflow-x: hidden;
   min-height: 0;
   position: relative;
+  /* We drive chat stick-to-bottom in JS; disable browser anchoring jitter. */
+  overflow-anchor: none;
 }
 
 .pi-messages__inner {
-  padding: 12px 4px 20px;
+  padding: 12px 4px 28px;
   display: flex;
   flex-direction: column;
   gap: 4px;


### PR DESCRIPTION
## Summary
- smooth chat auto-follow by observing both `.pi-messages` (viewport height changes) and `.pi-messages__inner` (content growth)
- extract explicit auto-scroll thresholds and tune them for better manual "pause and read" behavior during fast streaming (`disengage: 32px`, `re-engage: 20px`)
- disable browser scroll anchoring in the message scroller and add a touch more bottom padding so the last streaming lines stay readable above the input/footer

## Why
Streaming output could visibly jerk when footer-adjacent UI changed height (widgets / working indicator / input area effects). The old logic only reacted to content growth, so viewport-height changes fought with stick-to-bottom behavior.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
