### PR TITLE
fix: prefer claude-sonnet when tied with claude-opus

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -90,7 +90,7 @@ We intentionally avoid pinning exact versioned IDs now. Instead we:
   3) then the rest sorted deterministically
 
   Featured rules (current desired behavior):
-  - **Anthropic:** latest **Sonnet** *if* its version > latest **Opus**, then latest **Opus**
+  - **Anthropic:** latest **Sonnet** *if* its version >= latest **Opus**, then latest **Opus**
     - Version compare uses `parseMajorMinor()` where `claude-opus-4-5` → `45`, `claude-opus-4-6` → `46`.
     - Important: IDs like `claude-opus-4-20250514` are treated as **major only** (`40`) and the `YYYYMMDD` part is considered a separate date suffix by `modelRecencyScore()`.
   - **OpenAI Codex:** latest `gpt-5.x-codex`, then latest `gpt-5.x`
@@ -107,7 +107,7 @@ We intentionally avoid pinning exact versioned IDs now. Instead we:
   UI: the model picker is opened from the footer status bar (click the π model button).
 
 - Pick the default model via pattern rules:
-  - Anthropic is a small special-case (Opus unless a newer-version Sonnet exists; version compare uses `parseMajorMinor`)
+  - Anthropic is a small special-case (Sonnet when version ties or is newer than Opus; version compare uses `parseMajorMinor`)
   - otherwise `DEFAULT_MODEL_RULES` + `pickLatestMatchingModel()` (uses `getModels(provider)` to find the newest available ID)
 
 When new models ship, this usually “just works” as long as naming stays consistent. You only need to update these rules if:

--- a/src/compat/model-selector-patch.ts
+++ b/src/compat/model-selector-patch.ts
@@ -85,7 +85,7 @@ export function installModelSelectorPatch(): void {
     // "Latest for each" behavior:
     // - keep current model at the very top
     // - then show "featured" models (latest per provider, pattern-based)
-    //   - Anthropic: latest Sonnet if its version > latest Opus, then latest Opus
+    //   - Anthropic: latest Sonnet if its version >= latest Opus, then latest Opus
     //   - OpenAI Codex: latest gpt-5.x-codex, then latest gpt-5.x
     //   - Google API-key: latest gemini-*-pro*
     //   - Google OAuth (Gemini CLI / Antigravity): prefer stable Gemini before previews
@@ -157,7 +157,7 @@ export function installModelSelectorPatch(): void {
         if (bestOpus && bestSonnet) {
           const opusVer = parseMajorMinor(bestOpus.id);
           const sonnetVer = parseMajorMinor(bestSonnet.id);
-          if (sonnetVer > opusVer) {
+          if (sonnetVer >= opusVer) {
             featured.push(bestSonnet, bestOpus);
             continue;
           }

--- a/src/taskpane/default-model.ts
+++ b/src/taskpane/default-model.ts
@@ -55,7 +55,8 @@ export function pickDefaultModel(
   customDefaultModel?: Model<Api> | null,
 ): Model<Api> {
   // Anthropic special-case:
-  // Prefer Opus, except if there's a *newer-version* Sonnet, use that first.
+  // Prefer Sonnet when its major/minor version is >= Opus (e.g. Sonnet 4-6 over Opus 4-6).
+  // Otherwise prefer Opus.
   if (availableProviders.includes("anthropic")) {
     const models: Model<Api>[] = getModels("anthropic");
     const opus = models
@@ -66,7 +67,7 @@ export function pickDefaultModel(
       .sort((a, b) => modelRecencyScore(b.id) - modelRecencyScore(a.id))[0];
 
     if (opus && sonnet) {
-      return parseMajorMinor(sonnet.id) > parseMajorMinor(opus.id) ? sonnet : opus;
+      return parseMajorMinor(sonnet.id) >= parseMajorMinor(opus.id) ? sonnet : opus;
     }
 
     if (opus) return opus;


### PR DESCRIPTION
## Summary\n- update Anthropic default model selection to prefer Sonnet when Sonnet and Opus have the same major/minor version\n- update model picker featured ordering with the same tie-break rule so Sonnet appears ahead of Opus on ties\n- align model update playbook docs with the new >= tie behavior\n\n## Verification\n- npm run test:models\n- npm run check\n- npm run build