### PR TITLE
fix: stabilize status footer responsiveness

### DIFF
--- a/src/taskpane/status-bar.ts
+++ b/src/taskpane/status-bar.ts
@@ -125,7 +125,7 @@ function renderStatusBar(
   const modeTooltip = modeIsAuto
     ? "Auto: Pi applies workbook changes immediately. Click to switch to Confirm."
     : "Confirm: Pi asks before each workbook change. Click to switch to Auto.";
-  const modeBadge = `<button type="button" class="pi-status-mode pi-status-clickable${modeBadgeClass}" data-tooltip="${modeTooltip}"><span>${modeLabel}</span><span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span></button>`;
+  const modeBadge = `<button type="button" class="pi-status-mode pi-status-clickable pi-status-tooltip--right${modeBadgeClass}" data-tooltip="${modeTooltip}"><span>${modeLabel}</span><span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span></button>`;
 
   const thinkingTooltip = escapeAttr(
     "How deeply Pi reasons before answering — higher is slower but more thorough. Click to choose, or ⇧Tab to cycle.",
@@ -136,15 +136,19 @@ function renderStatusBar(
   const ctxPopoverWarnText = ctxWarningText.length > 0 ? escapeAttr(ctxWarningText) : "";
 
   el.innerHTML = `
-    <button type="button" class="pi-status-model pi-status-clickable" data-tooltip="Switch the AI model for this session.">
-      <span class="pi-status-model__mark">π</span>
-      <span class="pi-status-model__name">${modelAliasEscaped}</span>
-      ${chevronSvg}
-    </button>
-    <button type="button" class="pi-status-thinking pi-status-clickable" data-tooltip="${thinkingTooltip}" aria-label="Thinking level ${thinkingLevel}">${brainSvg} ${thinkingLevel}<span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span></button>
-    <button type="button" class="pi-status-ctx pi-status-ctx--trigger pi-status-clickable has-tooltip" ${STATUS_CONTEXT_DESC_ATTR}="${ctxPopoverDesc}" ${STATUS_CONTEXT_TOKENS_ATTR}="${ctxPopoverTokens}" ${STATUS_CONTEXT_WARNING_ATTR}="${ctxPopoverWarnText}" ${STATUS_CONTEXT_WARNING_SEVERITY_ATTR}="${ctxWarningSeverity}" aria-label="Context usage ${pct}% of ${ctxLabel}"><span class="pi-status-ctx__pct ${ctxColor}">${pct}%</span><span class="pi-status-ctx__sep">/</span><span class="pi-status-ctx__limit">${ctxLabel}</span>${usageDebug}<span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span><span class="pi-tooltip"><span class="pi-tooltip__desc">${escapeHtml(ctxDescription)}</span><span class="pi-tooltip__tokens">${escapeHtml(ctxTokenDetail)}</span>${ctxWarning}</span></button>
-    ${lockBadge}
-    ${modeBadge}
+    <div class="pi-status-main">
+      <button type="button" class="pi-status-model pi-status-clickable pi-status-tooltip--left" data-tooltip="Switch the AI model for this session.">
+        <span class="pi-status-model__mark">π</span>
+        <span class="pi-status-model__name">${modelAliasEscaped}</span>
+        ${chevronSvg}
+      </button>
+      <button type="button" class="pi-status-thinking pi-status-clickable" data-tooltip="${thinkingTooltip}" aria-label="Thinking level ${thinkingLevel}">${brainSvg} ${thinkingLevel}<span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span></button>
+      <button type="button" class="pi-status-ctx pi-status-ctx--trigger pi-status-clickable has-tooltip" ${STATUS_CONTEXT_DESC_ATTR}="${ctxPopoverDesc}" ${STATUS_CONTEXT_TOKENS_ATTR}="${ctxPopoverTokens}" ${STATUS_CONTEXT_WARNING_ATTR}="${ctxPopoverWarnText}" ${STATUS_CONTEXT_WARNING_SEVERITY_ATTR}="${ctxWarningSeverity}" aria-label="Context usage ${pct}% of ${ctxLabel}"><span class="pi-status-ctx__pct ${ctxColor}">${pct}%</span><span class="pi-status-ctx__sep">/</span><span class="pi-status-ctx__limit">${ctxLabel}</span>${usageDebug}<span class="pi-status-affordance" aria-hidden="true">${affordanceChevronSvg}</span><span class="pi-tooltip"><span class="pi-tooltip__desc">${escapeHtml(ctxDescription)}</span><span class="pi-tooltip__tokens">${escapeHtml(ctxTokenDetail)}</span>${ctxWarning}</span></button>
+      ${lockBadge}
+    </div>
+    <div class="pi-status-side">
+      ${modeBadge}
+    </div>
   `;
 
   adjustContextTooltipAlignment(el);

--- a/src/ui/theme/components/status-bar.css
+++ b/src/ui/theme/components/status-bar.css
@@ -3,20 +3,35 @@
    ═══════════════════════════════════════════════════════ */
 
 .pi-status-bar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  column-gap: 6px;
+  row-gap: 4px;
   padding: 4px;
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   letter-spacing: 0.01em;
   color: var(--muted-foreground);
-  flex-wrap: wrap;
   overflow: visible;
   min-width: 0;
   position: relative;
   z-index: 20;
   container-type: inline-size;
+}
+
+.pi-status-main {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.pi-status-side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .pi-status-bar button {
@@ -181,13 +196,12 @@
   gap: 3px;
   border-radius: var(--radius-xs);
   padding: 2px 6px;
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   font-family: var(--font-sans);
   line-height: 1.4;
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
-  margin-left: auto;
   transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
 }
 
@@ -359,12 +373,14 @@
   opacity: 1;
   transition: opacity var(--duration-fast) ease;
 }
-/* Keep data-tooltips inside the sidebar */
-.pi-status-bar [data-tooltip]:first-child::after {
+
+.pi-status-bar [data-tooltip].pi-status-tooltip--left::after {
   left: 0;
+  right: auto;
   transform: none;
 }
-.pi-status-bar [data-tooltip]:last-child::after {
+
+.pi-status-bar [data-tooltip].pi-status-tooltip--right::after {
   left: auto;
   right: 0;
   transform: none;
@@ -587,14 +603,15 @@
 }
 
 @container (max-width: 300px) {
-  .pi-status-ctx__sep,
-  .pi-status-ctx__limit,
   .pi-status-ctx__debug {
     display: none;
   }
+}
 
-  .pi-status-mode {
-    margin-left: 0;
+@container (max-width: 260px) {
+  .pi-status-ctx__sep,
+  .pi-status-ctx__limit {
+    display: none;
   }
 
   .pi-status-thinking[data-tooltip]::after {


### PR DESCRIPTION
## Summary
- split the status footer into two lanes: left controls (model / thinking / context) and right execution mode
- keep auto/confirm in its own right-aligned container so it no longer shifts with wrap
- align auto/confirm typography with the other footer controls (`--text-sm`)
- make context token compaction progressive on narrow widths (`debug` hides first, `/200k` hides only at very small widths)
- anchor model/mode tooltips with explicit left/right classes after the new grouped DOM structure

## Validation
- npm run check
