### PR TITLE
fix(status-bar): prevent tooltip jitter during streaming

### DIFF
--- a/src/taskpane/status-bar.ts
+++ b/src/taskpane/status-bar.ts
@@ -314,12 +314,27 @@ export function injectStatusBar(opts: {
     markStatusBarInteractionEndSoon();
   };
 
+  const onFocusOut = (event: FocusEvent): void => {
+    const currentHost = resolveStatusBarHost(event.target);
+    if (!currentHost) {
+      return;
+    }
+
+    const relatedHost = resolveStatusBarHost(event.relatedTarget);
+    if (relatedHost === currentHost) {
+      return;
+    }
+
+    markStatusBarInteractionEndSoon();
+  };
+
   const onStatusUpdate = () => requestRender();
 
   document.addEventListener("pi:status-update", onStatusUpdate);
   document.addEventListener("pi:active-runtime-changed", bindActiveAgent);
   document.addEventListener("pointerover", onPointerOver, true);
   document.addEventListener("pointerout", onPointerOut, true);
+  document.addEventListener("focusout", onFocusOut, true);
 
   requestAnimationFrame(bindActiveAgent);
 
@@ -332,6 +347,7 @@ export function injectStatusBar(opts: {
     document.removeEventListener("pi:active-runtime-changed", bindActiveAgent);
     document.removeEventListener("pointerover", onPointerOver, true);
     document.removeEventListener("pointerout", onPointerOut, true);
+    document.removeEventListener("focusout", onFocusOut, true);
   };
 }
 


### PR DESCRIPTION
## Summary
- stop unnecessary status-bar DOM rewrites by caching a render signature on `#pi-status-bar`
- defer status-bar rerenders while the footer is actively interacted with (pointer hover or keyboard focus)
- flush exactly one deferred render after interaction settles, so streaming updates keep the UI fresh without tooltip blink

## Why
Footer tooltips are hover-driven CSS. During streaming, frequent status updates were replacing the status-bar DOM and occasionally dropping hover state, which looked like tooltip jitter/flicker.

## Validation
- `npx eslint src/taskpane/status-bar.ts`
- `npm run typecheck`
- `npm run build`
