### PR TITLE
fix(ui): replace proxy banner emojis with lucide icons

### DIFF
--- a/src/ui/lucide-icons.ts
+++ b/src/ui/lucide-icons.ts
@@ -11,7 +11,9 @@ import { iconDOM } from "@mariozechner/mini-lit";
 import type { IconNode } from "lucide";
 import {
   AlertTriangle,
+  Check,
   ClipboardList,
+  Copy,
   FileSpreadsheet,
   FileText,
   Folder,
@@ -37,7 +39,9 @@ export function lucide(glyph: IconNode): SVGElement {
 
 export {
   AlertTriangle,
+  Check,
   ClipboardList,
+  Copy,
   FileSpreadsheet,
   FileText,
   Folder,

--- a/src/ui/proxy-banner.ts
+++ b/src/ui/proxy-banner.ts
@@ -5,6 +5,8 @@
  * unavailable. Expands inline with quick setup guidance.
  */
 
+import { AlertTriangle, Check, Copy, lucide } from "./lucide-icons.js";
+
 const PROXY_COMMAND = "npx pi-for-excel-proxy";
 const INSTALL_GUIDE_URL = "https://pi.dev/excel#connect";
 
@@ -35,7 +37,15 @@ export function createProxyBanner(): ProxyBannerHandle {
 
   const text = document.createElement("p");
   text.className = "pi-proxy-banner__text";
-  text.textContent = "⚠ Proxy not running · some features won't work.";
+
+  const warningIcon = lucide(AlertTriangle);
+  warningIcon.classList.add("pi-proxy-banner__text-icon");
+  warningIcon.setAttribute("aria-hidden", "true");
+
+  const textLabel = document.createElement("span");
+  textLabel.textContent = "Proxy not running · some features won't work.";
+
+  text.append(warningIcon, textLabel);
 
   const action = document.createElement("button");
   action.type = "button";
@@ -61,8 +71,23 @@ export function createProxyBanner(): ProxyBannerHandle {
   const copyButton = document.createElement("button");
   copyButton.type = "button";
   copyButton.className = "pi-proxy-banner__copy";
-  copyButton.textContent = "📋";
-  copyButton.title = "Copy command";
+
+  let resetCopyIconTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const renderCopyIcon = (): void => {
+    copyButton.replaceChildren(lucide(Copy));
+    copyButton.title = "Copy command";
+    copyButton.setAttribute("aria-label", "Copy command");
+  };
+
+  const renderCopiedIcon = (): void => {
+    copyButton.replaceChildren(lucide(Check));
+    copyButton.title = "Copied";
+    copyButton.setAttribute("aria-label", "Copied");
+  };
+
+  renderCopyIcon();
+
   copyButton.addEventListener("click", () => {
     if (!navigator.clipboard?.writeText) {
       selectElementText(code);
@@ -71,9 +96,13 @@ export function createProxyBanner(): ProxyBannerHandle {
 
     void navigator.clipboard.writeText(PROXY_COMMAND).then(
       () => {
-        copyButton.textContent = "✓";
-        setTimeout(() => {
-          copyButton.textContent = "📋";
+        renderCopiedIcon();
+        if (resetCopyIconTimeout) {
+          clearTimeout(resetCopyIconTimeout);
+        }
+        resetCopyIconTimeout = setTimeout(() => {
+          renderCopyIcon();
+          resetCopyIconTimeout = null;
         }, 1400);
       },
       () => {

--- a/src/ui/theme/components/proxy-banner.css
+++ b/src/ui/theme/components/proxy-banner.css
@@ -24,6 +24,14 @@
   color: var(--foreground);
   font-size: var(--text-sm);
   line-height: 1.35;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pi-proxy-banner__text-icon {
+  flex-shrink: 0;
+  color: var(--pi-amber);
 }
 
 .pi-proxy-banner__action {
@@ -83,10 +91,18 @@
   border: none;
   background: none;
   color: var(--muted-foreground);
-  font-family: var(--font-sans);
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 18px;
+  block-size: 18px;
   cursor: pointer;
   padding: 0;
+}
+
+.pi-proxy-banner__copy > svg {
+  inline-size: 14px;
+  block-size: 14px;
 }
 
 .pi-proxy-banner__copy:hover {


### PR DESCRIPTION
## Summary
- replace the proxy warning prefix emoji with a Lucide AlertTriangle icon
- replace the proxy command copy button emoji/checkmark with Lucide Copy/Check glyphs
- keep copy-state feedback while improving icon button styling for SVG glyphs

## Testing
- npm run check
- npm run build