### PR TITLE
fix(ui): use scroll listeners for inner auto-follow instead of distance heuristic

### DIFF
--- a/src/ui/pi-sidebar.ts
+++ b/src/ui/pi-sidebar.ts
@@ -408,10 +408,10 @@ export class PiSidebar extends LitElement {
       cancelAnimationFrame(this._innerScrollRAF);
       this._innerScrollRAF = undefined;
     }
-    // Reset per-stream state. Weak refs let removed nodes GC naturally.
+    // Reset per-stream follow state. Keep listener registry so we don't
+    // duplicate listeners if streaming toggles while the same pane stays mounted.
     this._innerScrollSeen = new WeakSet<HTMLElement>();
     this._innerScrollDetached = new WeakSet<HTMLElement>();
-    this._innerScrollListeners = new WeakMap<HTMLElement, () => void>();
   }
 
   /** Lazily attach a scroll listener that tracks user-initiated detach/re-engage. */


### PR DESCRIPTION
Closes #406.

## Problem

PR #401 added inner auto-scroll for thinking/tool blocks during streaming, but it used a **distance-from-bottom heuristic** (`INNER_SCROLL_NEAR_BOTTOM_PX = 30`) in the rAF tick to decide whether to keep following. Token batches can easily grow content by more than 30 px between frames, which falsely disengages auto-follow even when the user hasn't scrolled.

## Fix

Replace the distance check with **per-element scroll listeners** that track actual user intent:

| Data structure | Purpose |
|---|---|
| `_innerScrollDetached` (`WeakSet`) | Set when a scroll event moves `distFromBottom` past the disengage threshold; cleared near bottom |
| `_innerScrollListeners` (`WeakMap`) | Lazily registered passive listeners, one per inner scrollable element |

The rAF loop now checks the `detached` flag instead of re-measuring distance. Since the listener fires on actual scroll events (both user-initiated and our programmatic `scrollTop` assignment), it correctly distinguishes "user scrolled up" from "content grew underneath."

### Behaviour

| Event | Outer scroll | Inner scroll |
|---|---|---|
| Thinking streams, block collapsed | Follows normally | N/A |
| Thinking streams, block expanded | Follows | **Auto-follows** |
| User scrolls inside inner block | Unchanged | **Detaches** |
| User returns to inner bottom | Unchanged | **Re-engages** |
| User scrolls outer chat up | Detaches | Pauses (resumes when outer re-engages) |
| Block expanded after thinking done | Absorbs height change | Snap to bottom once |

## Validation

- `npx eslint src/ui/pi-sidebar.ts` ✓
- `npm run typecheck` ✓
- `npm run build` ✓
