### PR TITLE
refactor(commands): share slash-command execution and streaming escape guard

### DIFF
--- a/src/commands/slash-command-execution.ts
+++ b/src/commands/slash-command-execution.ts
@@ -1,0 +1,37 @@
+import { isBusyAllowedCommand } from "./busy-command-policy.js";
+import { commandRegistry } from "./types.js";
+
+export type SlashCommandExecutionResult = "not-found" | "busy-blocked" | "missing-queue" | "queued" | "executed";
+
+export interface ExecuteSlashCommandOptions {
+  name: string;
+  args: string;
+  busy: boolean;
+  enqueueCommand?: (name: string, args: string) => void;
+  beforeExecute?: () => void;
+}
+
+export function executeSlashCommand(options: ExecuteSlashCommandOptions): SlashCommandExecutionResult {
+  const command = commandRegistry.get(options.name);
+  if (!command) {
+    return "not-found";
+  }
+
+  if (options.busy && !isBusyAllowedCommand(command)) {
+    return "busy-blocked";
+  }
+
+  options.beforeExecute?.();
+
+  if (options.name === "compact") {
+    if (!options.enqueueCommand) {
+      return "missing-queue";
+    }
+
+    options.enqueueCommand(options.name, options.args);
+    return "queued";
+  }
+
+  void command.execute(options.args);
+  return "executed";
+}

--- a/src/taskpane/keyboard-shortcuts.ts
+++ b/src/taskpane/keyboard-shortcuts.ts
@@ -11,10 +11,7 @@ import type { PiSidebar } from "../ui/pi-sidebar.js";
 import { moveCursorToEnd } from "../ui/input-focus.js";
 import { isActionToastVisible, showToast } from "../ui/toast.js";
 
-import {
-  doesExtensionWidgetClaimEscape,
-  doesOverlayClaimEscape,
-} from "../utils/escape-guard.js";
+import { doesUiClaimStreamingEscape } from "../utils/escape-guard.js";
 import { blurTextEntryTarget, isTextEntryTarget } from "../utils/text-entry.js";
 import {
   handleCommandMenuKey,
@@ -266,8 +263,7 @@ export function installKeyboardShortcuts(opts: {
     (context) => {
       const { event, isStreaming, agent, keyTarget } = context;
       const isEscapeKey = event.key === "Escape" || event.key === "Esc";
-      const escapeClaimedByOverlay = isEscapeKey
-        && (doesOverlayClaimEscape(keyTarget) || doesExtensionWidgetClaimEscape(keyTarget));
+      const escapeClaimedByOverlay = isEscapeKey && doesUiClaimStreamingEscape(keyTarget);
 
       if (
         !isEscapeKey

--- a/src/ui/pi-input.ts
+++ b/src/ui/pi-input.ts
@@ -16,10 +16,7 @@ import { icon } from "@mariozechner/mini-lit";
 import { customElement, property, state, query } from "lit/decorators.js";
 import { FileText } from "lucide";
 
-import {
-  doesExtensionWidgetClaimEscape,
-  doesOverlayClaimEscape,
-} from "../utils/escape-guard.js";
+import { doesUiClaimStreamingEscape } from "../utils/escape-guard.js";
 
 const PLACEHOLDER_HINTS = [
   "Ask about this workbook…",
@@ -79,7 +76,7 @@ export class PiInput extends LitElement {
     }
 
     if (e.key === "Escape" && this.isStreaming) {
-      if (doesOverlayClaimEscape(e.target) || doesExtensionWidgetClaimEscape(e.target)) return;
+      if (doesUiClaimStreamingEscape(e.target)) return;
       e.preventDefault();
       this.dispatchEvent(new CustomEvent("pi-abort", { bubbles: true }));
     }

--- a/src/utils/escape-guard.ts
+++ b/src/utils/escape-guard.ts
@@ -94,3 +94,11 @@ export function doesExtensionWidgetClaimEscape(target?: EventTarget | null): boo
 
   return doesSelectorSetClaimEscape(target, WIDGET_ESCAPE_OWNER_SELECTORS);
 }
+
+/**
+ * Used by streaming abort handlers where both overlays and extension widgets
+ * should consume Escape before aborting the active turn.
+ */
+export function doesUiClaimStreamingEscape(target?: EventTarget | null): boolean {
+  return doesOverlayClaimEscape(target) || doesExtensionWidgetClaimEscape(target);
+}

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -351,16 +351,23 @@ void test("settings overlay serializes open flow and adopts shared proxy + execu
   assert.doesNotMatch(settingsOverlaySource, /text:\s*"Save"/);
 });
 
-void test("slash-command busy policy is centralized and supports extension command defaults", async () => {
+void test("slash-command busy policy is centralized and shared across entry points", async () => {
   const keyboardActionsSource = await readFile(
     new URL("../src/taskpane/keyboard-shortcuts/editor-actions.ts", import.meta.url),
     "utf8",
   );
   const initSource = await readFile(new URL("../src/taskpane/init.ts", import.meta.url), "utf8");
+  const slashExecutionSource = await readFile(
+    new URL("../src/commands/slash-command-execution.ts", import.meta.url),
+    "utf8",
+  );
   const busyPolicySource = await readFile(new URL("../src/commands/busy-command-policy.ts", import.meta.url), "utf8");
 
-  assert.match(keyboardActionsSource, /isBusyAllowedCommand/);
-  assert.match(initSource, /isBusyAllowedCommand/);
+  assert.match(keyboardActionsSource, /executeSlashCommand/);
+  assert.match(initSource, /executeSlashCommand/);
+
+  assert.match(slashExecutionSource, /isBusyAllowedCommand/);
+  assert.match(slashExecutionSource, /commandRegistry\.get\(options\.name\)/);
 
   assert.match(busyPolicySource, /"yolo"/);
   assert.match(busyPolicySource, /"rules"/);
@@ -372,18 +379,19 @@ void test("slash-command busy policy is centralized and supports extension comma
   assert.doesNotMatch(busyPolicySource, /"addons"/);
 });
 
-void test("escape guard scopes widget escape claims to abort paths", async () => {
+void test("escape guard scopes widget claims to streaming abort paths", async () => {
   const escapeGuardSource = await readFile(new URL("../src/utils/escape-guard.ts", import.meta.url), "utf8");
   const keyboardShortcutsSource = await readFile(new URL("../src/taskpane/keyboard-shortcuts.ts", import.meta.url), "utf8");
   const inputSource = await readFile(new URL("../src/ui/pi-input.ts", import.meta.url), "utf8");
   const initSource = await readFile(new URL("../src/taskpane/init.ts", import.meta.url), "utf8");
 
   assert.match(escapeGuardSource, /export function doesExtensionWidgetClaimEscape/);
+  assert.match(escapeGuardSource, /export function doesUiClaimStreamingEscape/);
   assert.match(escapeGuardSource, /#pi-widget-slot:not\(:empty\)/);
   assert.match(escapeGuardSource, /#pi-widget-slot-below:not\(:empty\)/);
 
-  assert.match(keyboardShortcutsSource, /doesExtensionWidgetClaimEscape/);
-  assert.match(inputSource, /doesExtensionWidgetClaimEscape/);
+  assert.match(keyboardShortcutsSource, /doesUiClaimStreamingEscape/);
+  assert.match(inputSource, /doesUiClaimStreamingEscape/);
   assert.match(initSource, /doesOverlayClaimEscape\(document\.activeElement\)/);
 });
 


### PR DESCRIPTION
## Summary
- centralize slash-command execution rules in `src/commands/slash-command-execution.ts`
- route both entry points (`editor-actions` Enter flow and `pi:command-run` in taskpane init) through the same executor
- keep existing behavior for unknown commands, busy blocking, and `/compact` queueing
- add `doesUiClaimStreamingEscape()` to avoid duplicating overlay/widget escape checks across streaming abort handlers
- update regression checks to assert shared command execution + scoped escape behavior

## Testing
- `npm run check`
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/builtins-registry.test.ts tests/taskpane-runtime-utils.test.ts`
- `npm run build`
