### PR TITLE
docs: bundle all docs for assistant, add bridge skills, fix stale refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Pi for Excel is an AI agent that lives inside Excel. It reads your workbook, mak
 
 **Formatting conventions** — define your house style once (currency symbol, negative style, decimal places) and the AI follows it automatically.
 
-**Slash commands** — `/model`, `/login`, `/settings`, `/rules`, `/extensions`, `/integrations`, `/export`, `/compact`, `/new`, `/resume`, `/history`, `/shortcuts`, and more.
+**Slash commands** — `/model`, `/login`, `/settings`, `/rules`, `/extensions`, `/tools`, `/export`, `/compact`, `/new`, `/resume`, `/history`, `/shortcuts`, and more.
 
 **Extensions** — install sidebar extensions (mini-apps) from chat. The AI can generate and install extension code directly via the `extensions_manager` tool. Extensions run in an iframe sandbox by default.
 
 **Integrations** — opt-in external tool integrations:
-- **Web Search** (Serper/Tavily/Brave) + `fetch_page` — find and read external sources without leaving Excel
+- **Web Search** (Jina default, Serper/Tavily/Brave) + `fetch_page` — find and read external sources without leaving Excel
 - **MCP Gateway** — connect to user-configured MCP servers for custom tool access
 
 **Feature-flagged capabilities** (managed via `/experimental`):
@@ -57,7 +57,7 @@ Pi for Excel is an AI agent that lives inside Excel. It reads your workbook, mak
 - External skills discovery — opt-in loading of locally configured external `SKILL.md` sources
 - Advanced extension controls — remote URL opt-in, permission enforcement, sandbox rollback, and Widget API v2
 
-(Web Search + MCP are managed in `/integrations`.)
+(Web Search + MCP are managed in `/tools`, or `/extensions` → Connections.)
 
 ## Install
 
@@ -218,7 +218,7 @@ pkg/python-bridge/     # Publishable npm CLI package: `pi-for-excel-python-bridg
 pkg/tmux-bridge/       # Publishable npm CLI package: `pi-for-excel-tmux-bridge`
 tests/                 # Unit + security tests (~50 test files)
 docs/                  # Current docs (install/deploy/features/policy) + archive/ for historical plans
-skills/                # Bundled Agent Skill definitions (web-search, mcp-gateway)
+skills/                # Bundled Agent Skill definitions (web-search, mcp-gateway, tmux-bridge, python-bridge)
 public/assets/         # Add-in icons (16/32/80/128px)
 ```
 

--- a/docs/agent-skills-interop.md
+++ b/docs/agent-skills-interop.md
@@ -12,6 +12,8 @@ In this repo, standards artifacts live in:
 
 - `skills/web-search/SKILL.md`
 - `skills/mcp-gateway/SKILL.md`
+- `skills/tmux-bridge/SKILL.md`
+- `skills/python-bridge/SKILL.md`
 
 ## 2) Integrations (Excel runtime)
 
@@ -66,4 +68,4 @@ Safety: workspace-provided skills are untrusted input and may contain risky inst
 - **Integrations** manage runtime consent, scoping, and local configuration in the Excel add-in.
 
 Use the term **skill** only for standards-based `SKILL.md` artifacts.
-Use **integration** for Excel runtime toggles and UI (`/tools`, alias: `/integrations`).
+Use **integration** for Excel runtime toggles and UI (`/tools`, or `/extensions` → Connections).

--- a/docs/integrations-external-tools.md
+++ b/docs/integrations-external-tools.md
@@ -7,7 +7,7 @@ Issue: [#24](https://github.com/tmustier/pi-for-excel/issues/24)
 
 ## What shipped
 
-- **Tools & MCP manager UI** (`/tools`, alias: `/integrations`)
+- **Tools & MCP manager UI** (`/tools`, or `/extensions` → Connections)
   - enable/disable integration bundles per **session** and/or **workbook**
   - clear warnings for network/tool access
   - active integrations shown in the status bar
@@ -17,12 +17,12 @@ Issue: [#24](https://github.com/tmustier/pi-for-excel/issues/24)
 - **Web Search integration**
   - tools: `web_search`, `fetch_page`
   - providers: Jina (default, no key required), Serper.dev, Tavily, Brave Search
-  - configurable provider + provider-specific API key in `/tools` (or `/integrations`)
+  - configurable provider + provider-specific API key in `/tools`
   - fallback: if a configured keyed provider fails with auth/rate-limit/server/network errors, search retries with Jina for that request and surfaces a warning
   - result output includes explicit `Sent:` attribution and provider/transport metadata
 - **MCP integration**
   - tool: `mcp`
-  - server registry (`mcp.servers.v1`) configurable in `/tools` (or `/integrations`)
+  - server registry (`mcp.servers.v1`) configurable in `/tools`
   - add/remove/test server URL + optional bearer token
 
 ## Runtime model

--- a/skills/mcp-gateway/SKILL.md
+++ b/skills/mcp-gateway/SKILL.md
@@ -26,7 +26,7 @@ This repository exposes MCP access as a built-in **integration** in the Excel ad
 
 ## Excel-specific setup
 
-1. Open `/integrations`.
+1. Open `/tools` (or `/extensions` → Connections tab).
 2. Enable external tools.
 3. Add one or more MCP servers.
 4. Enable **MCP Gateway** for session and/or workbook scope.

--- a/skills/python-bridge/SKILL.md
+++ b/skills/python-bridge/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: python-bridge
+description: Native Python execution via the local Python bridge. Use when the user asks about running Python locally, setting up the Python bridge, LibreOffice conversion, or troubleshooting Python connectivity.
+compatibility: Python tools always work via in-browser Pyodide. The native bridge is optional and requires a local bridge process running on the user's machine.
+metadata:
+  tool-name: python_run
+  docs: docs/python-bridge-contract.md
+---
+
+# Python Bridge
+
+The Python bridge gives Pi access to native Python on the user's machine. It is an opt-in, feature-flagged capability that upgrades the default in-browser Pyodide runtime.
+
+## Pyodide (default) vs Native bridge
+
+| | Pyodide (default) | Native bridge |
+|---|---|---|
+| Setup | None — works out of the box | Requires local bridge process |
+| Packages | Pure-Python only (numpy, pandas, scipy via micropip) | Full ecosystem (C extensions, ML libs, etc.) |
+| Filesystem | No local filesystem access | Full local filesystem |
+| LibreOffice | Not available | Available (`libreoffice_convert` tool) |
+| Long scripts | WebAssembly limits | No limits |
+
+**Prefer Pyodide unless the task requires native-only capabilities.**
+
+## How to set it up
+
+### 1. Start the bridge
+
+```bash
+npx pi-for-excel-python-bridge
+```
+
+This defaults to **real execution mode** on `https://localhost:3340`.
+
+Options:
+- `--install-missing` — auto-install Python/LibreOffice via Homebrew (macOS)
+- `PYTHON_BRIDGE_MODE=stub` — safe simulated mode
+- `PYTHON_BRIDGE_TOKEN=your-secret` — require auth token
+- `PYTHON_BRIDGE_PYTHON_BIN=python3.12` — specify Python binary
+
+Requirements:
+- `python3` must be on `PATH` (or set `PYTHON_BRIDGE_PYTHON_BIN`)
+- LibreOffice (`soffice`) is optional — only needed for `libreoffice_convert`
+
+### 2. Configure in Pi (optional)
+
+The default URL (`https://localhost:3340`) works automatically. Override if needed:
+
+```
+/experimental python-bridge-url <url>
+/experimental python-bridge-token <token>
+```
+
+Or use: `/extensions` → **Connections** → **Python bridge**
+
+### 3. First execution
+
+The first time Python runs through the native bridge, Pi will ask for explicit user confirmation (one-time per bridge URL).
+
+## Tools
+
+- **python_run** — execute a Python snippet, inspect stdout/stderr/result
+- **python_transform_range** — read Excel range → run Python → write result back (single tool call)
+- **libreoffice_convert** — convert files between formats (xlsx ↔ csv ↔ pdf) — bridge-only
+
+## When the bridge is not running
+
+`python_run` and `python_transform_range` fall back to Pyodide automatically. Only `libreoffice_convert` strictly requires the bridge.
+
+## Security
+
+- Loopback-only (localhost)
+- Origin allowlist
+- Optional bearer token auth
+- Python runs with `-I` isolation flag
+- Code/input/output size limits
+- Timeout enforcement
+
+## Troubleshooting
+
+- **Falls back to Pyodide unexpectedly** — the bridge process isn't running. Start it with `npx pi-for-excel-python-bridge`.
+- **Import errors on Pyodide** — the package likely has C extensions. Set up the native bridge.
+- **LibreOffice convert fails** — ensure `soffice` is on PATH. Install with `brew install --cask libreoffice` (macOS).
+- **CORS/cert errors** — visit `https://localhost:3340` in your browser and accept the certificate.

--- a/skills/tmux-bridge/SKILL.md
+++ b/skills/tmux-bridge/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tmux-bridge
+description: Local terminal access via the tmux bridge. Use when the user asks about running shell commands, setting up the tmux bridge, or troubleshooting terminal connectivity.
+compatibility: Requires a local tmux bridge process running on the user's machine.
+metadata:
+  tool-name: tmux
+  docs: docs/tmux-bridge-contract.md
+---
+
+# Tmux Bridge
+
+The tmux bridge gives Pi access to a real local terminal on the user's machine. The `tmux` tool is always registered — it just needs the bridge process running locally to work.
+
+## What it does
+
+When the bridge is running, the `tmux` tool can:
+- **list_sessions** — see active tmux sessions
+- **create_session** — start a new shell session (optionally in a specific directory)
+- **send_keys** — type commands into a session
+- **capture_pane** — read terminal output
+- **send_and_capture** — send a command and wait for output in one call
+- **kill_session** — close a session
+
+## How to set it up
+
+### 1. Start the bridge
+
+The bridge is a local HTTPS server. Run it from a terminal:
+
+```bash
+npx pi-for-excel-tmux-bridge
+```
+
+This defaults to **real tmux mode** on `https://localhost:3341`.
+
+Options:
+- `--install-missing` — auto-install tmux via Homebrew (macOS)
+- `TMUX_BRIDGE_MODE=stub` — safe simulated mode (no real shell execution)
+- `TMUX_BRIDGE_TOKEN=your-secret` — require auth token
+
+### 2. Configure in Pi (usually not needed)
+
+The default bridge URL (`https://localhost:3341`) works automatically — no configuration required. If you need a custom URL or auth token:
+
+```
+/experimental tmux-bridge-url <url>
+/experimental tmux-bridge-token <token>
+/experimental tmux-status
+```
+
+### 3. Accept the local HTTPS certificate
+
+The bridge uses a self-signed cert. You may need to visit `https://localhost:3341` in your browser once and accept it.
+
+## When the bridge is not running
+
+The `tmux` tool stays registered but returns an error if the bridge is unreachable. Python tools (`python_run`, `python_transform_range`) still work via the in-browser Pyodide fallback — tmux is the only tool that strictly requires its bridge.
+
+## Security
+
+- Loopback-only (localhost)
+- Origin allowlist
+- Optional bearer token auth
+- Session names and key tokens are validated
+- No shell interpolation (argv-based tmux calls)
+
+## Troubleshooting
+
+- **"bridge URL is unavailable"** — the bridge process isn't running. Start it with `npx pi-for-excel-tmux-bridge`.
+- **"timed out"** — the bridge is running but the command took too long. Default timeout is 15s; use `timeout_ms` for longer operations.
+- **CORS/cert errors** — visit the bridge URL directly in your browser and accept the certificate.

--- a/skills/web-search/SKILL.md
+++ b/skills/web-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: web-search
-description: Search the public web for up-to-date facts using Serper.dev (default), Tavily, or Brave Search. Use when workbook context is insufficient and fresh external references are needed.
-compatibility: Requires Pi for Excel integration "web_search" to be enabled and a search-provider API key configured (Serper/Tavily/Brave).
+description: Search the public web for up-to-date facts. Works out of the box with Jina (default, no API key needed); optionally Serper, Tavily, or Brave Search. Use when workbook context is insufficient and fresh external references are needed.
+compatibility: Requires Pi for Excel integration "web_search" to be enabled. Works immediately with Jina (default); Serper/Tavily/Brave require an API key.
 metadata:
   integration-id: web_search
   tool-name: web_search
@@ -16,7 +16,18 @@ This repository exposes web search as a built-in **integration** in the Excel ad
 
 - Agent Skill name: `web-search`
 - Excel integration ID: `web_search`
-- Tool name: `web_search`
+- Tools: `web_search`, `fetch_page`
+
+## Providers
+
+| Provider | API key | Notes |
+|---|---|---|
+| **Jina** (default) | Optional (for higher limits) | Works out of the box — no signup needed |
+| Serper.dev | Required | Google SERP API, free tier available |
+| Tavily | Required | AI-native search, free monthly credits |
+| Brave Search | Required | Direct Brave Search API |
+
+If a keyed provider fails (auth/rate-limit/server error), search automatically retries with Jina and surfaces a warning.
 
 ## Usage notes
 
@@ -26,7 +37,7 @@ This repository exposes web search as a built-in **integration** in the Excel ad
 
 ## Excel-specific setup
 
-1. Open `/integrations`.
+1. Open `/tools` (or `/extensions` → Connections tab).
 2. Enable external tools.
-3. Choose provider (Serper/Tavily/Brave) and set its API key.
-4. Enable **Web Search** for session and/or workbook scope.
+3. Enable **Web Search** for session and/or workbook scope.
+4. (Optional) Choose a different provider and set its API key — Jina works by default with no configuration.

--- a/src/files/builtin-docs.ts
+++ b/src/files/builtin-docs.ts
@@ -1,11 +1,27 @@
 /**
  * Built-in, read-only docs exposed through the files workspace.
+ *
+ * Every non-archive doc is bundled so the assistant can answer user
+ * questions accurately instead of hallucinating setup instructions.
  */
 
 import projectReadmeMarkdown from "../../README.md?raw";
 import docsReadmeMarkdown from "../../docs/README.md?raw";
+import docsAgentSkillsInteropMarkdown from "../../docs/agent-skills-interop.md?raw";
+import docsCompactionMarkdown from "../../docs/compaction.md?raw";
+import docsContextManagementPolicyMarkdown from "../../docs/context-management-policy.md?raw";
+import docsDeployVercelMarkdown from "../../docs/deploy-vercel.md?raw";
 import docsExtensionsMarkdown from "../../docs/extensions.md?raw";
+import docsFilesWorkspaceMarkdown from "../../docs/files-workspace.md?raw";
+import docsInstallMarkdown from "../../docs/install.md?raw";
 import docsIntegrationsMarkdown from "../../docs/integrations-external-tools.md?raw";
+import docsManualFullBackupsMarkdown from "../../docs/manual-full-backups.md?raw";
+import docsModelUpdatesMarkdown from "../../docs/model-updates.md?raw";
+import docsPythonBridgeContractMarkdown from "../../docs/python-bridge-contract.md?raw";
+import docsSecurityThreatModelMarkdown from "../../docs/security-threat-model.md?raw";
+import docsTmuxBridgeContractMarkdown from "../../docs/tmux-bridge-contract.md?raw";
+import docsReleaseNotesV070Markdown from "../../docs/release-notes/v0.7.0-pre.md?raw";
+import docsReleaseNotesV080Markdown from "../../docs/release-notes/v0.8.0-pre.md?raw";
 
 import { normalizeWorkspacePath } from "./path.js";
 import type { WorkspaceFileEntry, WorkspaceFileReadResult } from "./types.js";
@@ -19,14 +35,29 @@ const BUILTIN_DOCS_PREFIX = "assistant-docs";
 const BUILTIN_DOC_TIMESTAMP = Date.now();
 
 const BUILTIN_DOC_SOURCES: readonly BuiltinDocSource[] = [
+  // Project root
   {
     path: `${BUILTIN_DOCS_PREFIX}/README.md`,
     markdown: projectReadmeMarkdown,
   },
+
+  // Docs index
   {
     path: `${BUILTIN_DOCS_PREFIX}/docs/README.md`,
     markdown: docsReadmeMarkdown,
   },
+
+  // Guides
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/install.md`,
+    markdown: docsInstallMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/deploy-vercel.md`,
+    markdown: docsDeployVercelMarkdown,
+  },
+
+  // Runtime features
   {
     path: `${BUILTIN_DOCS_PREFIX}/docs/extensions.md`,
     markdown: docsExtensionsMarkdown,
@@ -34,6 +65,56 @@ const BUILTIN_DOC_SOURCES: readonly BuiltinDocSource[] = [
   {
     path: `${BUILTIN_DOCS_PREFIX}/docs/integrations-external-tools.md`,
     markdown: docsIntegrationsMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/agent-skills-interop.md`,
+    markdown: docsAgentSkillsInteropMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/compaction.md`,
+    markdown: docsCompactionMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/manual-full-backups.md`,
+    markdown: docsManualFullBackupsMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/files-workspace.md`,
+    markdown: docsFilesWorkspaceMarkdown,
+  },
+
+  // Architecture & policy
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/context-management-policy.md`,
+    markdown: docsContextManagementPolicyMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/security-threat-model.md`,
+    markdown: docsSecurityThreatModelMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/model-updates.md`,
+    markdown: docsModelUpdatesMarkdown,
+  },
+
+  // Feature-flagged bridge contracts
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/tmux-bridge-contract.md`,
+    markdown: docsTmuxBridgeContractMarkdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/python-bridge-contract.md`,
+    markdown: docsPythonBridgeContractMarkdown,
+  },
+
+  // Release notes
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/release-notes/v0.7.0-pre.md`,
+    markdown: docsReleaseNotesV070Markdown,
+  },
+  {
+    path: `${BUILTIN_DOCS_PREFIX}/docs/release-notes/v0.8.0-pre.md`,
+    markdown: docsReleaseNotesV080Markdown,
   },
 ] as const;
 

--- a/src/skills/catalog.ts
+++ b/src/skills/catalog.ts
@@ -5,6 +5,8 @@
  */
 
 import mcpGatewaySkillMarkdown from "../../skills/mcp-gateway/SKILL.md?raw";
+import pythonBridgeSkillMarkdown from "../../skills/python-bridge/SKILL.md?raw";
+import tmuxBridgeSkillMarkdown from "../../skills/tmux-bridge/SKILL.md?raw";
 import webSearchSkillMarkdown from "../../skills/web-search/SKILL.md?raw";
 
 import { parseSkillDocument, type ParsedSkillFrontmatter } from "./frontmatter.js";
@@ -27,6 +29,14 @@ const BUNDLED_SKILL_SOURCES: readonly BundledSkillSource[] = [
   {
     location: "skills/mcp-gateway/SKILL.md",
     markdown: mcpGatewaySkillMarkdown,
+  },
+  {
+    location: "skills/tmux-bridge/SKILL.md",
+    markdown: tmuxBridgeSkillMarkdown,
+  },
+  {
+    location: "skills/python-bridge/SKILL.md",
+    markdown: pythonBridgeSkillMarkdown,
   },
 ] as const;
 


### PR DESCRIPTION
## Problem

The in-app agent only had access to 4 built-in docs (README, docs index, extensions, integrations). When users asked about tmux setup, Python bridge, installation, or other features, the agent hallucinated instructions — e.g. fabricating `npm install -g @pi-app/cli` and `pi bridge start` for tmux.

Several docs also referenced the removed `/integrations` command, and the web-search skill still listed Serper as the default provider (Jina has been default since the zero-config search update).

## Changes

### Assistant-accessible docs (4 → 19)

All non-archive docs are now bundled in `assistant-docs/` so the agent can look up accurate answers:

| Added | Content |
|---|---|
| `docs/install.md` | User install guide |
| `docs/tmux-bridge-contract.md` | Tmux bridge setup & API |
| `docs/python-bridge-contract.md` | Python bridge setup & API |
| `docs/compaction.md` | `/compact` feature |
| `docs/files-workspace.md` | Workspace conventions |
| `docs/manual-full-backups.md` | `/backup` feature |
| `docs/agent-skills-interop.md` | Skills vs integrations |
| `docs/context-management-policy.md` | Context/auto-injection |
| `docs/security-threat-model.md` | Security posture |
| `docs/model-updates.md` | Model update playbook |
| `docs/deploy-vercel.md` | Deployment guide |
| `docs/release-notes/v0.7.0-pre.md` | Release notes |
| `docs/release-notes/v0.8.0-pre.md` | Release notes |

The existing `docs/README.md` index was already bundled — its links now resolve to real files.

### New bundled Agent Skills

- **`skills/tmux-bridge/SKILL.md`** — setup instructions (`npx pi-for-excel-tmux-bridge`), actions, troubleshooting. Correctly notes the tool is always registered (not feature-flagged).
- **`skills/python-bridge/SKILL.md`** — Pyodide vs native comparison, setup, tools, fallback behavior.

Both registered in `src/skills/catalog.ts` (4 bundled skills total).

### Stale reference fixes

| File | Fix |
|---|---|
| `README.md` | `/integrations` → `/tools`; added Jina to web search providers; updated skills list |
| `docs/integrations-external-tools.md` | Removed `/integrations` alias references |
| `docs/agent-skills-interop.md` | Removed `/integrations` alias; added new skills to list |
| `skills/web-search/SKILL.md` | Jina as default; `/integrations` → `/tools` |
| `skills/mcp-gateway/SKILL.md` | `/integrations` → `/tools` |

## Verification

- `npm run check` ✅
- `npm run build` ✅
- Bundle size delta: ~49KB raw text (compresses well), negligible gzip impact
