### PR TITLE
refactor(tmux-bridge): dedupe capture pacing and wait_for polling

### DIFF
--- a/tests/tmux-bridge-server.test.mjs
+++ b/tests/tmux-bridge-server.test.mjs
@@ -302,6 +302,35 @@ test("capture_pane wait_ms delays response in stub mode", async (t) => {
   assert.match(payload.output, /echo hello/);
 });
 
+test("send_and_capture wait_for matches in stub mode", async (t) => {
+  const bridge = await startBridge();
+  t.after(async () => {
+    await bridge.stop();
+  });
+
+  const createSession = await fetch(`http://127.0.0.1:${bridge.port}/v1/tmux`, requestInit("POST", {
+    action: "create_session",
+    session: "wait-for-demo",
+  }));
+  assert.equal(createSession.status, 200);
+
+  const sendAndCapture = await fetch(`http://127.0.0.1:${bridge.port}/v1/tmux`, requestInit("POST", {
+    action: "send_and_capture",
+    session: "wait-for-demo",
+    text: "echo ready",
+    enter: true,
+    wait_for: "echo ready",
+    timeout_ms: 1000,
+    lines: 20,
+  }));
+
+  assert.equal(sendAndCapture.status, 200);
+
+  const payload = await sendAndCapture.json();
+  assert.equal(payload.action, "send_and_capture");
+  assert.match(payload.output, /echo ready/);
+});
+
 test("tmux bridge rejects invalid action payloads", async (t) => {
   const bridge = await startBridge();
   t.after(async () => {


### PR DESCRIPTION
## Summary

Refactors `scripts/tmux-bridge-server.mjs` to remove duplicated capture pacing and `wait_for` polling logic across stub and real tmux backends.

## What changed

- Added shared helpers:
  - `maybeDelayCapture(waitMs)`
  - `captureWithOptionalWaitFor({ waitFor, timeoutMs, pollIntervalMs, capture })`
- Reused these helpers in both backends for:
  - `capture_pane`
  - `send_and_capture`
- Kept backend-specific poll intervals explicit via constants:
  - `STUB_WAIT_FOR_POLL_INTERVAL_MS`
  - `REAL_WAIT_FOR_POLL_INTERVAL_MS`
- Added regression coverage for `send_and_capture` + `wait_for` in stub mode.

## Why

This keeps behavior the same but removes copy/pasted logic, reducing drift risk and making future maintenance safer and simpler.

## Validation

- `node --test --experimental-strip-types tests/tmux-bridge-server.test.mjs`
- `npm run lint`
- `npm run typecheck`
- `npm run test:security`
