### PR TITLE
fix(context): keep full tool disclosure for cache continuity

### DIFF
--- a/src/context/tool-disclosure.ts
+++ b/src/context/tool-disclosure.ts
@@ -1,15 +1,9 @@
 import type { Context, Tool } from "@mariozechner/pi-ai";
 
 import { type CoreToolName, CORE_TOOL_NAMES } from "../tools/names.js";
-import {
-  chooseToolDisclosureBundle,
-  filterToolsForDisclosureBundle,
-  type ToolDisclosureBundleId,
-} from "../tools/capabilities.js";
+import { type ToolDisclosureBundleId } from "../tools/capabilities.js";
 
 export type ToolBundleId = ToolDisclosureBundleId;
-
-type UserMessage = Extract<Context["messages"][number], { role: "user" }>;
 
 const CORE_TOOL_NAME_SET = new Set<string>(CORE_TOOL_NAMES);
 
@@ -24,34 +18,6 @@ function hasOnlyCoreTools(tools: readonly Tool[]): boolean {
   return true;
 }
 
-function extractUserText(content: UserMessage["content"]): string {
-  if (typeof content === "string") return content;
-
-  const textParts: string[] = [];
-  for (const item of content) {
-    if (item.type === "text") {
-      textParts.push(item.text);
-    }
-  }
-
-  return textParts.join(" ");
-}
-
-function getLastUserPrompt(messages: Context["messages"]): string | null {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const message = messages[i];
-    if (message.role !== "user") continue;
-
-    const text = extractUserText(message.content).trim();
-    if (text.length === 0) continue;
-
-    if (text.startsWith("[Auto-context]")) continue;
-    return text.toLowerCase();
-  }
-
-  return null;
-}
-
 export interface ToolDisclosureResult {
   tools: Context["tools"];
   bundleId: ToolBundleId;
@@ -60,22 +26,21 @@ export interface ToolDisclosureResult {
 /**
  * Select a deterministic tool bundle for the current call.
  *
- * Rules:
- * - Only applies to the core built-in tool set.
- * - If extension/non-core tools are present, keep full tool visibility.
- * - Selection is based on the latest non-auto user prompt.
+ * Cache-first policy:
+ * - If tools are present, always expose the full tool list.
+ * - We keep core-only and mixed toolsets aligned to the same stable tool schema
+ *   so prompt caches are not partitioned by intent-routed bundles.
  */
 export function selectToolBundle(context: Context): ToolDisclosureResult {
   if (!context.tools || context.tools.length === 0) {
     return { tools: context.tools, bundleId: "none" };
   }
 
+  // Keep the lightweight core-tool check to make intent explicit and to preserve
+  // future room for opt-in routing without reintroducing local tool-name lists.
   if (!hasOnlyCoreTools(context.tools)) {
     return { tools: context.tools, bundleId: "full" };
   }
 
-  const prompt = getLastUserPrompt(context.messages);
-  const bundleId = prompt ? chooseToolDisclosureBundle(prompt) : "core";
-  const tools = filterToolsForDisclosureBundle(context.tools, bundleId);
-  return { tools, bundleId };
+  return { tools: context.tools, bundleId: "full" };
 }

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -508,10 +508,10 @@ void test("extension registry migrates legacy v1 entries to v2 permissions", asy
   assert.equal(migrated.items.length, 1);
 });
 
-void test("tool disclosure bundles are centralized in capabilities metadata", async () => {
+void test("tool disclosure bundles remain centralized in capabilities metadata", async () => {
   const disclosureSource = await readFile(new URL("../src/context/tool-disclosure.ts", import.meta.url), "utf8");
-  assert.match(disclosureSource, /chooseToolDisclosureBundle/);
-  assert.match(disclosureSource, /filterToolsForDisclosureBundle/);
+  assert.match(disclosureSource, /type ToolDisclosureBundleId/);
+  assert.doesNotMatch(disclosureSource, /TOOL_DISCLOSURE_BUNDLES\s*=/);
 
   const capabilitiesSource = await readFile(new URL("../src/tools/capabilities.ts", import.meta.url), "utf8");
   assert.match(capabilitiesSource, /TOOL_DISCLOSURE_BUNDLES/);


### PR DESCRIPTION
## Summary
- switch `selectToolBundle()` to a cache-first policy: when tools are present, always return `full`
- remove intent-routed core-only disclosure from runtime selection to avoid prompt-cache key partitioning
- update tool-disclosure and registry tests to assert cache-stable behavior
- refresh context-management policy docs to match the new rollout semantics (`none` or `full`)

## Why
Prompt caching keys are sensitive to stable request prefixes. Intent-routed bundle changes (`analysis`/`formatting`/etc.) can split cache reuse for core-only sessions. Returning the full set for non-empty tool lists keeps a single stable tool-schema payload and avoids avoidable misses.

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
- `npm run test:models`
