### PR TITLE
fix(model): fork non-empty sessions on model switch

### DIFF
--- a/src/commands/builtins/index.ts
+++ b/src/commands/builtins/index.ts
@@ -27,13 +27,17 @@ export interface BuiltinsContext
     SkillsCommandActions,
     FilesCommandActions {
   getActiveAgent: ActiveAgentProvider;
+  openModelSelector: () => void;
 }
 
 /** Register all built-in commands. Call once after runtime manager is ready. */
 export function registerBuiltins(context: BuiltinsContext): void {
   // Keep registration order stable: this is the order shown in the command menu.
   const builtins: SlashCommand[] = [
-    ...createModelCommands(context.getActiveAgent),
+    ...createModelCommands({
+      getActiveAgent: context.getActiveAgent,
+      openModelSelector: context.openModelSelector,
+    }),
     ...createSettingsCommands(context),
     ...createAddonsCommands(context),
     ...createToolsCommands(context),

--- a/src/commands/builtins/model.ts
+++ b/src/commands/builtins/model.ts
@@ -3,36 +3,34 @@
  */
 
 import type { Agent } from "@mariozechner/pi-agent-core";
-import { ModelSelector } from "@mariozechner/pi-web-ui/dist/dialogs/ModelSelector.js";
 
 import type { SlashCommand } from "../types.js";
 import { showToast } from "../../ui/toast.js";
 
 export type ActiveAgentProvider = () => Agent | null;
 
-function openModelSelector(getActiveAgent: ActiveAgentProvider): void {
-  const agent = getActiveAgent();
-  if (!agent) {
-    showToast("No active session");
-    return;
-  }
-
-  void ModelSelector.open(agent.state.model, (model) => {
-    agent.setModel(model);
-    document.dispatchEvent(new CustomEvent("pi:model-changed"));
-    document.dispatchEvent(new CustomEvent("pi:status-update"));
-  });
+export interface ModelCommandActions {
+  getActiveAgent: ActiveAgentProvider;
+  openModelSelector: () => void;
 }
 
-export function createModelCommands(getActiveAgent: ActiveAgentProvider): SlashCommand[] {
+export function createModelCommands(actions: ModelCommandActions): SlashCommand[] {
+  const runModelSelector = (): void => {
+    const agent = actions.getActiveAgent();
+    if (!agent) {
+      showToast("No active session");
+      return;
+    }
+
+    actions.openModelSelector();
+  };
+
   return [
     {
       name: "model",
       description: "Change the AI model",
       source: "builtin",
-      execute: () => {
-        openModelSelector(getActiveAgent);
-      },
+      execute: runModelSelector,
     },
     {
       name: "default-models",
@@ -41,7 +39,7 @@ export function createModelCommands(getActiveAgent: ActiveAgentProvider): SlashC
       execute: () => {
         // TODO: implement scoped models dialog
         // For now, open model selector as a placeholder
-        openModelSelector(getActiveAgent);
+        runModelSelector();
       },
     },
   ];

--- a/tests/builtins-registry.test.ts
+++ b/tests/builtins-registry.test.ts
@@ -43,6 +43,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 void test("builtins registry wires /addons, /experimental, /extensions, /tools, and /files command registration", async () => {
   const source = await readFile(new URL("../src/commands/builtins/index.ts", import.meta.url), "utf8");
 
+  assert.match(source, /createModelCommands/);
+  assert.match(source, /openModelSelector:\s*context\.openModelSelector/);
+
   assert.match(source, /createAddonsCommands/);
   assert.match(source, /\.\.\.createAddonsCommands\(context\)/);
 


### PR DESCRIPTION
## Summary
- switch `/model` + status-bar model picking to a shared taskpane selector handler
- keep in-place model mutation only for empty sessions
- when a session already has messages, fork into a new tab with the selected model instead of mutating the existing runtime
- refactor runtime cloning into a shared helper used by both duplicate-tab and model-fork paths

## Why
Issue #424 tracks prompt-cache safety gaps. Mid-session model mutation is one of the highest-impact prefix churn paths.

This change keeps existing sessions stable by default: selecting a different model on a non-empty session now creates a model-forked tab and leaves the original tab unchanged.

## Implementation path
1. **Unify model selector entry points**
   - `createModelCommands` now delegates to an injected `openModelSelector` action.
   - `registerBuiltins` context now provides `openModelSelector`.
2. **Refactor tab cloning flow** in `src/taskpane/init.ts`
   - extract `cloneRuntimeToNewTab(...)` and `resolveRuntimeTabTitle(...)`.
   - `duplicateRuntimeTab` now reuses the helper.
3. **Apply cache-safe model switch policy**
   - add `applyModelSelection(runtimeId, nextModel)`:
     - same model => no-op
     - busy runtime => block with toast
     - empty session => in-place `setModel`
     - non-empty session => create a new runtime tab with copied messages + selected model
4. **Add regression guard**
   - update `tests/builtins-registry.test.ts` to assert model commands are wired through `context.openModelSelector`.

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
- `npm run test:models`

## Notes
- Reviewed issue #424 + comments before this slice; there were no additional issue comments to incorporate yet.
