### PR TITLE
docs(context): record compaction call-shape decision

### DIFF
--- a/docs/archive/issue-424-compaction-call-shape.md
+++ b/docs/archive/issue-424-compaction-call-shape.md
@@ -1,0 +1,24 @@
+# Issue #424 — Compaction call-shape decision
+
+## Decision
+
+For #424 area 1 (compaction call-shape), we are **deferring behavior changes** for now.
+
+- Keep the current isolated summarizer request in `src/commands/builtins/export.ts`.
+- Revisit cache-safe fork compaction after additional telemetry and guardrails.
+
+## Why defer now
+
+1. **Upstream parity:** pi-coding-agent currently uses the same isolated summarizer pattern (`dist/core/compaction/compaction.js`, `dist/core/agent-session.js`).
+2. **Replay complexity:** our normal loop relies on stateful `transformContext` behavior (`src/taskpane/context-injection.ts`), so reproducing the exact parent prefix safely is non-trivial.
+3. **Tool-call risk in side requests:** stream-simple side calls do not expose a strict `toolChoice=none` control.
+4. **Budget assumptions:** current compaction thresholds/buffers were tuned for serialized summarizer input, not full-prefix fork payloads.
+
+## Revisit criteria
+
+Before implementing cache-safe fork compaction, require:
+
+1. Telemetry that can distinguish compaction churn from normal-turn churn.
+2. A deterministic fallback when forked compaction returns tool calls or overflows.
+3. Budget validation for smaller context-window models.
+4. Explicit alignment decision with upstream behavior.

--- a/docs/context-management-policy.md
+++ b/docs/context-management-policy.md
@@ -187,6 +187,13 @@ Implications:
 
 ---
 
+## #424 investigation updates (current)
+
+- **Area 1 — compaction call-shape:** **defer behavior change** for now.
+  - Keep the current isolated summarizer request in `src/commands/builtins/export.ts`.
+  - Rationale: current behavior matches upstream `pi-coding-agent` compaction flow, and a cache-safe fork requires additional guardrails (transform-context replay, tool-call fallback, and explicit compaction-buffer budgeting).
+  - Research memo: `docs/archive/issue-424-compaction-call-shape.md`.
+
 ## Open decisions
 
 1. Exact tool bundle definitions + routing heuristics.


### PR DESCRIPTION
## Summary
- document the #424 area-1 decision to defer compaction call-shape changes for now
- add a dedicated memo in `docs/archive/issue-424-compaction-call-shape.md`
- link the decision from `docs/context-management-policy.md`

## Why
- current `/compact` behavior is intentionally aligned with upstream `pi-coding-agent`
- cache-safe fork compaction remains a valid future option, but needs explicit guardrails first (context replay, fallback behavior, and budget validation)

## Validation
- `npm run check`

Closes #424 (decision memo slice for area 1).
