### PR TITLE
docs(context): finalize issue #424 decision matrix

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -4,6 +4,11 @@ These docs are kept for historical context but are **not** the current source of
 
 If behavior in code conflicts with an archived doc, trust current implementation + active docs in `docs/`.
 
+## Archived on 2026-02-22
+
+- `issue-424-compaction-call-shape.md`
+- `issue-424-decision-matrix.md`
+
 ## Archived on 2026-02-13
 
 - `cleanup-approach.md`

--- a/docs/archive/issue-424-decision-matrix.md
+++ b/docs/archive/issue-424-decision-matrix.md
@@ -1,0 +1,33 @@
+# Issue #424 — consolidated keep/implement/defer decisions
+
+## Scope
+
+This memo consolidates all six investigation areas from #424 after the landed slices:
+- #428 (`fix(model): fork non-empty sessions on model switch`)
+- #431 (`feat(cache): add prefix churn observability counters`)
+- #434 (`docs(context): document compaction call-shape decision`)
+- #436 (`fix(context): skip no-op runtime tool refreshes`)
+
+## Decision matrix
+
+| Area | Decision | Outcome |
+|---|---|---|
+| 1) Compaction call-shape | **Defer** | Keep current isolated summarizer call for now. See `issue-424-compaction-call-shape.md` for guardrails required before revisiting cache-safe fork compaction. |
+| 2) Mid-session model switching | **Implement** | Shipped in #428: non-empty sessions fork into a new tab/runtime on model change. |
+| 3) Mid-session toolset churn | **Implement** | Shipped in #436: no-op tool-refresh suppression via metadata fingerprinting, with eager refresh preserved when extension tools are present. |
+| 4) Mid-session system-prompt churn | **Keep now, defer deeper refactor** | Keep dynamic safety-critical prompt sections in system prompt (rules, execution mode, connection/integration/skills state). Defer stable-base + volatile-message split until telemetry indicates material churn pain. |
+| 5) Side LLM operations (`llm.complete`) | **Keep independent** | Treat extension side-completions as intentionally separate from the primary runtime prefix. Add explicit extension-author guidance on minimizing side-call cache churn. Defer parent-prefix reuse mode. |
+| 6) Cache observability policy | **Implement v1 policy** | Use existing prefix-churn counters + payload snapshots as mandatory PR/release investigation signals for context-shape changes (workflow policy, not CI hard gate yet). |
+
+## Rationale highlights
+
+- **Safety over purity for system prompt layering:** several dynamic prompt blocks are policy/safety controls, not optional convenience text.
+- **No-op churn removal is high-leverage and low-risk:** model switching and tool refresh were the highest-confidence cache-churn wins and are now landed.
+- **Compaction fork remains high-risk without guardrails:** transform-context replay and budget behavior need explicit design before implementation.
+- **Extension side LLM calls should stay scoped:** side completions are useful, but should not masquerade as the primary session loop.
+
+## Follow-up queue (ordered)
+
+1. **Telemetry-driven validation pass** (no behavior change): review live `prefixChangeReasons` patterns after #436 and document expected baselines by scenario.
+2. **Optional extension side-call isolation enhancement** (if noise appears): evaluate session-id namespacing for `llm.complete` to avoid mixing side-call churn with main runtime churn signals.
+3. **Compaction fork design spike** (deferred): only after explicit guardrails are accepted (tool-call fallback, budget tests, replay consistency).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -118,6 +118,12 @@ Agent API surface:
 ### `llm.complete(request)`
 Host-mediated LLM completion. Supports optional model override (`provider/modelId` or model id), optional `systemPrompt`, and `messages` (`user`/`assistant`).
 
+Cache/prompt-shape guidance for extension authors:
+- Treat `llm.complete` as an **independent side completion** by default (separate from the main chat loop/tool prefix).
+- Keep `systemPrompt` short and stable across repeated extension calls when possible.
+- Put volatile data in `messages` rather than rewriting `systemPrompt` every call.
+- Use `agent.injectContext` / `agent.steer` when you need to influence the primary runtime conversation instead of emulating it through `llm.complete`.
+
 ### `http.fetch(url, options?)`
 Host-mediated outbound HTTP fetch with security policy enforcement.
 

--- a/docs/release-smoke-test-checklist.md
+++ b/docs/release-smoke-test-checklist.md
@@ -43,6 +43,17 @@ Run in repo root:
 
 Record run date and commit SHA in the evidence table below.
 
+### Context/cache instrumentation sanity (for context-shape changes)
+
+Run this add-on check when the release includes changes to model context composition (system prompt, tool disclosure, toolset refresh, compaction, or context injection):
+
+1. Enable debug mode.
+2. Run a deterministic mini-session (≥5 calls, including at least one tool loop).
+3. Record prefix churn counters (`prefixChanges`, `prefixModelChanges`, `prefixSystemPromptChanges`, `prefixToolChanges`).
+4. Confirm each non-zero reason has an intentional trigger in the scenario.
+
+If churn is unexpected, treat as a release blocker until explained or fixed.
+
 ## Environment matrix
 
 - macOS Excel Desktop: **required**


### PR DESCRIPTION
## Summary
- add a consolidated #424 keep/implement/defer decision memo at `docs/archive/issue-424-decision-matrix.md`
- update `docs/context-management-policy.md` with a full 6-area decision matrix and a cache observability workflow policy (v1)
- document extension-author cache guidance for `llm.complete` in `docs/extensions.md`
- add a context/cache instrumentation sanity block to `docs/release-smoke-test-checklist.md`
- update `docs/archive/README.md` archive index for the new #424 memos

## Why
Issue #424 requested an explicit classification across all cache-safety investigation areas. We had landed slices for model switching/tool churn/compaction memo, but the final cross-area decision matrix and workflow policy were not yet consolidated in tracked docs.

This PR closes that documentation gap and makes the expected cache-observability workflow explicit for future context-shape changes.

## Validation
- pre-commit hook:
  - `npm run lint`
  - `npm run typecheck`

Refs #424
