### PR TITLE
fix(extensions): isolate llm.complete side-session keys

### DIFF
--- a/docs/archive/issue-424-decision-matrix.md
+++ b/docs/archive/issue-424-decision-matrix.md
@@ -7,6 +7,7 @@ This memo consolidates all six investigation areas from #424 after the landed sl
 - #431 (`feat(cache): add prefix churn observability counters`)
 - #434 (`docs(context): document compaction call-shape decision`)
 - #436 (`fix(context): skip no-op runtime tool refreshes`)
+- #439 (`docs(context): add prefix-churn baseline runbook`)
 
 ## Decision matrix
 
@@ -16,7 +17,7 @@ This memo consolidates all six investigation areas from #424 after the landed sl
 | 2) Mid-session model switching | **Implement** | Shipped in #428: non-empty sessions fork into a new tab/runtime on model change. |
 | 3) Mid-session toolset churn | **Implement** | Shipped in #436: no-op tool-refresh suppression via metadata fingerprinting, with eager refresh preserved when extension tools are present. |
 | 4) Mid-session system-prompt churn | **Keep now, defer deeper refactor** | Keep dynamic safety-critical prompt sections in system prompt (rules, execution mode, connection/integration/skills state). Defer stable-base + volatile-message split until telemetry indicates material churn pain. |
-| 5) Side LLM operations (`llm.complete`) | **Keep independent** | Treat extension side-completions as intentionally separate from the primary runtime prefix. Add explicit extension-author guidance on minimizing side-call cache churn. Defer parent-prefix reuse mode. |
+| 5) Side LLM operations (`llm.complete`) | **Keep independent** | Treat extension side-completions as intentionally separate from the primary runtime prefix. Extension calls now use extension-scoped side session keys so side-call churn is isolated from primary runtime telemetry. |
 | 6) Cache observability policy | **Implement v1 policy** | Use existing prefix-churn counters + payload snapshots as mandatory PR/release investigation signals for context-shape changes (workflow policy, not CI hard gate yet). |
 
 ## Rationale highlights
@@ -28,6 +29,6 @@ This memo consolidates all six investigation areas from #424 after the landed sl
 
 ## Follow-up queue (ordered)
 
-1. **Telemetry-driven validation pass** (no behavior change): review live `prefixChangeReasons` patterns after #436 and document expected baselines by scenario.
-2. **Optional extension side-call isolation enhancement** (if noise appears): evaluate session-id namespacing for `llm.complete` to avoid mixing side-call churn with main runtime churn signals.
+1. ✅ **Telemetry-driven validation pass** (no behavior change): baseline runbook + template shipped in #439.
+2. ✅ **Extension side-call isolation enhancement:** `llm.complete` now uses extension-scoped side session keys to avoid mixing side-call churn with main runtime churn signals.
 3. **Compaction fork design spike** (deferred): only after explicit guardrails are accepted (tool-call fallback, budget tests, replay consistency).

--- a/docs/cache-observability-baselines.md
+++ b/docs/cache-observability-baselines.md
@@ -37,6 +37,7 @@ Use this as the default expectation map when reviewing context-shape changes.
 | Integration toggle (`web_search`, `mcp_tools`) | `["systemPrompt", "tools"]` | Both prompt integration section and tool list change. |
 | Extension add/remove tool (schema delta) | includes `"tools"` | Tool schema changed. |
 | Extension handler hot-reload with same schema | `[]` | #436 keeps extension refresh eager while preserving schema-stable prefixes. |
+| Extension `llm.complete` side call | Main runtime session: `[]` | Side completions use an extension-scoped session key, so prefix churn is isolated from the primary runtime session. |
 
 ## Investigation rules
 

--- a/docs/context-management-policy.md
+++ b/docs/context-management-policy.md
@@ -196,7 +196,7 @@ Implications:
 | 2) Mid-session model switching | **Implement** cache-safe behavior | ✅ shipped (#428) | Non-empty sessions now fork into a new tab/model runtime; empty sessions still switch in place. |
 | 3) Mid-session toolset churn | **Implement** targeted stabilization | ✅ shipped (#436) | Runtime now skips no-op `setTools(...)` updates via fingerprinting, while keeping extension-tool refreshes eager for handler hot-reloads. |
 | 4) Mid-session system-prompt churn | **Keep + defer deeper refactor** | ✅ decision recorded | Keep dynamic safety-critical sections (rules, execution mode, connection/integration/skills state) in system prompt for now. Defer stable-base + volatile-message layering until telemetry justifies complexity. |
-| 5) Side LLM operations (`llm.complete`) | **Keep intentionally independent** | ✅ decision recorded | Treat extension side-completions as separate from main runtime context; add explicit extension-author guidance on cache impact (see `docs/extensions.md`). Defer parent-prefix reuse mode. |
+| 5) Side LLM operations (`llm.complete`) | **Keep intentionally independent** | ✅ guidance + session-key isolation implemented | Treat extension side-completions as separate from main runtime context; extension calls now use extension-scoped side session keys so observability/prefix churn is isolated from the primary runtime. |
 | 6) Cache observability policy | **Implement v1 workflow policy** | ✅ policy + baseline matrix documented | Use prefix-churn counters + payload snapshots as release/PR smoke signals for context changes. Baselines: `docs/cache-observability-baselines.md`. |
 
 ### Cache observability policy (v1)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -120,6 +120,7 @@ Host-mediated LLM completion. Supports optional model override (`provider/modelI
 
 Cache/prompt-shape guidance for extension authors:
 - Treat `llm.complete` as an **independent side completion** by default (separate from the main chat loop/tool prefix).
+- Host runtime uses an extension-scoped side session key for `llm.complete`, so side-call churn is isolated from the primary runtime session telemetry.
 - Keep `systemPrompt` short and stable across repeated extension calls when possible.
 - Put volatile data in `messages` rather than rewriting `systemPrompt` every call.
 - Use `agent.injectContext` / `agent.steer` when you need to influence the primary runtime conversation instead of emulating it through `llm.complete`.

--- a/src/extensions/runtime-manager.ts
+++ b/src/extensions/runtime-manager.ts
@@ -54,6 +54,7 @@ import { showToast } from "../ui/toast.js";
 import { getEnabledProxyBaseUrl, resolveOutboundRequestUrl } from "../tools/external-fetch.js";
 import { clearExtensionStorage } from "./storage-store.js";
 import {
+  createExtensionLlmCompletionSessionId,
   describeExtensionSource,
   extractAssistantText,
   getRuntimeManagerErrorMessage,
@@ -417,7 +418,10 @@ export class ExtensionRuntimeManager {
       },
       {
         apiKey,
-        sessionId: agent.sessionId,
+        sessionId: createExtensionLlmCompletionSessionId({
+          agentSessionId: agent.sessionId,
+          extensionId: entry.id,
+        }),
         maxTokens: request.maxTokens,
       },
     );

--- a/tests/extension-overlay-integration.test.ts
+++ b/tests/extension-overlay-integration.test.ts
@@ -12,7 +12,10 @@ import {
   type StoredExtensionTrust,
 } from "../src/extensions/permissions.ts";
 import { ExtensionRuntimeManager, type ExtensionRuntimeStatus } from "../src/extensions/runtime-manager.ts";
-import { describeExtensionSource } from "../src/extensions/runtime-manager-helpers.ts";
+import {
+  createExtensionLlmCompletionSessionId,
+  describeExtensionSource,
+} from "../src/extensions/runtime-manager-helpers.ts";
 import { describeExtensionRuntimeMode, type ExtensionRuntimeMode } from "../src/extensions/runtime-mode.ts";
 import type { ExtensionSettingsStore, StoredExtensionSource } from "../src/extensions/store.ts";
 import { EXTENSION_OVERLAY_ID } from "../src/ui/overlay-ids.ts";
@@ -119,6 +122,29 @@ function createRuntimeStatus(input: {
     lastError: input.lastError ?? null,
   };
 }
+
+void test("createExtensionLlmCompletionSessionId namespaces side completions by extension", () => {
+  const sessionId = createExtensionLlmCompletionSessionId({
+    agentSessionId: "session-abc",
+    extensionId: "ext.weather",
+  });
+
+  assert.equal(sessionId, "session-abc::ext-llm:ext.weather");
+});
+
+void test("createExtensionLlmCompletionSessionId trims values and handles missing base session", () => {
+  const withoutBaseSession = createExtensionLlmCompletionSessionId({
+    agentSessionId: " ",
+    extensionId: " ext.weather ",
+  });
+  assert.equal(withoutBaseSession, "ext-llm:ext.weather");
+
+  const withoutExtensionId = createExtensionLlmCompletionSessionId({
+    agentSessionId: "session-abc",
+    extensionId: "  ",
+  });
+  assert.equal(withoutExtensionId, "session-abc::ext-llm:unknown-extension");
+});
 
 function collectElements(root: HTMLElement, predicate: (element: HTMLElement) => boolean): HTMLElement[] {
   const matches: HTMLElement[] = [];


### PR DESCRIPTION
## Summary
- isolate extension `llm.complete` calls from primary runtime session telemetry by using extension-scoped side session keys
- add `createExtensionLlmCompletionSessionId(...)` in `src/extensions/runtime-manager-helpers.ts`
- wire `runExtensionLlmCompletion(...)` in `src/extensions/runtime-manager.ts` to use the side-session key instead of the main `agent.sessionId`
- add focused tests in `tests/extension-overlay-integration.test.ts` for session-key composition behavior
- update cache policy/docs to reflect this shipped follow-up for #424 area 5

## Why
Issue #424 follow-up identified that extension side completions can be intentionally independent, but sharing the main runtime session id can mix side-call prefix churn into primary runtime observability.

This keeps side completions independent and makes prefix churn/debug signals cleaner for the main runtime session.

## Validation
- `npm run check`
- `npm run test:context`
- `npm run build`
- `npm run test:models`

Refs #424
