### PR TITLE
fix(bridge): polish setup guidance + accessibility

### DIFF
--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -179,6 +179,8 @@ function buildLocalServicesSection(localServices: LocalServiceEntry[] | undefine
     "",
     "These run on the user's machine alongside Excel. Probed at session start.",
     "When a service is unavailable, use the skills tool to read the referenced skill before responding.",
+    "If a bridge-related tool result includes `Skill: <name>` (or `details.skillHint`), read that skill before giving setup guidance.",
+    "Do not guess platform-specific install commands — rely on the referenced skill.",
     "",
   ];
 

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -153,6 +153,7 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
 ## Tmux bridge tool (`tmux`)
 - **Availability:** non-core tool, always registered via `createAllTools()`; execution is gated by `applyExperimentalToolGates()`.
 - **Gate model:** requires a healthy bridge URL (`tmux.bridge.url` override, else default `https://localhost:3341`) and successful `/health` probe.
+- **Gate failure contract:** blocked gate checks return structured `AgentToolResult` payloads (`details.gateReason`, `details.skillHint`) instead of throwing, enabling inline setup UX and deterministic agent recovery.
 - **Execution policy:** classified as `read/none` in workbook coordinator (no workbook lock writes or blueprint invalidation).
 - **Bridge implementation:** local helper script `scripts/tmux-bridge-server.mjs`.
   - one-command helper (`npx pi-for-excel-tmux-bridge`) defaults to real `tmux` mode
@@ -180,6 +181,7 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
   - effective bridge URL = configured override or default `https://localhost:3340`.
   - first execution requires user confirmation when the effective bridge URL is reachable (cached once per bridge URL).
   - bridge-only tool (`libreoffice_convert`) is blocked when no reachable bridge URL is available.
+  - blocked gate checks return structured `AgentToolResult` payloads (`details.gateReason`, `details.skillHint`) rather than thrown errors.
 - **Execution policy:**
   - `python_run` + `libreoffice_convert` → `read/none` (no direct workbook mutation)
   - `python_transform_range` → `mutate/content` (writes transformed values into workbook)

--- a/src/tools/experimental-tool-gates/evaluation.ts
+++ b/src/tools/experimental-tool-gates/evaluation.ts
@@ -124,13 +124,17 @@ export function buildTmuxBridgeGateErrorMessage(reason: TmuxBridgeGateReason): s
   switch (reason) {
     case "missing_bridge_url":
       return (
-        `Tmux bridge is not reachable at the default URL (${DEFAULT_TMUX_BRIDGE_URL}), ` +
+        "Terminal access is not available right now. " +
+        `Pi could not reach the tmux bridge at the default URL (${DEFAULT_TMUX_BRIDGE_URL}), ` +
         `and no URL override is configured (setting: ${TMUX_BRIDGE_URL_SETTING_KEY}).`
       );
     case "invalid_bridge_url":
-      return "Tmux bridge URL is invalid. Use a full URL like https://localhost:3341.";
+      return (
+        "Terminal access is not available because the tmux bridge URL is invalid. " +
+        "Use a full URL like https://localhost:3341."
+      );
     case "bridge_unreachable":
-      return "Tmux bridge is not reachable at the configured URL.";
+      return "Terminal access is not available right now because the tmux bridge is not reachable at the configured URL.";
   }
 }
 
@@ -138,12 +142,16 @@ export function buildPythonBridgeGateErrorMessage(reason: PythonBridgeGateReason
   switch (reason) {
     case "missing_bridge_url":
       return (
-        `Python bridge is not reachable at the default URL (${DEFAULT_PYTHON_BRIDGE_URL}), ` +
+        "Native Python is not available right now. " +
+        `Pi could not reach the Python bridge at the default URL (${DEFAULT_PYTHON_BRIDGE_URL}), ` +
         `and no URL override is configured (setting: ${PYTHON_BRIDGE_URL_SETTING_KEY}).`
       );
     case "invalid_bridge_url":
-      return "Python bridge URL is invalid. Use a full URL like https://localhost:3340.";
+      return (
+        "Native Python is not available because the Python bridge URL is invalid. " +
+        "Use a full URL like https://localhost:3340."
+      );
     case "bridge_unreachable":
-      return "Python bridge is not reachable at the configured URL.";
+      return "Native Python is not available right now because the Python bridge is not reachable at the configured URL.";
   }
 }

--- a/src/tools/libreoffice-convert.ts
+++ b/src/tools/libreoffice-convert.ts
@@ -366,7 +366,12 @@ function shouldAttachPythonBridgeSkillHint(message: string): boolean {
     || normalized.includes("python-bridge-url")
     || normalized.includes("bridge url")
     || normalized.includes("missing_bridge_url")
-    || normalized.includes("bridge");
+    || normalized.includes("bridge unavailable")
+    || normalized.includes("bridge request")
+    || normalized.includes("failed to fetch")
+    || normalized.includes("fetch failed")
+    || normalized.includes("network request failed")
+    || normalized.includes("econnrefused");
 }
 
 export function createLibreOfficeConvertTool(

--- a/src/tools/python-run.ts
+++ b/src/tools/python-run.ts
@@ -394,10 +394,16 @@ function shouldAttachPythonBridgeSkillHint(message: string): boolean {
   const normalized = message.toLowerCase();
 
   return normalized.includes("python bridge")
+    || normalized.includes("python-bridge-url")
     || normalized.includes("bridge url")
     || normalized.includes("no_python_runtime")
     || normalized.includes("webassembly workers")
-    || normalized.includes("bridge");
+    || normalized.includes("bridge unavailable")
+    || normalized.includes("bridge request")
+    || normalized.includes("failed to fetch")
+    || normalized.includes("fetch failed")
+    || normalized.includes("network request failed")
+    || normalized.includes("econnrefused");
 }
 
 export function shouldFallbackToPyodideAfterBridgeError(

--- a/src/tools/python-transform-range.ts
+++ b/src/tools/python-transform-range.ts
@@ -396,10 +396,16 @@ function shouldAttachPythonBridgeSkillHint(message: string): boolean {
   const normalized = message.toLowerCase();
 
   return normalized.includes("python bridge")
+    || normalized.includes("python-bridge-url")
     || normalized.includes("bridge url")
     || normalized.includes("no_python_runtime")
     || normalized.includes("webassembly workers")
-    || normalized.includes("bridge");
+    || normalized.includes("bridge unavailable")
+    || normalized.includes("bridge request")
+    || normalized.includes("failed to fetch")
+    || normalized.includes("fetch failed")
+    || normalized.includes("network request failed")
+    || normalized.includes("econnrefused");
 }
 
 export function createPythonTransformRangeTool(

--- a/src/tools/tmux.ts
+++ b/src/tools/tmux.ts
@@ -574,7 +574,12 @@ function shouldAttachTmuxBridgeSkillHint(message: string): boolean {
     || normalized.includes("tmux-bridge-url")
     || normalized.includes("bridge url")
     || normalized.includes("missing_bridge_url")
-    || normalized.includes("bridge");
+    || normalized.includes("bridge unavailable")
+    || normalized.includes("bridge request")
+    || normalized.includes("failed to fetch")
+    || normalized.includes("fetch failed")
+    || normalized.includes("network request failed")
+    || normalized.includes("econnrefused");
 }
 
 export function createTmuxTool(

--- a/src/ui/bridge-setup-card.ts
+++ b/src/ui/bridge-setup-card.ts
@@ -331,6 +331,8 @@ export function mountBridgeSetupCard(
 
   const status = document.createElement("span");
   status.className = "pi-bridge-setup__status";
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
 
   let checking = false;
 

--- a/src/ui/web-search-setup-card.ts
+++ b/src/ui/web-search-setup-card.ts
@@ -120,6 +120,8 @@ function createProxyStep(options: ProxyStepOptions): HTMLDivElement {
 
   const status = document.createElement("span");
   status.className = "pi-search-setup__status";
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
 
   let checking = false;
 
@@ -205,6 +207,8 @@ function createKeyStep(
 
   const status = document.createElement("span");
   status.className = "pi-search-setup__status";
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
 
   let saving = false;
 

--- a/tests/bridge-setup-card.test.ts
+++ b/tests/bridge-setup-card.test.ts
@@ -24,7 +24,7 @@ void test("shows tmux setup card for tmux bridge gate failures", () => {
     kind: "tmux_bridge",
     ok: false,
     action: "capture_pane",
-    error: "Tmux bridge is not reachable at the configured URL.",
+    error: "Terminal access is not available right now because the tmux bridge is not reachable at the configured URL.",
     gateReason: "bridge_unreachable",
     skillHint: "tmux-bridge",
   };
@@ -44,7 +44,7 @@ void test("uses bridge URL from details when testing tmux setup", () => {
     ok: false,
     action: "list_sessions",
     bridgeUrl: "https://localhost:4441",
-    error: "Tmux bridge is not reachable at the configured URL.",
+    error: "Terminal access is not available right now because the tmux bridge is not reachable at the configured URL.",
     gateReason: "bridge_unreachable",
     skillHint: "tmux-bridge",
   };
@@ -59,7 +59,7 @@ void test("does not probe default URL when tmux bridge setting is invalid", asyn
     kind: "tmux_bridge",
     ok: false,
     action: "list_sessions",
-    error: "Tmux bridge URL is invalid. Use a full URL like https://localhost:3341.",
+    error: "Terminal access is not available because the tmux bridge URL is invalid. Use a full URL like https://localhost:3341.",
     gateReason: "invalid_bridge_url",
     skillHint: "tmux-bridge",
   };
@@ -102,7 +102,7 @@ void test("shows python setup card for libreoffice bridge outages", () => {
     ok: false,
     action: "convert",
     bridgeUrl: "https://localhost:4450",
-    error: "Python bridge is not reachable at the configured URL.",
+    error: "Native Python is not available right now because the Python bridge is not reachable at the configured URL.",
     gateReason: "bridge_unreachable",
     skillHint: "python-bridge",
   };
@@ -118,7 +118,7 @@ void test("shows setup card for transform-range gate failures", () => {
   const details: PythonTransformRangeDetails = {
     kind: "python_transform_range",
     blocked: false,
-    error: "Python bridge is not reachable at the configured URL.",
+    error: "Native Python is not available right now because the Python bridge is not reachable at the configured URL.",
     gateReason: "bridge_unreachable",
     skillHint: "python-bridge",
   };
@@ -149,7 +149,7 @@ void test("testBridgeSetupConnection probes the resolved URL", async () => {
     ok: false,
     action: "run_python",
     bridgeUrl: "https://localhost:5540",
-    error: "Python bridge is not reachable at the configured URL.",
+    error: "Native Python is not available right now because the Python bridge is not reachable at the configured URL.",
     gateReason: "bridge_unreachable",
     skillHint: "python-bridge",
   };

--- a/tests/experimental-tool-gates.test.ts
+++ b/tests/experimental-tool-gates.test.ts
@@ -99,6 +99,7 @@ void test("keeps tmux tool registered and returns structured gate errors", async
   });
 
   const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+  assert.match(text, /Terminal access is not available/i);
   assert.match(text, /default URL|URL override/i);
   assert.match(text, /Skill: tmux-bridge/i);
 
@@ -135,6 +136,7 @@ void test("tmux hard gate re-checks execution on every call", async () => {
 
   const missingResult = await gatedTmux.execute("call-2", {});
   const missingText = missingResult.content[0]?.type === "text" ? missingResult.content[0].text : "";
+  assert.match(missingText, /Terminal access is not available/i);
   assert.match(missingText, /default URL|URL override/i);
   assert.match(missingText, /Skill: tmux-bridge/i);
   const missingDetails: unknown = missingResult.details;
@@ -147,6 +149,7 @@ void test("tmux hard gate re-checks execution on every call", async () => {
 
   const unreachableResult = await gatedTmux.execute("call-3", {});
   const unreachableText = unreachableResult.content[0]?.type === "text" ? unreachableResult.content[0].text : "";
+  assert.match(unreachableText, /Terminal access is not available/i);
   assert.match(unreachableText, /not reachable/i);
   assert.match(unreachableText, /Skill: tmux-bridge/i);
   const unreachableDetails: unknown = unreachableResult.details;
@@ -172,6 +175,7 @@ void test("evaluateTmuxBridgeGate reports explicit reason codes", async () => {
 
   assert.equal(unreachable.allowed, false);
   assert.equal(unreachable.reason, "bridge_unreachable");
+  assert.match(buildTmuxBridgeGateErrorMessage(unreachable.reason), /Terminal access is not available/i);
   assert.match(buildTmuxBridgeGateErrorMessage(unreachable.reason), /not reachable/i);
 });
 
@@ -354,6 +358,7 @@ void test("python fallback tools return structured gate errors when configured b
 
   const result = await pythonTool.execute("call-python-unreachable", { code: "print('hi')" });
   const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+  assert.match(text, /Native Python is not available/i);
   assert.match(text, /not reachable/i);
   assert.match(text, /Skill: python-bridge/i);
 
@@ -381,6 +386,7 @@ void test("python_transform_range gate errors keep transform detail kind", async
     code: "result = [[1], [2]]",
   });
   const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+  assert.match(text, /Native Python is not available/i);
   assert.match(text, /not reachable/i);
   assert.match(text, /Skill: python-bridge/i);
 
@@ -409,6 +415,7 @@ void test("libreoffice_convert still requires configured + reachable bridge", as
     target_format: "csv",
   });
   const missingText = missingResult.content[0]?.type === "text" ? missingResult.content[0].text : "";
+  assert.match(missingText, /Native Python is not available/i);
   assert.match(missingText, /default URL|URL override|not configured/i);
   assert.match(missingText, /Skill: python-bridge/i);
 
@@ -430,6 +437,7 @@ void test("libreoffice_convert still requires configured + reachable bridge", as
     target_format: "csv",
   });
   const unreachableText = unreachableResult.content[0]?.type === "text" ? unreachableResult.content[0].text : "";
+  assert.match(unreachableText, /Native Python is not available/i);
   assert.match(unreachableText, /not reachable/i);
   assert.match(unreachableText, /Skill: python-bridge/i);
 
@@ -545,6 +553,7 @@ void test("evaluatePythonBridgeGate reports explicit reason codes", async () => 
 
   assert.equal(unreachable.allowed, false);
   assert.equal(unreachable.reason, "bridge_unreachable");
+  assert.match(buildPythonBridgeGateErrorMessage(unreachable.reason), /Native Python is not available/i);
   assert.match(buildPythonBridgeGateErrorMessage(unreachable.reason), /not reachable/i);
 });
 
@@ -553,7 +562,7 @@ void test("bridge gate helper detects only gate-shaped bridge details", () => {
     kind: "python_bridge",
     ok: false,
     action: "run_python",
-    error: "Python bridge is not reachable at the configured URL.",
+    error: "Native Python is not available right now because the Python bridge is not reachable at the configured URL.",
     gateReason: "bridge_unreachable",
     skillHint: "python-bridge",
   };

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -296,6 +296,8 @@ void test("system prompt renders Local Services for both bridges not running", (
   assert.match(prompt, /## Local Services/);
   assert.match(prompt, /Probed at session start/);
   assert.match(prompt, /use the skills tool to read the referenced skill before responding/);
+  assert.match(prompt, /tool result includes `Skill: <name>`/);
+  assert.match(prompt, /Do not guess platform-specific install commands/);
   assert.match(prompt, /\*\*Python \(native\)\:\*\* not running/);
   assert.match(prompt, /Pyodide/);
   assert.match(prompt, /read skill "python-bridge"/);


### PR DESCRIPTION
## Summary
Follow-up polish for bridge UX after #450/#451 review feedback.

### Agent guidance + messaging
- strengthen `## Local Services` prompt rules to explicitly require skill lookup on bridge failures signaled by `Skill: <name>` / `details.skillHint`
- add explicit guardrail: do not guess platform install commands
- reframe gate error copy to user-benefit-first language:
  - `tmux`: "Terminal access is not available..."
  - `python/libreoffice`: "Native Python is not available..."

### Error hint precision
- tighten bridge skill-hint heuristics in tool catch paths by removing broad `includes("bridge")` catch-all and using explicit bridge/network signatures

### Accessibility
- add `role="status"` + `aria-live="polite"` to dynamic status text in:
  - `src/ui/bridge-setup-card.ts`
  - `src/ui/web-search-setup-card.ts`

### Documentation
- update `src/tools/DECISIONS.md` to document gate-failure contract:
  - structured `AgentToolResult` return with `gateReason` + `skillHint` (no thrown gate errors)

## Testing
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/system-prompt.test.ts tests/experimental-tool-gates.test.ts tests/bridge-setup-card.test.ts tests/python-run-tool.test.ts tests/python-transform-range-tool.test.ts tests/tmux-tool.test.ts tests/libreoffice-convert-tool.test.ts`
- `npm run check`
- `npm run build`
- `npm run test:context`
