### PR TITLE
chore(release): bump to v0.9.0-pre with notes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This folder contains **current** docs that should match shipped behavior.
 ## Guides
 - [Install Pi for Excel](./install.md)
 - [Deploy hosted build on Vercel](./deploy-vercel.md)
-- [Release notes (`v0.8.0-pre`)](./release-notes/v0.8.0-pre.md)
+- [Release notes (`v0.9.0-pre`)](./release-notes/v0.9.0-pre.md)
 - [Release smoke test checklist](./release-smoke-test-checklist.md)
 - [Release smoke run logs](./release-smoke-runs/README.md)
 

--- a/docs/release-notes/v0.9.0-pre.md
+++ b/docs/release-notes/v0.9.0-pre.md
@@ -1,0 +1,55 @@
+# v0.9.0-pre release notes
+
+_Pre-release. Changes since `v0.8.0-pre`._
+
+## Snapshot since last release
+
+- Previous release tag: `v0.8.0-pre` (`ba33117`, 2026-02-16)
+- This release includes **75 first-parent commits** (**72 merged PRs**) on `main`
+
+## Highlights
+
+- **Bridge setup UX is now first-class and self-healing**
+  - Added `## Local Services` prompt context with bridge health state at session start (#447)
+  - Added inline setup cards for Python/tmux bridge failures in chat (#451)
+  - Bridge gate failures now return structured tool results (`gateReason`, `skillHint`) instead of throws (#450)
+  - Tightened setup guidance and a11y announcements (`aria-live`) for setup status regions (#452)
+
+- **Connections got safer and more deterministic**
+  - Added extension connection contract + preflight path, plus `/tools → Connections` UX (#421, #426)
+  - Migrated web-search keys + MCP tokens into connection storage flows (#432, #433)
+  - Hardened auth-error redaction and rollback behavior on metadata/token persistence failures (#435, #440)
+  - Added proactive setup guidance tests and follow-up hardening for extension connection refresh paths (#430, #437)
+
+- **Context + model behavior became more cache-stable**
+  - Added prefix-churn observability counters and baseline/runbook docs (#431, #439)
+  - Reduced unnecessary runtime/tool refresh churn with no-op skips + revision tracking (#425, #436, #446)
+  - Preserved full tool disclosure for prompt-cache continuity (#423)
+  - Model-switch behavior now defaults to **in-place** for active sessions, with fork kept as opt-in (#443)
+
+- **Web search and external integrations improved**
+  - Added inline setup card UX for web search failures (#416)
+  - Added Firecrawl provider and tightened Jina provider behavior (API key required) (#413)
+  - Improved proxy-down error guidance for `web_search`, `fetch_page`, and MCP paths (#396, #398)
+
+- **Broad UX reliability polish**
+  - Improved streaming auto-follow behavior and reduced status-tooltip jitter (#397, #401, #403, #408)
+  - Improved abort UX and preserved draft recovery (`Alt+Up`) after aborts (#407, #418)
+  - Disabled accidental dollar-delimited math parsing in markdown rendering (#405)
+  - Continued UI consistency polish (icons, status/footer structure, copy cleanup) (#402, #404)
+
+## Platform, security, and maintainer updates
+
+- Fixed Office WebView CSP compatibility by stubbing Ajv unsafe-eval paths and follow-up bridge diagnostics hardening (#364, #366)
+- Upgraded lint/tooling baseline to ESLint 10 and aligned Node engine constraints (#385, #386)
+- Refreshed Pi model registry/dependencies to `0.54.0` and added lockstep automation in CI (#387, #388)
+
+## Notes
+
+- This is a **minor pre-release bump** due breadth of shipped UX/runtime changes since `v0.8.0-pre`.
+- Recommended validation before broader rollout:
+  - `npm run check`
+  - `npm run build`
+  - `npm run test:models`
+  - `npm run test:context`
+  - `npm run test:security`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-for-excel",
-  "version": "0.8.0-pre",
+  "version": "0.9.0-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-for-excel",
-      "version": "0.8.0-pre",
+      "version": "0.9.0-pre",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel",
-  "version": "0.8.0-pre",
+  "version": "0.9.0-pre",
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -5,4 +5,4 @@
  */
 
 export const APP_NAME = "pi-for-excel";
-export const APP_VERSION = "0.8.0-pre";
+export const APP_VERSION = "0.9.0-pre";


### PR DESCRIPTION
## Summary
Release prep bump from `v0.8.0-pre` → `v0.9.0-pre`.

### What changed
- bumped app version:
  - `package.json`
  - `package-lock.json`
  - `src/app/metadata.ts`
- added new release notes:
  - `docs/release-notes/v0.9.0-pre.md`
- updated docs index to point to latest release notes:
  - `docs/README.md`

### Release notes scope
`docs/release-notes/v0.9.0-pre.md` summarizes changes since `v0.8.0-pre` (`ba33117`):
- 75 first-parent commits / 72 merged PRs
- bridge/local services setup UX improvements
- connection store migrations + connection hardening
- context/cache observability + refresh churn reductions
- model switch behavior update (in-place default)
- web-search/proxy guidance improvements
- platform/tooling/security updates

## Validation
- `npm run check`
- `npm run build`
- `npm run test:models`
- `npm run test:context`
- `npm run test:security`
