### PR TITLE
feat: prefer GPT-5.4 for OpenAI defaults

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,8 +1,8 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-02-20
+**Last verified:** 2026-03-06
 
-This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.3-codex`, `claude-opus-4-6`).
+This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.4`, `gpt-5.3-codex`, `claude-opus-4-6`).
 
 This doc describes how to update:
 - the **Pi dependency versions** we ship (`@mariozechner/pi-ai`, `@mariozechner/pi-web-ui`, `@mariozechner/pi-agent-core`)
@@ -65,6 +65,7 @@ npm install
 Search the local registry:
 
 ```bash
+rg -n "gpt-5\\.4"       node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 rg -n "gpt-5\\.3-codex" node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 rg -n "claude-opus-4-6"  node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 ```
@@ -93,21 +94,23 @@ We intentionally avoid pinning exact versioned IDs now. Instead we:
   - **Anthropic:** latest **Sonnet** *if* its version >= latest **Opus**, then latest **Opus**
     - Version compare uses `parseMajorMinor()` where `claude-opus-4-5` → `45`, `claude-opus-4-6` → `46`.
     - Important: IDs like `claude-opus-4-20250514` are treated as **major only** (`40`) and the `YYYYMMDD` part is considered a separate date suffix by `modelRecencyScore()`.
-  - **OpenAI Codex:** latest `gpt-5.x-codex`, then latest `gpt-5.x`
-    - `gpt-5.3-codex` scores as `53`.
+  - **OpenAI (`openai` + `openai-codex`):** latest general `gpt-5.x` *if* its version >= latest `gpt-5.x-codex`, then latest Codex
+    - `gpt-5.4` scores as `54`; `gpt-5.3-codex` scores as `53`.
+    - Plain `gpt-5.x` beats same-version suffixed variants (`gpt-5.4` before `gpt-5.4-pro`).
   - **Google (API key):** latest `gemini-*-pro*` (regex: `/^gemini-.*-pro/i`)
   - **Google OAuth providers (`google-gemini-cli`, `google-antigravity`):** prefer stable Gemini before previews
 
   The ordering logic is driven by:
   - `providerPriority()` (Anthropic → OpenAI Codex → OpenAI → Google → …)
-  - `familyPriority()` (Opus/Sonnet/Haiku, Codex vs non-Codex, etc.)
-  - `parseMajorMinor()` + `modelRecencyScore()` (treats `4-6` as `46`, `5.3` as `53`, and keeps `YYYYMMDD` as a separate date suffix)
+  - `familyPriority()` / `openAiFamilyPriority()` (Opus/Sonnet/Haiku, GPT vs Codex, etc.)
+  - `parseMajorMinor()` + `modelRecencyScore()` (treats `4-6` as `46`, `5.4` as `54`, and keeps `YYYYMMDD` as a separate date suffix)
   - `compareModels()` (provider + family + recency tie-breaks; deterministic sorting)
 
   UI: the model picker is opened from the footer status bar (click the π model button).
 
-- Pick the default model via pattern rules:
+- Pick the default model via provider-aware rules:
   - Anthropic is a small special-case (Sonnet when version ties or is newer than Opus; version compare uses `parseMajorMinor`)
+  - OpenAI (`openai` + `openai-codex`) prefers the newest general GPT-5 when it is at least as new as Codex, with Codex as fallback
   - otherwise `DEFAULT_MODEL_RULES` + `pickLatestMatchingModel()` (uses `getModels(provider)` to find the newest available ID)
 
 When new models ship, this usually “just works” as long as naming stays consistent. You only need to update these rules if:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
-        "@mariozechner/pi-agent-core": "^0.55.3",
-        "@mariozechner/pi-ai": "^0.55.3",
-        "@mariozechner/pi-web-ui": "^0.55.3",
+        "@mariozechner/pi-agent-core": "^0.56.2",
+        "@mariozechner/pi-ai": "^0.56.2",
+        "@mariozechner/pi-web-ui": "^0.56.2",
         "@sinclair/typebox": "^0.34.41",
         "lit": "^3.2.1",
-        "marked": "^17.0.3"
+        "marked": "^17.0.4"
       },
       "devDependencies": {
         "@types/office-js": "^1.0.580",
@@ -3170,32 +3170,32 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.55.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.55.3.tgz",
-      "integrity": "sha512-rqbfpQ9BrP6BDiW+Ps3A8Z/p9+Md/pAfc/ECq8JP6cwnZL/jQgU355KWZKtF8zM9az1p0Q9hIWi9cQygVo6Auw==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.56.2.tgz",
+      "integrity": "sha512-jpE5MosroL0Lk7UiJX7GY0qpkhibiZORZviGUiGfoIK25fa+ToLYwmErRYKpmj44wc7G1IMdQujr6f65FAkBGA==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.55.3"
+        "@mariozechner/pi-ai": "^0.56.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.55.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.55.3.tgz",
-      "integrity": "sha512-f9jWoDzJR9Wy/H8JPMbjoM4WvVUeFZ65QdYA9UHIfoOopDfwWE8F8JHQOj5mmmILMacXuzsqA3J7MYqNWZRvvQ==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.56.2.tgz",
+      "integrity": "sha512-7cPhumqo/Ke7W4Lng5RyGmBWuhK0G9Z7JVfTl00m11snk5G+MYtNeqpi7VHZ5yW1K0DLsTAY9Mi2KLghaFImiA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
         "@aws-sdk/client-bedrock-runtime": "^3.983.0",
         "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.10.0",
+        "@mistralai/mistralai": "1.14.1",
         "@sinclair/typebox": "^0.34.41",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "chalk": "^5.6.2",
-        "openai": "6.10.0",
+        "openai": "6.26.0",
         "partial-json": "^0.1.7",
         "proxy-agent": "^6.5.0",
         "undici": "^7.19.1",
@@ -3229,20 +3229,22 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.55.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.55.3.tgz",
-      "integrity": "sha512-Gh4wkYgiSPCJJaB/4wEWSL7Ga8bxSq1Crp1RPRT4vKybE/DG0W/MQr5VJDvktarxtJrD16ixScwE4dzdox/PIA==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.56.2.tgz",
+      "integrity": "sha512-UsbJNeyRnUqEp5AOCxNB/1EOCSN4ZpA/Irbbu1DLCzBPPGMrQnSp9mcFcuwqzw/t2P7VqGxY4n0hGkiAKbvgpQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
         "get-east-asian-width": "^1.3.0",
-        "koffi": "^2.9.0",
         "marked": "^15.0.12",
         "mime-types": "^3.0.1"
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
       }
     },
     "node_modules/@mariozechner/pi-tui/node_modules/marked": {
@@ -3258,14 +3260,14 @@
       }
     },
     "node_modules/@mariozechner/pi-web-ui": {
-      "version": "0.55.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.55.3.tgz",
-      "integrity": "sha512-c/lcc3yFSh/fNB03M1WANI/dXNQz0HBenceuplVVkmZUWkZHjhT8NS7sL+X2MV6sgv42kFLfmxYTC94RRI0yKA==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.56.2.tgz",
+      "integrity": "sha512-64qtw7XS+4fsCnO6r3TNaoI6GK/pcgv5nc5+BL0/inDKTjMBGYxkxHXZW25B0bi+UVjU4SavtQY40/4fnb1yeg==",
       "license": "MIT",
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
-        "@mariozechner/pi-ai": "^0.55.3",
-        "@mariozechner/pi-tui": "^0.55.3",
+        "@mariozechner/pi-ai": "^0.56.2",
+        "@mariozechner/pi-tui": "^0.56.2",
         "docx-preview": "^0.3.7",
         "jszip": "^3.10.1",
         "lucide": "^0.544.0",
@@ -3886,21 +3888,13 @@
       }
     },
     "node_modules/@mistralai/mistralai": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.10.0.tgz",
-      "integrity": "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
       "dependencies": {
-        "zod": "^3.20.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.24.1"
-      }
-    },
-    "node_modules/@mistralai/mistralai/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -7609,10 +7603,22 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
+      "integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
       "funding": [
         {
           "type": "github",
@@ -7621,6 +7627,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -9198,6 +9205,7 @@
       "integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://liberapay.com/Koromix"
       }
@@ -9395,9 +9403,9 @@
       "license": "ISC"
     },
     "node_modules/marked": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
-      "integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+      "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -10691,9 +10699,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.10.0.tgz",
-      "integrity": "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -12158,9 +12166,9 @@
       "peer": true
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -12524,9 +12532,9 @@
       "peer": true
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -13043,7 +13051,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@mariozechner/pi-agent-core": "^0.55.3",
-    "@mariozechner/pi-ai": "^0.55.3",
-    "@mariozechner/pi-web-ui": "^0.55.3",
+    "@mariozechner/pi-agent-core": "^0.56.2",
+    "@mariozechner/pi-ai": "^0.56.2",
+    "@mariozechner/pi-web-ui": "^0.56.2",
     "@sinclair/typebox": "^0.34.41",
     "lit": "^3.2.1",
-    "marked": "^17.0.3"
+    "marked": "^17.0.4"
   },
   "devDependencies": {
     "@types/office-js": "^1.0.580",
@@ -63,6 +63,9 @@
     "axios": "1.13.5",
     "minimatch": "10.2.4",
     "rollup": "4.59.0",
-    "basic-ftp": "5.2.0"
+    "basic-ftp": "5.2.0",
+    "underscore": "1.13.8",
+    "tar": "7.5.10",
+    "fast-xml-parser": "5.4.2"
   }
 }

--- a/src/auth/google-browser-oauth-core.ts
+++ b/src/auth/google-browser-oauth-core.ts
@@ -7,7 +7,7 @@ import type {
   OAuthLoginCallbacks,
   OAuthProviderInterface,
 } from "@mariozechner/pi-ai";
-import { generatePKCE } from "@mariozechner/pi-ai/dist/utils/oauth/pkce.js";
+import { generatePKCE } from "./pkce.js";
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";

--- a/src/auth/oauth-provider-registry.ts
+++ b/src/auth/oauth-provider-registry.ts
@@ -1,15 +1,17 @@
 /**
  * Minimal OAuth provider registry for the Excel taskpane.
  *
- * We intentionally avoid importing `@mariozechner/pi-ai`'s OAuth index, which
- * registers CLI-only providers (Google Antigravity / Gemini CLI) that pull in
- * Node-only modules (e.g. `http`) and bloat browser bundles.
+ * pi-ai 0.56+ exposes OAuth providers via the public `@mariozechner/pi-ai/oauth`
+ * subpath instead of package-internal deep imports. We still curate our own
+ * registry here so the taskpane can substitute browser-safe Google/OpenAI flows.
  */
 
 import type { OAuthProviderInterface } from "@mariozechner/pi-ai";
 
-import { anthropicOAuthProvider } from "@mariozechner/pi-ai/dist/utils/oauth/anthropic.js";
-import { githubCopilotOAuthProvider } from "@mariozechner/pi-ai/dist/utils/oauth/github-copilot.js";
+import {
+  anthropicOAuthProvider,
+  githubCopilotOAuthProvider,
+} from "@mariozechner/pi-ai/oauth";
 
 import { openaiCodexBrowserOAuthProvider } from "./openai-codex-browser-oauth.js";
 import {

--- a/src/auth/openai-codex-browser-oauth.ts
+++ b/src/auth/openai-codex-browser-oauth.ts
@@ -13,7 +13,7 @@ import type {
   OAuthLoginCallbacks,
   OAuthProviderInterface,
 } from "@mariozechner/pi-ai";
-import { generatePKCE } from "@mariozechner/pi-ai/dist/utils/oauth/pkce.js";
+import { generatePKCE } from "./pkce.js";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";

--- a/src/auth/pkce.ts
+++ b/src/auth/pkce.ts
@@ -1,0 +1,30 @@
+/**
+ * Browser-safe PKCE utilities.
+ *
+ * Kept local so we do not depend on pi-ai package-internal deep imports.
+ */
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+export async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64urlEncode(verifierBytes);
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const challenge = base64urlEncode(new Uint8Array(hashBuffer));
+
+  return { verifier, challenge };
+}

--- a/src/compat/model-selector-patch.ts
+++ b/src/compat/model-selector-patch.ts
@@ -86,7 +86,8 @@ export function installModelSelectorPatch(): void {
     // - keep current model at the very top
     // - then show "featured" models (latest per provider, pattern-based)
     //   - Anthropic: latest Sonnet if its version >= latest Opus, then latest Opus
-    //   - OpenAI Codex: latest gpt-5.x-codex, then latest gpt-5.x
+    //   - OpenAI (API + ChatGPT): latest GPT-5 when its version >= latest Codex,
+    //     then latest Codex
     //   - Google API-key: latest gemini-*-pro*
     //   - Google OAuth (Gemini CLI / Antigravity): prefer stable Gemini before previews
     // - then show the remaining models, sorted deterministically
@@ -144,6 +145,29 @@ export function installModelSelectorPatch(): void {
       );
     };
 
+    const pickBestOpenAi = (
+      models: ModelSelectorItem[],
+      filter: (m: ModelSelectorItem) => boolean,
+    ): ModelSelectorItem | null => {
+      const list = models.filter(filter);
+      if (!list.length) return null;
+      return (
+        list
+          .slice()
+          .sort((a, b) => {
+            const aRec = modelRecencyScore(a.id);
+            const bRec = modelRecencyScore(b.id);
+            if (aRec !== bRec) return bRec - aRec;
+
+            const aFam = familyPriority(a.provider, a.id);
+            const bFam = familyPriority(b.provider, b.id);
+            if (aFam !== bFam) return aFam - bFam;
+
+            return a.id.localeCompare(b.id);
+          })[0] ?? null
+      );
+    };
+
     const featured: ModelSelectorItem[] = [];
     for (const provider of providers) {
       const models = byProvider.get(provider);
@@ -180,16 +204,34 @@ export function installModelSelectorPatch(): void {
         continue;
       }
 
-      if (provider === "openai-codex") {
-        const bestCodex = pickBestByRecency(models, (m) => /^gpt-5\.(\d+)-codex$/.test(m.id));
-        const bestGpt5 = pickBestByRecency(
+      if (provider === "openai-codex" || provider === "openai") {
+        const bestCodex = pickBestOpenAi(
+          models,
+          (m) => /^gpt-5\.(\d+)-codex(?:-|$)/.test(m.id),
+        );
+        const bestGpt5 = pickBestOpenAi(
           models,
           (m) => /^gpt-5\./.test(m.id) && !/codex/.test(m.id),
         );
 
-        if (bestCodex) featured.push(bestCodex);
-        if (bestGpt5) featured.push(bestGpt5);
-        if (bestCodex || bestGpt5) continue;
+        if (bestCodex && bestGpt5) {
+          if (parseMajorMinor(bestGpt5.id) >= parseMajorMinor(bestCodex.id)) {
+            featured.push(bestGpt5, bestCodex);
+            continue;
+          }
+          featured.push(bestCodex, bestGpt5);
+          continue;
+        }
+
+        if (bestGpt5) {
+          featured.push(bestGpt5);
+          continue;
+        }
+
+        if (bestCodex) {
+          featured.push(bestCodex);
+          continue;
+        }
 
         const best = pickBest(models);
         if (best) featured.push(best);

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -20,6 +20,21 @@ export function providerPriority(provider: string): number {
   return PROVIDER_ORDER[provider] ?? 999;
 }
 
+const OPENAI_CODEX_RE = /^gpt-5\.(\d+)-codex(?:-|$)/;
+const OPENAI_PLAIN_GPT_RE = /^gpt-5\.(\d+)$/;
+const OPENAI_GPT_RE = /^gpt-5\./;
+
+export function openAiFamilyPriority(id: string): number {
+  // Prefer the latest general GPT-5 model first, then other GPT-5 variants,
+  // then Codex-specialized variants, then older o-series fallbacks.
+  if (OPENAI_PLAIN_GPT_RE.test(id)) return 0;
+  if (OPENAI_GPT_RE.test(id) && !OPENAI_CODEX_RE.test(id)) return 1;
+  if (OPENAI_CODEX_RE.test(id)) return 2;
+  if (id.startsWith("gpt-")) return 3;
+  if (id.startsWith("o")) return 4;
+  return 9;
+}
+
 export function familyPriority(provider: string, id: string): number {
   if (provider === "anthropic") {
     if (id.startsWith("claude-opus-")) return 0;
@@ -29,10 +44,7 @@ export function familyPriority(provider: string, id: string): number {
   }
 
   if (provider === "openai-codex" || provider === "openai") {
-    if (id.includes("codex")) return 0;
-    if (id.startsWith("gpt-")) return 1;
-    if (id.startsWith("o")) return 2;
-    return 9;
+    return openAiFamilyPriority(id);
   }
 
   if (provider === "google" || provider === "google-gemini-cli" || provider === "google-antigravity") {

--- a/src/taskpane/default-model.ts
+++ b/src/taskpane/default-model.ts
@@ -4,7 +4,11 @@
 
 import { getModel, getModels, type Api, type Model } from "@mariozechner/pi-ai";
 
-import { modelRecencyScore, parseMajorMinor } from "../models/model-ordering.js";
+import {
+  modelRecencyScore,
+  openAiFamilyPriority,
+  parseMajorMinor,
+} from "../models/model-ordering.js";
 
 type DefaultProvider =
   | "openai-codex"
@@ -16,14 +20,6 @@ type DefaultProvider =
 type DefaultModelRule = { provider: DefaultProvider; match: RegExp };
 
 const DEFAULT_MODEL_RULES: DefaultModelRule[] = [
-  // Prefer latest GPT-5.x Codex on ChatGPT subscription (openai-codex)
-  { provider: "openai-codex", match: /^gpt-5\.(\d+)-codex$/ },
-  { provider: "openai-codex", match: /^gpt-5\./ },
-
-  // API key OpenAI provider (if user connected OpenAI instead of openai-codex)
-  { provider: "openai", match: /^gpt-5\.(\d+)-codex$/ },
-  { provider: "openai", match: /^gpt-5\./ },
-
   // Gemini defaults: Pro-ish first, then any Gemini
   { provider: "google", match: /^gemini-.*-pro/i },
   { provider: "google", match: /^gemini-/i },
@@ -46,8 +42,41 @@ const DEFAULT_MODEL_RULES: DefaultModelRule[] = [
 function pickLatestMatchingModel(provider: DefaultProvider, match: RegExp): Model<Api> | null {
   const models: Model<Api>[] = getModels(provider);
   const candidates = models.filter((m) => match.test(m.id));
-  candidates.sort((a, b) => modelRecencyScore(b.id) - modelRecencyScore(a.id));
+  candidates.sort((a, b) => {
+    const recency = modelRecencyScore(b.id) - modelRecencyScore(a.id);
+    if (recency !== 0) return recency;
+    return a.id.localeCompare(b.id);
+  });
   return candidates[0] ?? null;
+}
+
+function compareOpenAiCandidates(a: Model<Api>, b: Model<Api>): number {
+  const recency = modelRecencyScore(b.id) - modelRecencyScore(a.id);
+  if (recency !== 0) return recency;
+
+  const family = openAiFamilyPriority(a.id) - openAiFamilyPriority(b.id);
+  if (family !== 0) return family;
+
+  return a.id.localeCompare(b.id);
+}
+
+function pickPreferredOpenAiModel(provider: "openai-codex" | "openai"): Model<Api> | null {
+  const models: Model<Api>[] = getModels(provider);
+  const bestGpt = models
+    .filter((m) => /^gpt-5\./.test(m.id) && !/codex/.test(m.id))
+    .sort(compareOpenAiCandidates)[0];
+  const bestCodex = models
+    .filter((m) => /^gpt-5\.(\d+)-codex(?:-|$)/.test(m.id))
+    .sort(compareOpenAiCandidates)[0];
+
+  if (bestGpt && bestCodex) {
+    return parseMajorMinor(bestGpt.id) >= parseMajorMinor(bestCodex.id) ? bestGpt : bestCodex;
+  }
+
+  if (bestGpt) return bestGpt;
+  if (bestCodex) return bestCodex;
+
+  return models.slice().sort(compareOpenAiCandidates)[0] ?? null;
 }
 
 export function pickDefaultModel(
@@ -72,6 +101,15 @@ export function pickDefaultModel(
 
     if (opus) return opus;
     if (sonnet) return sonnet;
+  }
+
+  // OpenAI special-case:
+  // Prefer the newest general GPT-5 model when it is at least as new as Codex
+  // (e.g. GPT-5.4 over GPT-5.3 Codex), while keeping Codex as fallback.
+  for (const provider of ["openai-codex", "openai"] as const) {
+    if (!availableProviders.includes(provider)) continue;
+    const model = pickPreferredOpenAiModel(provider);
+    if (model) return model;
   }
 
   // Other providers: pattern-based rules

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import {
   compareModels,
   modelRecencyScore,
+  openAiFamilyPriority,
   parseMajorMinor,
   providerPriority,
 } from "../src/models/model-ordering.ts";
@@ -30,6 +31,11 @@ void test("parseMajorMinor handles dot-style versions", () => {
 
 void test("parseMajorMinor supports 2-digit minors (e.g. 5.12)", () => {
   assert.equal(parseMajorMinor("gpt-5.12"), 512);
+});
+
+void test("openAiFamilyPriority prefers base GPT-5 over Codex variants", () => {
+  assert.ok(openAiFamilyPriority("gpt-5.4") < openAiFamilyPriority("gpt-5.4-pro"));
+  assert.ok(openAiFamilyPriority("gpt-5.4-pro") < openAiFamilyPriority("gpt-5.3-codex"));
 });
 
 void test("modelRecencyScore prefers higher version, then later date suffix", () => {
@@ -72,6 +78,18 @@ void test("compareModels sorts by provider, family, then recency", () => {
 
   // Sanity: providerPriority is stable
   assert.ok(providerPriority("anthropic") < providerPriority("openai"));
+});
+
+void test("openai compareModels prefers GPT-5 over older Codex variants", () => {
+  const models = [
+    { provider: "openai", id: "gpt-5.3-codex" },
+    { provider: "openai", id: "gpt-5.4" },
+    { provider: "openai", id: "gpt-5.4-pro" },
+  ];
+
+  models.sort(compareModels);
+
+  assert.deepEqual(models.map((m) => m.id), ["gpt-5.4", "gpt-5.4-pro", "gpt-5.3-codex"]);
 });
 
 void test("provider-map keeps openai-codex distinct from openai", () => {


### PR DESCRIPTION
## Summary
- bump the Pi stack to `0.56.2` and pull in `marked@17.0.4`
- prefer `gpt-5.4` over older Codex variants in OpenAI default/model-picker ordering
- switch OAuth imports to supported pi-ai public entrypoints and keep PKCE local to avoid deep-import breakage
- add safe overrides for `underscore`, `tar`, and `fast-xml-parser` so audit is clean
- refresh the model update playbook for the new OpenAI behavior

## Why
We wanted to add GPT-5.4 to the available model list and make it the default/top OpenAI choice in the relevant UI. The latest Pi registry includes `gpt-5.4`, but the app was still effectively centering `gpt-5.3-codex`.

## Validation
- `npm run check`
- `npm run build`
- `npm run test:models`
- `npm run test:security`
- `npm audit --audit-level=high`
- verified `pickDefaultModel(['openai'])` and `pickDefaultModel(['openai-codex'])` resolve to `gpt-5.4`

## Notes
- This supersedes the current Dependabot PRs for the Pi stack / marked bumps (#470, #471).
