### PR TITLE
refactor: centralize OpenAI model ordering

### DIFF
--- a/src/compat/model-selector-patch.ts
+++ b/src/compat/model-selector-patch.ts
@@ -13,10 +13,14 @@ import { ModelSelector } from "@mariozechner/pi-web-ui/dist/dialogs/ModelSelecto
 
 import {
   compareModels as compareModelRefs,
+  compareOpenAiModelIds,
   familyPriority,
+  isOpenAiCodexModelId,
+  isOpenAiGeneralGptModelId,
   modelRecencyScore,
   parseMajorMinor,
   providerPriority,
+  shouldPreferOpenAiGeneralModel,
 } from "../models/model-ordering.js";
 
 let _activeProviders: Set<string> | null = null;
@@ -151,21 +155,7 @@ export function installModelSelectorPatch(): void {
     ): ModelSelectorItem | null => {
       const list = models.filter(filter);
       if (!list.length) return null;
-      return (
-        list
-          .slice()
-          .sort((a, b) => {
-            const aRec = modelRecencyScore(a.id);
-            const bRec = modelRecencyScore(b.id);
-            if (aRec !== bRec) return bRec - aRec;
-
-            const aFam = familyPriority(a.provider, a.id);
-            const bFam = familyPriority(b.provider, b.id);
-            if (aFam !== bFam) return aFam - bFam;
-
-            return a.id.localeCompare(b.id);
-          })[0] ?? null
-      );
+      return list.slice().sort((a, b) => compareOpenAiModelIds(a.id, b.id))[0] ?? null;
     };
 
     const featured: ModelSelectorItem[] = [];
@@ -205,17 +195,11 @@ export function installModelSelectorPatch(): void {
       }
 
       if (provider === "openai-codex" || provider === "openai") {
-        const bestCodex = pickBestOpenAi(
-          models,
-          (m) => /^gpt-5\.(\d+)-codex(?:-|$)/.test(m.id),
-        );
-        const bestGpt5 = pickBestOpenAi(
-          models,
-          (m) => /^gpt-5\./.test(m.id) && !/codex/.test(m.id),
-        );
+        const bestCodex = pickBestOpenAi(models, (m) => isOpenAiCodexModelId(m.id));
+        const bestGpt5 = pickBestOpenAi(models, (m) => isOpenAiGeneralGptModelId(m.id));
 
         if (bestCodex && bestGpt5) {
-          if (parseMajorMinor(bestGpt5.id) >= parseMajorMinor(bestCodex.id)) {
+          if (shouldPreferOpenAiGeneralModel(bestGpt5.id, bestCodex.id)) {
             featured.push(bestGpt5, bestCodex);
             continue;
           }

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -24,12 +24,20 @@ const OPENAI_CODEX_RE = /^gpt-5\.(\d+)-codex(?:-|$)/;
 const OPENAI_PLAIN_GPT_RE = /^gpt-5\.(\d+)$/;
 const OPENAI_GPT_RE = /^gpt-5\./;
 
+export function isOpenAiCodexModelId(id: string): boolean {
+  return OPENAI_CODEX_RE.test(id);
+}
+
+export function isOpenAiGeneralGptModelId(id: string): boolean {
+  return OPENAI_GPT_RE.test(id) && !isOpenAiCodexModelId(id);
+}
+
 export function openAiFamilyPriority(id: string): number {
   // Prefer the latest general GPT-5 model first, then other GPT-5 variants,
   // then Codex-specialized variants, then older o-series fallbacks.
   if (OPENAI_PLAIN_GPT_RE.test(id)) return 0;
-  if (OPENAI_GPT_RE.test(id) && !OPENAI_CODEX_RE.test(id)) return 1;
-  if (OPENAI_CODEX_RE.test(id)) return 2;
+  if (isOpenAiGeneralGptModelId(id)) return 1;
+  if (isOpenAiCodexModelId(id)) return 2;
   if (id.startsWith("gpt-")) return 3;
   if (id.startsWith("o")) return 4;
   return 9;
@@ -110,10 +118,29 @@ export function modelRecencyScore(id: string): number {
   return majorMinor * 100_000_000 + date;
 }
 
+export function compareOpenAiModelIds(aId: string, bId: string): number {
+  const recency = modelRecencyScore(bId) - modelRecencyScore(aId);
+  if (recency !== 0) return recency;
+
+  const family = openAiFamilyPriority(aId) - openAiFamilyPriority(bId);
+  if (family !== 0) return family;
+
+  return aId.localeCompare(bId);
+}
+
+export function shouldPreferOpenAiGeneralModel(generalId: string, codexId: string): boolean {
+  return parseMajorMinor(generalId) >= parseMajorMinor(codexId);
+}
+
 export function compareModels(a: ModelRef, b: ModelRef): number {
   const aProv = providerPriority(a.provider);
   const bProv = providerPriority(b.provider);
   if (aProv !== bProv) return aProv - bProv;
+
+  if (a.provider === b.provider && (a.provider === "openai-codex" || a.provider === "openai")) {
+    // OpenAI is recency-first so newer Codex variants still outrank older GPT variants.
+    return compareOpenAiModelIds(a.id, b.id);
+  }
 
   const aFam = familyPriority(a.provider, a.id);
   const bFam = familyPriority(b.provider, b.id);

--- a/src/taskpane/default-model.ts
+++ b/src/taskpane/default-model.ts
@@ -5,9 +5,12 @@
 import { getModel, getModels, type Api, type Model } from "@mariozechner/pi-ai";
 
 import {
+  compareOpenAiModelIds,
+  isOpenAiCodexModelId,
+  isOpenAiGeneralGptModelId,
   modelRecencyScore,
-  openAiFamilyPriority,
   parseMajorMinor,
+  shouldPreferOpenAiGeneralModel,
 } from "../models/model-ordering.js";
 
 type DefaultProvider =
@@ -50,33 +53,23 @@ function pickLatestMatchingModel(provider: DefaultProvider, match: RegExp): Mode
   return candidates[0] ?? null;
 }
 
-function compareOpenAiCandidates(a: Model<Api>, b: Model<Api>): number {
-  const recency = modelRecencyScore(b.id) - modelRecencyScore(a.id);
-  if (recency !== 0) return recency;
-
-  const family = openAiFamilyPriority(a.id) - openAiFamilyPriority(b.id);
-  if (family !== 0) return family;
-
-  return a.id.localeCompare(b.id);
-}
-
 function pickPreferredOpenAiModel(provider: "openai-codex" | "openai"): Model<Api> | null {
   const models: Model<Api>[] = getModels(provider);
   const bestGpt = models
-    .filter((m) => /^gpt-5\./.test(m.id) && !/codex/.test(m.id))
-    .sort(compareOpenAiCandidates)[0];
+    .filter((m) => isOpenAiGeneralGptModelId(m.id))
+    .sort((a, b) => compareOpenAiModelIds(a.id, b.id))[0];
   const bestCodex = models
-    .filter((m) => /^gpt-5\.(\d+)-codex(?:-|$)/.test(m.id))
-    .sort(compareOpenAiCandidates)[0];
+    .filter((m) => isOpenAiCodexModelId(m.id))
+    .sort((a, b) => compareOpenAiModelIds(a.id, b.id))[0];
 
   if (bestGpt && bestCodex) {
-    return parseMajorMinor(bestGpt.id) >= parseMajorMinor(bestCodex.id) ? bestGpt : bestCodex;
+    return shouldPreferOpenAiGeneralModel(bestGpt.id, bestCodex.id) ? bestGpt : bestCodex;
   }
 
   if (bestGpt) return bestGpt;
   if (bestCodex) return bestCodex;
 
-  return models.slice().sort(compareOpenAiCandidates)[0] ?? null;
+  return models.slice().sort((a, b) => compareOpenAiModelIds(a.id, b.id))[0] ?? null;
 }
 
 export function pickDefaultModel(

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -5,10 +5,12 @@ import { test } from "node:test";
 
 import {
   compareModels,
+  compareOpenAiModelIds,
   modelRecencyScore,
   openAiFamilyPriority,
   parseMajorMinor,
   providerPriority,
+  shouldPreferOpenAiGeneralModel,
 } from "../src/models/model-ordering.ts";
 import { BROWSER_OAUTH_PROVIDERS, mapToApiProvider } from "../src/auth/provider-map.ts";
 import { rewriteDevProxyUrl } from "../src/auth/dev-rewrites.ts";
@@ -38,6 +40,17 @@ void test("openAiFamilyPriority prefers base GPT-5 over Codex variants", () => {
   assert.ok(openAiFamilyPriority("gpt-5.4-pro") < openAiFamilyPriority("gpt-5.3-codex"));
 });
 
+void test("compareOpenAiModelIds prefers newer versions before family tie-breaks", () => {
+  const ids = ["gpt-5.4-pro", "gpt-5.5-codex", "gpt-5.5"];
+  ids.sort(compareOpenAiModelIds);
+  assert.deepEqual(ids, ["gpt-5.5", "gpt-5.5-codex", "gpt-5.4-pro"]);
+});
+
+void test("shouldPreferOpenAiGeneralModel only prefers GPT when it is as new or newer", () => {
+  assert.equal(shouldPreferOpenAiGeneralModel("gpt-5.4", "gpt-5.3-codex"), true);
+  assert.equal(shouldPreferOpenAiGeneralModel("gpt-5.4-pro", "gpt-5.5-codex"), false);
+});
+
 void test("modelRecencyScore prefers higher version, then later date suffix", () => {
   assert.ok(
     modelRecencyScore("claude-opus-4-20250201") > modelRecencyScore("claude-opus-4-20250101"),
@@ -51,7 +64,7 @@ void test("modelRecencyScore prefers higher version, then later date suffix", ()
   );
 });
 
-void test("compareModels sorts by provider, family, then recency", () => {
+void test("compareModels sorts non-OpenAI models by provider, family, then recency", () => {
   const models = [
     { provider: "openai", id: "gpt-5.3" },
     { provider: "anthropic", id: "claude-opus-4-6" },
@@ -80,16 +93,16 @@ void test("compareModels sorts by provider, family, then recency", () => {
   assert.ok(providerPriority("anthropic") < providerPriority("openai"));
 });
 
-void test("openai compareModels prefers GPT-5 over older Codex variants", () => {
+void test("openai compareModels prefers newer Codex over older GPT variants", () => {
   const models = [
-    { provider: "openai", id: "gpt-5.3-codex" },
-    { provider: "openai", id: "gpt-5.4" },
     { provider: "openai", id: "gpt-5.4-pro" },
+    { provider: "openai", id: "gpt-5.5-codex" },
+    { provider: "openai", id: "gpt-5.5" },
   ];
 
   models.sort(compareModels);
 
-  assert.deepEqual(models.map((m) => m.id), ["gpt-5.4", "gpt-5.4-pro", "gpt-5.3-codex"]);
+  assert.deepEqual(models.map((m) => m.id), ["gpt-5.5", "gpt-5.5-codex", "gpt-5.4-pro"]);
 });
 
 void test("provider-map keeps openai-codex distinct from openai", () => {


### PR DESCRIPTION
## Summary
- centralize OpenAI model classification and comparison helpers in `model-ordering.ts`
- reuse the shared helpers in both default-model selection and model-picker featured ordering
- make general model sorting recency-first for OpenAI so newer Codex variants still beat older GPT variants
- extend model-ordering tests to cover the shared OpenAI rules

## Why
The GPT-5.4 change worked, but the OpenAI ordering logic was duplicated across multiple files. This follow-up keeps the structure simpler and makes future model updates less error-prone.

## Validation
- `npm run test:models`
- `npm run check`
- `npm run build`
