### PR TITLE
fix(extensions): isolate sandbox RPC on a MessageChannel

### DIFF
--- a/src/extensions/sandbox-runtime.ts
+++ b/src/extensions/sandbox-runtime.ts
@@ -27,9 +27,11 @@ import {
 } from "./internal/widget-surface.js";
 import { normalizeSandboxUiNode } from "./sandbox-ui.js";
 import {
+  SANDBOX_BOOTSTRAP_KIND,
   SANDBOX_CHANNEL,
   SANDBOX_REQUEST_TIMEOUT_MS,
   isSandboxEnvelope,
+  type SandboxBootstrapEnvelope,
   type SandboxRequestEnvelope,
   type SandboxResponseEnvelope,
   type SandboxEventEnvelope,
@@ -256,8 +258,12 @@ class SandboxRuntimeHost {
   private readonly overlayActionIds = new Set<string>();
   private readonly widgetActionIdsByWidgetId = new Map<string, Set<string>>();
 
-  private readonly onWindowMessage = (event: MessageEvent<unknown>) => {
-    this.handleWindowMessage(event);
+  private readonly onIframeLoad = () => {
+    this.bootstrapSandboxPort();
+  };
+
+  private readonly onPortMessage = (event: MessageEvent<unknown>) => {
+    this.handlePortMessage(event);
   };
 
   private readonly readyPromise: Promise<void>;
@@ -268,6 +274,7 @@ class SandboxRuntimeHost {
   private disposed = false;
   private readonly widgetOwnerId: string;
   private readonly widgetApiV2Enabled: boolean;
+  private port: MessagePort | null = null;
 
   constructor(options: SandboxActivationOptions) {
     this.options = options;
@@ -286,6 +293,7 @@ class SandboxRuntimeHost {
     this.iframe.setAttribute("aria-hidden", "true");
     this.iframe.tabIndex = -1;
     this.iframe.style.display = "none";
+    this.iframe.addEventListener("load", this.onIframeLoad, { once: true });
     this.iframe.srcdoc = buildSandboxSrcdoc({
       instanceId: this.options.instanceId,
       extensionName: this.options.extensionName,
@@ -293,7 +301,6 @@ class SandboxRuntimeHost {
       widgetApiV2Enabled: this.widgetApiV2Enabled,
     });
 
-    window.addEventListener("message", this.onWindowMessage);
     document.body.appendChild(this.iframe);
   }
 
@@ -352,11 +359,61 @@ class SandboxRuntimeHost {
       dismissWidget();
     }
 
-    window.removeEventListener("message", this.onWindowMessage);
+    this.port?.removeEventListener("message", this.onPortMessage);
+    this.port?.close();
+    this.port = null;
+
     this.iframe.remove();
   }
 
+  private bootstrapSandboxPort(): void {
+    if (this.disposed || this.port) {
+      return;
+    }
 
+    const targetWindow = this.iframe.contentWindow;
+    if (!targetWindow) {
+      this.rejectReady?.(new Error("Sandbox frame is not ready."));
+      this.resolveReady = null;
+      this.rejectReady = null;
+      return;
+    }
+
+    const channel = new MessageChannel();
+    const port = channel.port1;
+    this.port = port;
+    port.addEventListener("message", this.onPortMessage);
+    port.start();
+
+    const bootstrap: SandboxBootstrapEnvelope = {
+      channel: SANDBOX_CHANNEL,
+      instanceId: this.options.instanceId,
+      direction: "host_to_sandbox",
+      kind: SANDBOX_BOOTSTRAP_KIND,
+    };
+
+    try {
+      // Sandboxed srcdoc iframes have opaque origins, so the initial port transfer
+      // must use a wildcard target. All subsequent sandbox RPC stays on the
+      // dedicated MessagePort instead of window.postMessage.
+      targetWindow.postMessage(bootstrap, "*", [channel.port2]);
+    } catch (error: unknown) {
+      port.removeEventListener("message", this.onPortMessage);
+      port.close();
+      this.port = null;
+      this.rejectReady?.(new Error(`Sandbox bridge bootstrap failed: ${getErrorMessage(error)}`));
+      this.resolveReady = null;
+      this.rejectReady = null;
+    }
+  }
+
+  private getSandboxPort(): MessagePort {
+    if (!this.port) {
+      throw new Error("Sandbox bridge is not ready.");
+    }
+
+    return this.port;
+  }
 
   private async callSandbox(
     method: string,
@@ -367,11 +424,6 @@ class SandboxRuntimeHost {
   ): Promise<unknown> {
     if (this.disposed && !options?.allowWhenDisposed) {
       throw new Error("Sandbox runtime is already disposed.");
-    }
-
-    const targetWindow = this.iframe.contentWindow;
-    if (!targetWindow) {
-      throw new Error("Sandbox frame is not ready.");
     }
 
     const requestId = `req-${this.nextRequestId}`;
@@ -399,7 +451,7 @@ class SandboxRuntimeHost {
         params,
       };
 
-      targetWindow.postMessage(envelope, "*");
+      this.getSandboxPort().postMessage(envelope);
     });
   }
 
@@ -408,8 +460,7 @@ class SandboxRuntimeHost {
     ok: boolean,
     payload: unknown,
   ): void {
-    const targetWindow = this.iframe.contentWindow;
-    if (!targetWindow) {
+    if (!this.port) {
       return;
     }
 
@@ -428,12 +479,11 @@ class SandboxRuntimeHost {
       envelope.error = typeof payload === "string" ? payload : "Unknown host error";
     }
 
-    targetWindow.postMessage(envelope, "*");
+    this.port.postMessage(envelope);
   }
 
   private sendEvent(eventName: string, data: unknown): void {
-    const targetWindow = this.iframe.contentWindow;
-    if (!targetWindow) {
+    if (!this.port) {
       return;
     }
 
@@ -446,7 +496,7 @@ class SandboxRuntimeHost {
       data,
     };
 
-    targetWindow.postMessage(envelope, "*");
+    this.port.postMessage(envelope);
   }
 
   private replaceActionIds(target: Set<string>, next: Set<string>): void {
@@ -475,11 +525,7 @@ class SandboxRuntimeHost {
       });
   }
 
-  private handleWindowMessage(event: MessageEvent<unknown>): void {
-    if (event.source !== this.iframe.contentWindow) {
-      return;
-    }
-
+  private handlePortMessage(event: MessageEvent<unknown>): void {
     const envelope = event.data;
     if (!isSandboxEnvelope(envelope)) {
       return;

--- a/src/extensions/sandbox/protocol.ts
+++ b/src/extensions/sandbox/protocol.ts
@@ -2,6 +2,7 @@ import { isRecord } from "../../utils/type-guards.js";
 
 export const SANDBOX_CHANNEL = "pi.extension.sandbox.rpc.v1";
 export const SANDBOX_REQUEST_TIMEOUT_MS = 15_000;
+export const SANDBOX_BOOTSTRAP_KIND = "bootstrap";
 
 export type SandboxDirection = "sandbox_to_host" | "host_to_sandbox";
 
@@ -12,6 +13,13 @@ interface SandboxEnvelopeBase {
   instanceId: string;
   direction: SandboxDirection;
   kind: SandboxEnvelopeKind;
+}
+
+export interface SandboxBootstrapEnvelope {
+  channel: string;
+  instanceId: string;
+  direction: "host_to_sandbox";
+  kind: typeof SANDBOX_BOOTSTRAP_KIND;
 }
 
 export interface SandboxRequestEnvelope extends SandboxEnvelopeBase {
@@ -37,7 +45,12 @@ export interface SandboxEventEnvelope extends SandboxEnvelopeBase {
 
 export type SandboxEnvelope = SandboxRequestEnvelope | SandboxResponseEnvelope | SandboxEventEnvelope;
 
-export function isSandboxEnvelope(value: unknown): value is SandboxEnvelope {
+function hasValidSandboxEnvelopeBase(value: unknown): value is Record<string, unknown> & {
+  channel: string;
+  instanceId: string;
+  direction: SandboxDirection;
+  kind: string;
+} {
   if (!isRecord(value)) {
     return false;
   }
@@ -59,6 +72,23 @@ export function isSandboxEnvelope(value: unknown): value is SandboxEnvelope {
     return false;
   }
 
+  return typeof kind === "string";
+}
+
+export function isSandboxBootstrapEnvelope(value: unknown): value is SandboxBootstrapEnvelope {
+  if (!hasValidSandboxEnvelopeBase(value)) {
+    return false;
+  }
+
+  return value.direction === "host_to_sandbox" && value.kind === SANDBOX_BOOTSTRAP_KIND;
+}
+
+export function isSandboxEnvelope(value: unknown): value is SandboxEnvelope {
+  if (!hasValidSandboxEnvelopeBase(value)) {
+    return false;
+  }
+
+  const kind = value.kind;
   if (kind !== "request" && kind !== "response" && kind !== "event") {
     return false;
   }

--- a/src/extensions/sandbox/srcdoc.ts
+++ b/src/extensions/sandbox/srcdoc.ts
@@ -1,4 +1,5 @@
 import {
+  SANDBOX_BOOTSTRAP_KIND,
   SANDBOX_CHANNEL,
   serializeForSandboxInlineScript,
 } from "./protocol.js";
@@ -29,6 +30,7 @@ export function buildSandboxSrcdoc(options: BuildSandboxSrcdocOptions): string {
 
     const config = {
       channel: SANDBOX_CHANNEL,
+      bootstrapKind: SANDBOX_BOOTSTRAP_KIND,
       instanceId: options.instanceId,
       extensionName: options.extensionName,
       source: sourceConfig,
@@ -75,6 +77,7 @@ export function buildSandboxSrcdoc(options: BuildSandboxSrcdocOptions): string {
         "button",
       ]);
 
+      let hostPort = null;
       let nextRequestId = 1;
       let moduleDeactivate = null;
       let cleanups = [];
@@ -89,7 +92,11 @@ export function buildSandboxSrcdoc(options: BuildSandboxSrcdocOptions): string {
       }
 
       function sendToHost(envelope) {
-        parent.postMessage(envelope, "*");
+        if (!hostPort) {
+          throw new Error('Sandbox host port is not ready');
+        }
+
+        hostPort.postMessage(envelope);
       }
 
       function sendEvent(eventName, data) {
@@ -447,7 +454,7 @@ export function buildSandboxSrcdoc(options: BuildSandboxSrcdocOptions): string {
         }
       }
 
-      window.addEventListener("message", (event) => {
+      function handleHostMessage(event) {
         const message = event.data;
         if (!message || typeof message !== "object") {
           return;
@@ -485,6 +492,38 @@ export function buildSandboxSrcdoc(options: BuildSandboxSrcdocOptions): string {
         if (message.kind === "event") {
           handleHostEvent(message);
         }
+      }
+
+      window.addEventListener("message", (event) => {
+        if (event.source !== parent) {
+          return;
+        }
+
+        const message = event.data;
+        if (!message || typeof message !== "object") {
+          return;
+        }
+
+        if (message.channel !== config.channel || message.instanceId !== config.instanceId) {
+          return;
+        }
+
+        if (message.direction !== "host_to_sandbox" || message.kind !== config.bootstrapKind) {
+          return;
+        }
+
+        const port = event.ports[0];
+        if (!(port instanceof MessagePort) || hostPort) {
+          return;
+        }
+
+        hostPort = port;
+        hostPort.addEventListener("message", handleHostMessage);
+        hostPort.start();
+
+        void activateExtension().catch((error) => {
+          sendEvent("error", { message: getErrorMessage(error) });
+        });
       });
 
       function queueActivationOp(promise) {
@@ -1022,10 +1061,6 @@ export function buildSandboxSrcdoc(options: BuildSandboxSrcdocOptions): string {
 
         sendEvent("ready", null);
       }
-
-      activateExtension().catch((error) => {
-        sendEvent("error", { message: getErrorMessage(error) });
-      });
     </script>
   </body>
 </html>`;

--- a/tests/extensions-runtime-manager-sandbox.test.ts
+++ b/tests/extensions-runtime-manager-sandbox.test.ts
@@ -12,7 +12,9 @@ import { ExtensionRuntimeManager } from "../src/extensions/runtime-manager.ts";
 import { isConnectionToolErrorDetails } from "../src/tools/tool-details.ts";
 import { withConnectionPreflight } from "../src/tools/with-connection-preflight.ts";
 import {
+  SANDBOX_BOOTSTRAP_KIND,
   SANDBOX_CHANNEL,
+  isSandboxBootstrapEnvelope,
   isSandboxEnvelope,
   serializeForSandboxInlineScript,
 } from "../src/extensions/sandbox/protocol.ts";
@@ -673,14 +675,25 @@ void test("sandbox srcdoc builder emits expected bridge hooks and config", () =>
 
   assert.match(html, /"instanceId":"ext\.inline\.srcdoc"/);
   assert.match(html, /"widgetApiV2Enabled":true/);
+  assert.match(html, /"bootstrapKind":"bootstrap"/);
   assert.match(html, /if \(method === "ui_action"\)/);
   assert.match(html, /Unknown sandbox UI action id:/);
   assert.match(html, /api\.agent is not available in sandbox runtime/);
+  assert.match(html, /event\.source !== parent/);
+  assert.match(html, /message\.kind !== config\.bootstrapKind/);
+  assert.match(html, /hostPort\.addEventListener\("message", handleHostMessage\)/);
   assert.match(html, /placement: payload\.placement === "above-input" \|\| payload\.placement === "below-input"/);
   assert.match(html, /payload\.minHeightPx === null/);
 });
 
 void test("sandbox protocol helpers validate envelope shapes and escape inline script payloads", () => {
+  const validBootstrap: unknown = {
+    channel: SANDBOX_CHANNEL,
+    instanceId: "ext.inline.proto",
+    direction: "host_to_sandbox",
+    kind: SANDBOX_BOOTSTRAP_KIND,
+  };
+
   const validRequest: unknown = {
     channel: SANDBOX_CHANNEL,
     instanceId: "ext.inline.proto",
@@ -708,6 +721,8 @@ void test("sandbox protocol helpers validate envelope shapes and escape inline s
     method: "register_tool",
   };
 
+  assert.equal(isSandboxBootstrapEnvelope(validBootstrap), true);
+  assert.equal(isSandboxBootstrapEnvelope(validRequest), false);
   assert.equal(isSandboxEnvelope(validRequest), true);
   assert.equal(isSandboxEnvelope(invalidDirection), false);
   assert.equal(isSandboxEnvelope(invalidKind), false);
@@ -720,7 +735,10 @@ void test("sandbox runtime host source retains isolation boundary guards", async
   const hostSource = await readFile(new URL("../src/extensions/sandbox-runtime.ts", import.meta.url), "utf8");
 
   assert.match(hostSource, /setAttribute\("sandbox", "allow-scripts"\)/);
-  assert.match(hostSource, /if \(event\.source !== this\.iframe\.contentWindow\)/);
+  assert.match(hostSource, /new MessageChannel\(\)/);
+  assert.match(hostSource, /postMessage\(bootstrap,/);
+  assert.match(hostSource, /channel\.port2/);
+  assert.match(hostSource, /this\.getSandboxPort\(\)\.postMessage\(envelope\)/);
   assert.match(hostSource, /if \(envelope\.direction !== "sandbox_to_host"\)/);
   assert.match(hostSource, /if \(!isSandboxEnvelope\(envelope\)\)/);
 });


### PR DESCRIPTION
## Summary
- move sandbox host/runtime RPC off wildcard `window.postMessage` traffic onto a dedicated `MessageChannel`
- keep a minimal one-time bootstrap postMessage only for transferring the port into the sandbox iframe
- add bootstrap envelope helpers and coverage for the new bridge shape

## Why
GitHub CodeQL is flagging the sandbox runtime for `postMessage("*")` on host→sandbox traffic. Since sandboxed `srcdoc` iframes have opaque origins, we still need one bootstrap `postMessage` to transfer a port, but sensitive follow-up RPC can stay on a dedicated `MessagePort` instead.

## Testing
- `npm run check`
- `npm run test:context`
- `npm run test:security`
- `npm run build`
