### PR TITLE
fix(csp): allow blob module imports for Office.js

### DIFF
--- a/tests/web-search-provider-hosts.test.mjs
+++ b/tests/web-search-provider-hosts.test.mjs
@@ -116,3 +116,9 @@ test("taskpane CSP allows Pyodide CDN host in script-src and connect-src", async
   assert.ok(connectTokens.has("https://cdn.jsdelivr.net"), "Missing jsDelivr in CSP connect-src");
   assert.ok(scriptTokens.has("https://cdn.jsdelivr.net"), "Missing jsDelivr in CSP script-src");
 });
+
+test("taskpane CSP allows blob module imports in script-src", async () => {
+  const scriptTokens = await readTaskpaneScriptSrcTokens();
+
+  assert.ok(scriptTokens.has("blob:"), "Missing blob: in CSP script-src");
+});

--- a/vercel.json
+++ b/vercel.json
@@ -77,7 +77,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'none'; script-src 'self' https://appsforoffice.microsoft.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://appsforoffice.microsoft.com https://cdn.jsdelivr.net https://api.anthropic.com https://console.anthropic.com https://api.openai.com https://auth.openai.com https://chatgpt.com https://generativelanguage.googleapis.com https://oauth2.googleapis.com https://github.com https://api.github.com https://*.githubcopilot.com https://s.jina.ai https://api.firecrawl.dev https://google.serper.dev https://api.tavily.com https://api.search.brave.com https://localhost:* https://127.0.0.1:*; object-src 'none'; base-uri 'none'; form-action 'none'"
+          "value": "default-src 'none'; script-src 'self' blob: https://appsforoffice.microsoft.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://appsforoffice.microsoft.com https://cdn.jsdelivr.net https://api.anthropic.com https://console.anthropic.com https://api.openai.com https://auth.openai.com https://chatgpt.com https://generativelanguage.googleapis.com https://oauth2.googleapis.com https://github.com https://api.github.com https://*.githubcopilot.com https://s.jina.ai https://api.firecrawl.dev https://google.serper.dev https://api.tavily.com https://api.search.brave.com https://localhost:* https://127.0.0.1:*; object-src 'none'; base-uri 'none'; form-action 'none'"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- allow `blob:` module imports in the hosted taskpane CSP
- add a regression test covering `blob:` in `script-src`

## Why
`execute_office_js` compiles user-approved Office.js snippets into a Blob URL and loads them with dynamic `import(blobUrl)`. On Windows/WebView2, the hosted CSP blocked that path because `script-src` did not include `blob:`.

This should unblock chart/pivottable flows that fall back to `execute_office_js` in stricter WebView2 hosts.

Closes #467

## Validation
- `npm run test:security`
- `npm run build`