### PR TITLE
fix(prompt): clarify Office.js needs no extra bridge

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -203,6 +203,11 @@ If you installed with `manifest.prod.xml`, Pi for Excel loads from a hosted URL 
 ### I installed, but changes are not visible
 - Close and reopen Excel to clear cached taskpane state
 
+### Do I need to install a separate Office.js bridge?
+- No — Office.js support comes from Excel itself when you install Pi with `manifest.prod.xml`
+- You do **not** need `generator-office`, Yeoman, or any extra Office.js package to use the hosted add-in
+- The optional local helper services are only for OAuth proxying, native Python / LibreOffice, and tmux
+
 ### OAuth login still fails
 - Confirm proxy is running and reachable at the exact URL in `/settings`
 - Confirm proxy URL is `https://localhost:<port>` (not `http://`)

--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -388,6 +388,8 @@ Python runs **in-browser via Pyodide** (WebAssembly) by default — no setup req
 Other tools may be available depending on enabled experiments/integrations.
 Use **files** for workspace artifacts (list/read/write/delete files). Pass \`path\` on \`list\` to scope to a folder.
 Built-in assistant docs are always available under \`assistant-docs/\` (for example \`assistant-docs/docs/extensions.md\`).
+Office.js runs inside Excel — there is no separate Office.js bridge for end users to install.
+For workbook features not covered by structured tools (for example Excel tables with filters, charts, and PivotTables), use **execute_office_js** instead of claiming setup is missing.
 If **execute_office_js** is available, keep code minimal, call \`context.sync()\` after \`load()\`, and return JSON-serializable results.`;
 
 const WORKSPACE = `## Workspace

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -146,6 +146,8 @@ void test("system prompt documents execute_office_js safety guidance", () => {
   const prompt = buildSystemPrompt();
   assert.match(prompt, /\*\*execute_office_js\*\*/);
   assert.match(prompt, /Office\.js/i);
+  assert.match(prompt, /there is no separate Office\.js bridge/i);
+  assert.match(prompt, /tables with filters, charts, and PivotTables/i);
   assert.match(prompt, /explanation \+ user approval required/i);
   assert.match(prompt, /context\.sync\(\)/i);
 });


### PR DESCRIPTION
## Summary
- tell the agent that Office.js runs inside Excel and does not need a separate bridge install
- nudge the agent to use `execute_office_js` for tables, charts, and PivotTables instead of claiming setup is missing
- document the same guidance in the install troubleshooting guide

## Why
Issue #457 reports the assistant telling Windows users that an "Office.js bridge" is missing when they ask for Excel-native objects like real tables. That setup step does not exist for hosted installs, so the best fix is to make the guidance explicit in both the system prompt and user-facing docs.

Closes #457

## Validation
- `npm run test:context`
- `npm run build`