### PR TITLE
docs(install): clarify Windows sideload path

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -55,6 +55,9 @@ You can try to install and run this on Windows — it might work!
 4. Select the `manifest.prod.xml` file you downloaded
 5. Click **Open Pi** in the ribbon
 
+> ⚠️ Use **Upload My Add-in…** for `manifest.prod.xml`.
+> Do **not** import it via **Manage → XML Expansion Packs** — that is a legacy Excel path and can surface misleading certificate errors for Office add-in manifests.
+
 For more detail, see [Microsoft's guide for Windows](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing).
 
 ### Excel on the Web (Office Online)
@@ -195,6 +198,11 @@ If you installed with `manifest.prod.xml`, Pi for Excel loads from a hosted URL 
 ### Pi does not appear in My Add-ins
 - Re-open Excel and try again
 - Ensure you uploaded `manifest.prod.xml` (not the localhost dev manifest)
+
+### Windows says the manifest certificate is invalid / mentions XML Expansion Packs
+- Use **Insert → My Add-ins → Upload My Add-in…** instead of **Manage → XML Expansion Packs**
+- `manifest.prod.xml` is an Office add-in manifest, not a legacy Excel XML Expansion Pack
+- If you already tried the XML Expansion Packs path, close Excel and repeat the upload flow above
 
 ### Taskpane opens but is blank
 - Your network may block `https://pi-for-excel.vercel.app`

--- a/public/index.html
+++ b/public/index.html
@@ -208,6 +208,9 @@
           <li>Go to <strong>Insert → My Add-ins → Upload My Add-in…</strong></li>
           <li>Select the <code>manifest.prod.xml</code> file you downloaded</li>
         </ol>
+        <div class="callout">
+          <strong>Important:</strong> use <strong>Upload My Add-in…</strong> for this file — not <strong>Manage → XML Expansion Packs</strong>. That older Excel path can show misleading certificate errors for Office add-in manifests.
+        </div>
       </div>
 
       <div class="card">


### PR DESCRIPTION
## Summary
- clarify that Windows installs must use **Insert → My Add-ins → Upload My Add-in…**
- warn against **Manage → XML Expansion Packs** for Office add-in manifests
- add the same troubleshooting note to the hosted landing page

## Why
Issue #469 reports a Windows certificate error while trying to import `manifest.prod.xml` via **XML Expansion Packs**. That is the wrong install path for an Office add-in manifest, so the clearest fix is to make the supported sideload flow explicit anywhere users are likely to follow install steps.

Closes #469

## Validation
- `npm run build`
- `npm run check:landing-connect-copy`