### PR TITLE
fix: disable remaining KaTeX math extensions + restore diff table text contrast

### DIFF
--- a/src/compat/marked-safety-policy.ts
+++ b/src/compat/marked-safety-policy.ts
@@ -6,7 +6,12 @@
  */
 
 const ALLOWED_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
-const DISABLED_MARKDOWN_EXTENSION_NAMES = new Set(["inlineMathDollar", "blockMathDollar"]);
+const DISABLED_MARKDOWN_EXTENSION_NAMES = new Set([
+  "inlineMathDollar",
+  "blockMathDollar",
+  "inlineMathLatex",
+  "blockMathLatex",
+]);
 
 export type MarkdownImageRenderPlan =
   | { kind: "link"; href: string; label: string }
@@ -33,10 +38,12 @@ export function isAllowedMarkdownUrl(raw: string): boolean {
 }
 
 /**
- * mini-lit enables `$...$` and `$$...$$` KaTeX extensions by default.
- * In spreadsheet/finance prose this collides with currency notation and
- * causes large chunks of text to render as math. We disable only the
- * dollar-delimited math extensions and keep `\(...\)` / `\[...\]` support.
+ * mini-lit enables four KaTeX math extensions by default: `$...$`,
+ * `$$...$$`, `\(...\)`, and `\[...\]`. All four collide with
+ * spreadsheet/finance notation — dollar signs with currency, and
+ * backslash-parens/brackets with escaped formula references — causing
+ * prose to render as math in a serif italic font (KaTeX_Math).
+ * Disable all of them.
  */
 export function isMarkdownExtensionDisabledByPolicy(name: string): boolean {
   return DISABLED_MARKDOWN_EXTENSION_NAMES.has(name);

--- a/src/ui/theme/content/tool-card-markdown.css
+++ b/src/ui/theme/content/tool-card-markdown.css
@@ -64,6 +64,7 @@
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   line-height: 1.35;
+  color: var(--foreground);
 }
 
 .pi-tool-card__diff-table th,

--- a/tests/marked-safety-policy.test.ts
+++ b/tests/marked-safety-policy.test.ts
@@ -20,10 +20,12 @@ void test("isAllowedMarkdownUrl blocks unsafe protocols", () => {
   assert.equal(isAllowedMarkdownUrl(""), false);
 });
 
-void test("policy disables dollar-delimited KaTeX extensions", () => {
+void test("policy disables all KaTeX math extensions", () => {
   assert.equal(isMarkdownExtensionDisabledByPolicy("inlineMathDollar"), true);
   assert.equal(isMarkdownExtensionDisabledByPolicy("blockMathDollar"), true);
-  assert.equal(isMarkdownExtensionDisabledByPolicy("inlineMathLatex"), false);
+  assert.equal(isMarkdownExtensionDisabledByPolicy("inlineMathLatex"), true);
+  assert.equal(isMarkdownExtensionDisabledByPolicy("blockMathLatex"), true);
+  assert.equal(isMarkdownExtensionDisabledByPolicy("someOtherExtension"), false);
 });
 
 void test("markdown image plans never render <img>", () => {


### PR DESCRIPTION
Fixes #486 and #483.

## Changes

### KaTeX math extension hijack (#486)
The `\\(...\\)` and `\\[...\\]` KaTeX extensions were still active, causing formula text with escaped parentheses to render in serif italic (KaTeX_Math font). This adds them to the `DISABLED_MARKDOWN_EXTENSION_NAMES` set alongside the already-disabled dollar-sign variants.

### Diff table contrast (#483)
The CHANGES diff table inside tool cards inherited a muted text color, making cell references and values nearly invisible. Adds an explicit `color: var(--foreground)` on the table element.

## Testing
- `npm run build` ✅
- `npm run test:security` ✅ (marked safety policy is covered)