### PR TITLE
fix(files): tone down badge pill in file list + fix text preview scroll

### DIFF
--- a/src/ui/theme/components/files.css
+++ b/src/ui/theme/components/files.css
@@ -509,3 +509,24 @@
 .pi-files-detail-actions__spacer {
   flex: 1;
 }
+
+/* ── Badge overrides inside file items (#490) ────── */
+.pi-files-item .pi-overlay-badge {
+  border-radius: var(--radius-xs);
+  border: none;
+  padding: 1px 5px;
+  font-size: 10px;
+}
+
+/* ── Text preview scroll fixes (#491) ────────────── */
+.pi-files-detail-preview--text {
+  max-height: min(400px, 50vh);
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+.pi-files-detail-preview__code {
+  white-space: pre;
+  overflow-x: auto;
+  text-overflow: unset;
+}


### PR DESCRIPTION
Fixes #490 and #491.

## Changes

### Badge appearance (#490)
The `.pi-overlay-badge` with `border-radius: 999px` + border was too prominent inside compact file list items. Overrides within `.pi-files-item` now use `border-radius: var(--radius-xs)` with no border — a subtle rounded-rect label.

### Text preview scroll (#491)
- `max-height`: 220px → `min(400px, 50vh)` — shows ~25 lines instead of ~13
- `overscroll-behavior: contain` — prevents scroll chaining to the outer overlay
- `scrollbar-width: thin` — ensures the scrollbar is visible
- Horizontal: replaced `text-overflow: ellipsis` with `overflow-x: auto` so long lines can be scrolled