### PR TITLE
fix(toast): prevent action toast from persisting forever

### DIFF
--- a/src/ui/toast.ts
+++ b/src/ui/toast.ts
@@ -35,14 +35,22 @@ interface ResolvedToastOptions {
 const ERROR_TOAST_PATTERN = /\b(fail(?:ed|ure)?|error|invalid|denied|blocked|could\s*not|couldn't|can\s*not|can't|unable|timed\s*out)\b/iu;
 const DEFAULT_INFO_DURATION_MS = 2000;
 const DEFAULT_ERROR_DURATION_MS = 6000;
+const ACTION_TOAST_DEFAULT_MS = 7000;
 
 let toastElements: ToastElements | null = null;
 let hideTimer: ReturnType<typeof setTimeout> | null = null;
+/** Backup timer for action toasts — fires even if the primary is cancelled. */
+let actionHideTimer: ReturnType<typeof setTimeout> | null = null;
 
 function clearHideTimer(): void {
-  if (hideTimer === null) return;
-  clearTimeout(hideTimer);
-  hideTimer = null;
+  if (hideTimer !== null) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  if (actionHideTimer !== null) {
+    clearTimeout(actionHideTimer);
+    actionHideTimer = null;
+  }
 }
 
 function ensureToastElements(): ToastElements {
@@ -148,12 +156,37 @@ function renderToast(opts: ResolvedToastOptions): void {
 
   elements.root.classList.add("visible");
   scheduleHide(opts.duration);
+
+  // For action toasts, schedule an independent backup hide that can't be
+  // cancelled by a subsequent plain showToast() call.  Adds 1s margin so
+  // the primary timer normally wins.
+  if (opts.action) {
+    if (actionHideTimer !== null) clearTimeout(actionHideTimer);
+    actionHideTimer = setTimeout(() => {
+      actionHideTimer = null;
+      // Only hide if the action toast is still showing (not already
+      // dismissed by the user or the primary timer).
+      if (isActionToastVisible()) {
+        const el = toastElements;
+        if (!el) return;
+        el.root.classList.remove("visible", "pi-toast--action", "pi-toast--error");
+        el.action.hidden = true;
+        el.action.onclick = null;
+      }
+    }, opts.duration + 1000);
+  }
 }
 
 export function showToast(message: string, duration?: number): void;
 export function showToast(message: string, options?: ToastOptions): void;
 export function showToast(message: string, durationOrOptions?: number | ToastOptions): void {
   const normalized = normalizeToastOptions(message, durationOrOptions);
+
+  // Don't let a plain info toast overwrite an active action toast — the
+  // action toast has an undo button the user may still need, and replacing
+  // it would also cancel its hide timer, leaving the toast stuck forever.
+  // Error toasts are allowed through — they're higher priority.
+  if (normalized.variant !== "error" && isActionToastVisible()) return;
 
   renderToast({
     message,
@@ -165,7 +198,7 @@ export function showToast(message: string, durationOrOptions?: number | ToastOpt
 export function showActionToast(opts: ActionToastOptions): void {
   renderToast({
     message: opts.message,
-    duration: opts.duration ?? 9000,
+    duration: opts.duration ?? ACTION_TOAST_DEFAULT_MS,
     variant: "info",
     action: {
       label: opts.actionLabel,


### PR DESCRIPTION
Fixes #485.

## Problem
The undo toast after closing a tab could persist indefinitely. The root cause: `showToast()` (plain info toast) called during tab-switching would cancel the action toast's hide timer via the shared `clearHideTimer()`, leaving the action toast visible with no timer to remove it.

## Fix
1. **Guard `showToast()`**: skip plain info toasts when an action toast is active (already had `isActionToastVisible()` for this check)
2. **Backup timer**: action toasts now schedule an independent safety-net timer that fires 1s after the primary — catches edge cases where the primary timer is cancelled or frozen (WebView suspension)
3. **Duration**: reduced default from 9s → 7s