### PR TITLE
chore(deps): bump pi-stack to v0.58.1 — 1M context for Opus/Sonnet 4.6

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,6 +1,6 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-03-06
+**Last verified:** 2026-03-15
 
 This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.4`, `gpt-5.3-codex`, `claude-opus-4-6`).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
-        "@mariozechner/pi-agent-core": "^0.56.2",
-        "@mariozechner/pi-ai": "^0.56.2",
-        "@mariozechner/pi-web-ui": "^0.56.2",
+        "@mariozechner/pi-agent-core": "^0.58.1",
+        "@mariozechner/pi-ai": "^0.58.1",
+        "@mariozechner/pi-web-ui": "^0.58.1",
         "@sinclair/typebox": "^0.34.41",
         "lit": "^3.2.1",
         "marked": "^17.0.4"
@@ -3198,21 +3198,21 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.56.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.56.2.tgz",
-      "integrity": "sha512-jpE5MosroL0Lk7UiJX7GY0qpkhibiZORZviGUiGfoIK25fa+ToLYwmErRYKpmj44wc7G1IMdQujr6f65FAkBGA==",
+      "version": "0.58.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.58.1.tgz",
+      "integrity": "sha512-7bnkMRgdbfH1A397K7OOQ8XGpZQtJ+kqT1WClj7W00eHTvTUxgJBMCAJXmsho4PqmUxHwIoOTr1mhPW14yH3Zw==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.56.2"
+        "@mariozechner/pi-ai": "^0.58.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.56.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.56.2.tgz",
-      "integrity": "sha512-7cPhumqo/Ke7W4Lng5RyGmBWuhK0G9Z7JVfTl00m11snk5G+MYtNeqpi7VHZ5yW1K0DLsTAY9Mi2KLghaFImiA==",
+      "version": "0.58.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.58.1.tgz",
+      "integrity": "sha512-ZZ9+SiWVm55JlafOlv3InAUBrSzAji1n8otvSjS7VLHHpfEUeG5s+L1w8S76t8gn9+lqVLK4/UgkxQUdFWIyDw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -3257,9 +3257,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.56.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.56.2.tgz",
-      "integrity": "sha512-UsbJNeyRnUqEp5AOCxNB/1EOCSN4ZpA/Irbbu1DLCzBPPGMrQnSp9mcFcuwqzw/t2P7VqGxY4n0hGkiAKbvgpQ==",
+      "version": "0.58.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.58.1.tgz",
+      "integrity": "sha512-4cO6E4/zN3FFzfwvdBpBYaZagrEyuOzZV2PYiS+FFl8u4pC1TsrV2GYqjhVVpylgxoOTKNyiargZvthp0kc4xQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -3288,14 +3288,14 @@
       }
     },
     "node_modules/@mariozechner/pi-web-ui": {
-      "version": "0.56.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.56.2.tgz",
-      "integrity": "sha512-64qtw7XS+4fsCnO6r3TNaoI6GK/pcgv5nc5+BL0/inDKTjMBGYxkxHXZW25B0bi+UVjU4SavtQY40/4fnb1yeg==",
+      "version": "0.58.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.58.1.tgz",
+      "integrity": "sha512-nZcp9H3B/qqbBuoYaGRxB27EYcMYztxvZF/BL+MnugTKHSjR+WLTKESxihiVX7xoYDlgdAuB9Td6K+4Vfop/Kw==",
       "license": "MIT",
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
-        "@mariozechner/pi-ai": "^0.56.2",
-        "@mariozechner/pi-tui": "^0.56.2",
+        "@mariozechner/pi-ai": "^0.58.1",
+        "@mariozechner/pi-tui": "^0.58.1",
         "docx-preview": "^0.3.7",
         "jszip": "^3.10.1",
         "lucide": "^0.544.0",
@@ -9255,9 +9255,9 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
-      "integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
+      "integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@mariozechner/pi-agent-core": "^0.56.2",
-    "@mariozechner/pi-ai": "^0.56.2",
-    "@mariozechner/pi-web-ui": "^0.56.2",
+    "@mariozechner/pi-agent-core": "^0.58.1",
+    "@mariozechner/pi-ai": "^0.58.1",
+    "@mariozechner/pi-web-ui": "^0.58.1",
     "@sinclair/typebox": "^0.34.41",
     "lit": "^3.2.1",
     "marked": "^17.0.4"

--- a/src/auth/stream-proxy.ts
+++ b/src/auth/stream-proxy.ts
@@ -440,11 +440,11 @@ function withPayloadHook(
   const originalOnPayload = options?.onPayload;
   if (!captureSnapshot && !originalOnPayload) return options;
 
-  const onPayload = (payload: unknown) => {
+  const onPayload: NonNullable<StreamOptions["onPayload"]> = (payload, model) => {
     if (captureSnapshot) {
       upsertPayloadShape(call, payload);
     }
-    originalOnPayload?.(payload);
+    return originalOnPayload?.(payload, model);
   };
 
   if (options) return { ...options, onPayload };


### PR DESCRIPTION
Closes #488. Supersedes #479 (Dependabot PR that was failing due to the `onPayload` signature change).

## Changes
- Bump `@mariozechner/pi-ai`, `pi-web-ui`, `pi-agent-core` from 0.56.2 → 0.58.1
- Adapt `withPayloadHook` in `stream-proxy.ts` — upstream `onPayload` callback now takes a second `model` parameter
- Update `docs/model-updates.md` last-verified date

## What's new in the registry
| Model | Context window | Change |
|-------|---------------|--------|
| `claude-opus-4-6` | **1,000,000** | was 200K |
| `claude-sonnet-4-6` | **1,000,000** | was 200K |
| `supportsXhigh()` | Now includes GPT-5.2/5.3/5.4 | was Opus 4.6 only |

## Testing
- `npm run check` ✅ (lockstep, lint, typecheck)
- `npm run build` ✅
- `npm run test:models` ✅ (18/18)
- `npm run test:context` ✅ (640/640)