### PR TITLE
fix(css): make heading scale resilient — target markdown-block, not hook class

### DIFF
--- a/src/ui/theme/content/message-components.css
+++ b/src/ui/theme/content/message-components.css
@@ -131,6 +131,23 @@ thinking-block markdown-block {
   overscroll-behavior: contain;
 }
 
+/* Compact heading scale for thinking blocks — override the global
+   markdown-block heading rules which are sized for the message body. */
+thinking-block markdown-block h1,
+thinking-block markdown-block h2,
+thinking-block markdown-block h3 {
+  font-size: var(--text-sm);
+  font-weight: 700;
+  margin: 8px 0 4px;
+}
+thinking-block markdown-block h4,
+thinking-block markdown-block h5,
+thinking-block markdown-block h6 {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  margin: 6px 0 3px;
+}
+
 /* Added by applyMessageStyleHooks() so we don't depend on utility classes. */
 .pi-thinking-label--streaming {
   animation-duration: 1.2s;

--- a/src/ui/theme/content/messages.css
+++ b/src/ui/theme/content/messages.css
@@ -33,43 +33,60 @@ assistant-message { margin-right: var(--pill-inset); }
 }
 
 /* ── Markdown heading scale (sidebar-appropriate) ───────────── */
+/*
+ * IMPORTANT: target `markdown-block h1` (stable custom-element tag), NOT
+ * `.pi-assistant-body h1` (hook-dependent class).
+ *
+ * Tailwind v4's base reset (`@layer base`) sets
+ *   h1,h2,...,h6 { font-size: inherit; font-weight: inherit }
+ * which strips browser defaults. Our overrides are unlayered so they win
+ * over the reset, but ONLY if the selector actually matches. The old
+ * `.pi-assistant-body h1` selector failed whenever the style hook didn't
+ * run (streaming, DOM structure changes from upstream bumps, timing
+ * races) — leaving headings at `inherit` with no cap.
+ *
+ * Using `markdown-block h1` always matches because `markdown-block` is a
+ * stable custom element tag in pi-web-ui's light DOM. This also covers
+ * headings inside thinking blocks and tool cards without needing separate
+ * overrides (those have their own more-specific rules if needed).
+ */
 
-.pi-assistant-body h1 {
+markdown-block h1 {
   font-size: var(--text-lg);
   font-weight: 700;
   line-height: 1.3;
   margin: 16px 0 8px;
 }
 
-.pi-assistant-body h2 {
+markdown-block h2 {
   font-size: var(--text-md);
   font-weight: 700;
   line-height: 1.35;
   margin: 14px 0 6px;
 }
 
-.pi-assistant-body h3 {
+markdown-block h3 {
   font-size: var(--text-base);
   font-weight: 700;
   line-height: 1.4;
   margin: 12px 0 4px;
 }
 
-.pi-assistant-body h4,
-.pi-assistant-body h5,
-.pi-assistant-body h6 {
+markdown-block h4,
+markdown-block h5,
+markdown-block h6 {
   font-size: var(--text-base);
   font-weight: 600;
   line-height: 1.4;
   margin: 10px 0 4px;
 }
 
-.pi-assistant-body h1:first-child,
-.pi-assistant-body h2:first-child,
-.pi-assistant-body h3:first-child,
-.pi-assistant-body h4:first-child,
-.pi-assistant-body h5:first-child,
-.pi-assistant-body h6:first-child {
+markdown-block h1:first-child,
+markdown-block h2:first-child,
+markdown-block h3:first-child,
+markdown-block h4:first-child,
+markdown-block h5:first-child,
+markdown-block h6:first-child {
   margin-top: 0;
 }
 


### PR DESCRIPTION
## Problem
H1 headings in assistant messages render at browser-default size (~32px) instead of our sidebar scale (18px). This is a recurring regression — the same root cause has been behind multiple rendering issues.

## Root cause
Tailwind v4's base reset (`@layer base`) sets `h1 { font-size: inherit; font-weight: inherit }`, stripping browser defaults. Our overrides used `.pi-assistant-body h1` — which depends on `applyMessageStyleHooks()` successfully stamping the class. When the hook fails (streaming state, DOM structure changes from dep bumps, timing), headings get **no sizing at all** and inherit from the parent chain.

This is the same fragility pattern that caused:
- #486 (KaTeX hijacking formula text)
- #487 (thinking block scroll issues)

All relied on hook-dependent class selectors matching specific DOM structures.

## Fix
Target `markdown-block h1` instead of `.pi-assistant-body h1`. `markdown-block` is a stable custom element tag in pi-web-ui's light DOM — it always exists in the render tree regardless of hook state, streaming, or upstream component changes.

| Before | After |
|--------|-------|
| `.pi-assistant-body h1` (hook-dependent) | `markdown-block h1` (always matches) |
| Fails when hook doesn't run → browser defaults | Always applies → 18px max |

## Testing
- `npm run build` ✅
- `npm run test:context` ✅ (640/640)