### PR TITLE
feat: configurable context windows for custom gateways

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This folder contains **current** docs that should match shipped behavior.
 ## Guides
 - [Install Pi for Excel](./install.md)
 - [Deploy hosted build on Vercel](./deploy-vercel.md)
-- [Release notes (`v0.9.0-pre`)](./release-notes/v0.9.0-pre.md)
+- [Release notes (`v0.9.2-pre`)](./release-notes/v0.9.2-pre.md)
 - [Release smoke test checklist](./release-smoke-test-checklist.md)
 - [Release smoke run logs](./release-smoke-runs/README.md)
 

--- a/docs/release-notes/v0.9.2-pre.md
+++ b/docs/release-notes/v0.9.2-pre.md
@@ -1,0 +1,16 @@
+# v0.9.2-pre release notes
+
+_Pre-release. Changes since `v0.9.1-pre`._
+
+## Highlights
+
+- **Custom OpenAI-compatible gateways can now declare their real context window**
+  - Added a **Max context tokens** field in Settings → Providers → Custom OpenAI-compatible gateways.
+  - Custom gateway cards now show the configured local context budget.
+  - Pi now uses that configured value for local context budgeting, status-bar context math, and auto-compaction thresholds.
+  - Restored sessions and live runtimes refresh custom gateway model metadata from the latest saved gateway configuration.
+
+## Notes
+
+- This release addresses issue #522.
+- Thanks to @lifeishimeizi for the report, repro, and feature suggestion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.1-pre",
+  "version": "0.9.2-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-for-excel",
-      "version": "0.9.1-pre",
+      "version": "0.9.2-pre",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5996,16 +5996,16 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-retry": {
@@ -6018,6 +6018,17 @@
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/balanced-match": {
@@ -6050,9 +6061,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.1-pre",
+  "version": "0.9.2-pre",
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
   },
   "overrides": {
     "tmp": "0.2.5",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "minimatch": "10.2.4",
     "rollup": "4.59.0",
-    "basic-ftp": "5.2.0",
+    "basic-ftp": "5.2.2",
     "underscore": "1.13.8",
     "tar": "7.5.11",
     "fast-xml-parser": "5.5.10"

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -5,4 +5,4 @@
  */
 
 export const APP_NAME = "pi-for-excel";
-export const APP_VERSION = "0.9.0-pre";
+export const APP_VERSION = "0.9.2-pre";

--- a/src/auth/custom-gateways.ts
+++ b/src/auth/custom-gateways.ts
@@ -9,8 +9,8 @@ const OPENAI_GATEWAY_ID_PREFIX = "pi-openai-gateway:";
 export const OPENAI_GATEWAY_PROVIDER_PREFIX = "Gateway · ";
 const OPENAI_GATEWAY_TYPE = "openai-completions";
 
-const DEFAULT_CONTEXT_WINDOW = 16_384;
-const DEFAULT_MAX_TOKENS = 4_096;
+export const DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW = 16_384;
+const DEFAULT_OPENAI_GATEWAY_MAX_TOKENS = 4_096;
 
 type StoredModel = NonNullable<CustomProvider["models"]>[number];
 
@@ -28,6 +28,7 @@ export interface OpenAiGatewayConfig {
   modelId: string;
   apiKey: string;
   providerName: string;
+  contextWindow: number;
 }
 
 export interface SaveOpenAiGatewayInput {
@@ -36,6 +37,7 @@ export interface SaveOpenAiGatewayInput {
   endpointUrl: string;
   modelId: string;
   apiKey?: string;
+  contextWindow?: number;
 }
 
 export interface CustomProviderRuntimeInfo {
@@ -82,6 +84,23 @@ export function normalizeGatewayEndpointUrl(endpointUrl: string): string {
 
 export function normalizeGatewayModelId(modelId: string): string {
   return normalizeRequiredString(modelId, "Model ID");
+}
+
+export function normalizeGatewayContextWindow(contextWindow: number | null | undefined): number {
+  if (contextWindow == null) {
+    return DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW;
+  }
+
+  if (!Number.isInteger(contextWindow)) {
+    throw new Error("Max context tokens must be a whole number.");
+  }
+
+  const normalized = contextWindow;
+  if (normalized < 1_024) {
+    throw new Error("Max context tokens must be at least 1024.");
+  }
+
+  return normalized;
 }
 
 function deriveDisplayName(rawName: string | undefined, endpointUrl: string): string {
@@ -166,6 +185,7 @@ function providerToGatewayConfig(provider: CustomProvider): OpenAiGatewayConfig 
     modelId,
     apiKey: normalizeOptionalString(provider.apiKey),
     providerName,
+    contextWindow: normalizeGatewayContextWindow(model.contextWindow),
   };
 }
 
@@ -173,6 +193,7 @@ function createGatewayModel(args: {
   endpointUrl: string;
   modelId: string;
   providerName: string;
+  contextWindow: number;
 }): Model<"openai-completions"> {
   return {
     id: args.modelId,
@@ -188,8 +209,8 @@ function createGatewayModel(args: {
       cacheRead: 0,
       cacheWrite: 0,
     },
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
+    contextWindow: args.contextWindow,
+    maxTokens: DEFAULT_OPENAI_GATEWAY_MAX_TOKENS,
   };
 }
 
@@ -239,6 +260,7 @@ export async function saveOpenAiGatewayConfig(
 ): Promise<OpenAiGatewayConfig> {
   const endpointUrl = normalizeGatewayEndpointUrl(input.endpointUrl);
   const modelId = normalizeGatewayModelId(input.modelId);
+  const contextWindow = normalizeGatewayContextWindow(input.contextWindow);
   const existingGateways = await listOpenAiGatewayConfigs(customProvidersStore);
 
   if (input.id) {
@@ -269,6 +291,7 @@ export async function saveOpenAiGatewayConfig(
         endpointUrl,
         modelId,
         providerName,
+        contextWindow,
       }),
     ],
   };
@@ -282,7 +305,35 @@ export async function saveOpenAiGatewayConfig(
     modelId,
     apiKey,
     providerName,
+    contextWindow,
   };
+}
+
+export function resolveCustomProviderModel(
+  customProviders: CustomProvider[],
+  persistedModel: Pick<Model<Api>, "api" | "id" | "provider" | "baseUrl">,
+): Model<Api> | null {
+  let fallbackMatch: Model<Api> | null = null;
+
+  for (const provider of customProviders) {
+    const storedModels = Array.isArray(provider.models) ? provider.models : [];
+
+    for (const storedModel of storedModels) {
+      if (storedModel.api !== persistedModel.api || storedModel.id !== persistedModel.id) {
+        continue;
+      }
+
+      if (storedModel.provider === persistedModel.provider) {
+        return storedModel;
+      }
+
+      if (fallbackMatch === null && storedModel.baseUrl === persistedModel.baseUrl) {
+        fallbackMatch = storedModel;
+      }
+    }
+  }
+
+  return fallbackMatch;
 }
 
 export async function deleteOpenAiGatewayConfig(

--- a/src/auth/custom-gateways.ts
+++ b/src/auth/custom-gateways.ts
@@ -195,6 +195,8 @@ function createGatewayModel(args: {
   providerName: string;
   contextWindow: number;
 }): Model<"openai-completions"> {
+  const maxTokens = Math.min(DEFAULT_OPENAI_GATEWAY_MAX_TOKENS, args.contextWindow);
+
   return {
     id: args.modelId,
     name: args.modelId,
@@ -210,7 +212,7 @@ function createGatewayModel(args: {
       cacheWrite: 0,
     },
     contextWindow: args.contextWindow,
-    maxTokens: DEFAULT_OPENAI_GATEWAY_MAX_TOKENS,
+    maxTokens,
   };
 }
 
@@ -309,17 +311,24 @@ export async function saveOpenAiGatewayConfig(
   };
 }
 
+function matchesPersistedCustomModel(
+  storedModel: StoredModel,
+  persistedModel: Pick<Model<Api>, "api" | "id" | "provider" | "baseUrl">,
+): storedModel is Model<Api> {
+  return storedModel.api === persistedModel.api && storedModel.id === persistedModel.id;
+}
+
 export function resolveCustomProviderModel(
   customProviders: CustomProvider[],
   persistedModel: Pick<Model<Api>, "api" | "id" | "provider" | "baseUrl">,
 ): Model<Api> | null {
-  let fallbackMatch: Model<Api> | null = null;
+  const fallbackMatches: Model<Api>[] = [];
 
   for (const provider of customProviders) {
     const storedModels = Array.isArray(provider.models) ? provider.models : [];
 
     for (const storedModel of storedModels) {
-      if (storedModel.api !== persistedModel.api || storedModel.id !== persistedModel.id) {
+      if (!matchesPersistedCustomModel(storedModel, persistedModel)) {
         continue;
       }
 
@@ -327,13 +336,13 @@ export function resolveCustomProviderModel(
         return storedModel;
       }
 
-      if (fallbackMatch === null && storedModel.baseUrl === persistedModel.baseUrl) {
-        fallbackMatch = storedModel;
+      if (storedModel.baseUrl === persistedModel.baseUrl) {
+        fallbackMatches.push(storedModel);
       }
     }
   }
 
-  return fallbackMatch;
+  return fallbackMatches.length === 1 ? fallbackMatches[0] : null;
 }
 
 export async function deleteOpenAiGatewayConfig(

--- a/src/commands/builtins/custom-gateway-settings.ts
+++ b/src/commands/builtins/custom-gateway-settings.ts
@@ -5,6 +5,7 @@
 import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.js";
 
 import {
+  DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW,
   deleteOpenAiGatewayConfig,
   listOpenAiGatewayConfigs,
   saveOpenAiGatewayConfig,
@@ -27,6 +28,10 @@ function createHint(text: string): HTMLParagraphElement {
   hint.className = "pi-overlay-hint";
   hint.textContent = text;
   return hint;
+}
+
+function formatTokenCount(value: number): string {
+  return `${value.toLocaleString()} tokens`;
 }
 
 function createGatewayCard(args: {
@@ -82,11 +87,15 @@ function createGatewayCard(args: {
   model.className = "pi-settings-gateway-item__meta";
   model.textContent = `Model: ${args.gateway.modelId}`;
 
+  const contextWindow = document.createElement("p");
+  contextWindow.className = "pi-settings-gateway-item__meta";
+  contextWindow.textContent = `Max context: ${formatTokenCount(args.gateway.contextWindow)}`;
+
   const keyState = document.createElement("p");
   keyState.className = "pi-settings-gateway-item__meta";
   keyState.textContent = args.gateway.apiKey.length > 0 ? "API key: configured" : "API key: none";
 
-  card.append(topRow, endpoint, model, keyState);
+  card.append(topRow, endpoint, model, contextWindow, keyState);
   return card;
 }
 
@@ -121,6 +130,14 @@ export async function buildCustomGatewaySection(
     placeholder: "model-id",
   });
 
+  const contextWindowInput = createConfigInput({
+    placeholder: String(DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW),
+    type: "number",
+  });
+  contextWindowInput.min = "1024";
+  contextWindowInput.step = "1";
+  contextWindowInput.inputMode = "numeric";
+
   const apiKeyInput = createConfigInput({
     placeholder: "API key (optional for local servers)",
     type: "password",
@@ -149,6 +166,10 @@ export async function buildCustomGatewaySection(
     createConfigRow("Name", nameInput),
     createConfigRow("Endpoint", endpointInput),
     createConfigRow("Model", modelInput),
+    createConfigRow("Max context tokens", contextWindowInput),
+    createHint(
+      "Used for Pi's local context budgeting and auto-compaction. Set this to your gateway model's real context window.",
+    ),
     createConfigRow("API key", apiKeyInput),
     errorText,
     formActions,
@@ -180,6 +201,7 @@ export async function buildCustomGatewaySection(
     nameInput.value = "";
     endpointInput.value = "";
     modelInput.value = "";
+    contextWindowInput.value = "";
     apiKeyInput.value = "";
     cancelButton.hidden = true;
     saveButton.textContent = "Save gateway";
@@ -191,6 +213,7 @@ export async function buildCustomGatewaySection(
     nameInput.value = gateway.displayName;
     endpointInput.value = gateway.endpointUrl;
     modelInput.value = gateway.modelId;
+    contextWindowInput.value = String(gateway.contextWindow);
     apiKeyInput.value = gateway.apiKey;
     cancelButton.hidden = false;
     saveButton.textContent = "Update gateway";
@@ -252,12 +275,18 @@ export async function buildCustomGatewaySection(
       cancelButton.disabled = true;
 
       try {
+        const rawContextWindow = contextWindowInput.value.trim();
+        const contextWindow = rawContextWindow.length > 0
+          ? Number(rawContextWindow)
+          : undefined;
+
         const saved = await saveOpenAiGatewayConfig(getAppStorage().customProviders, {
           id: editingGatewayId ?? undefined,
           displayName: nameInput.value,
           endpointUrl: endpointInput.value,
           modelId: modelInput.value,
           apiKey: apiKeyInput.value,
+          contextWindow,
         });
 
         await reloadGateways();

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -10,6 +10,7 @@ import { Agent } from "@mariozechner/pi-agent-core";
 import { ApiKeyPromptDialog } from "@mariozechner/pi-web-ui/dist/dialogs/ApiKeyPromptDialog.js";
 import { ModelSelector } from "@mariozechner/pi-web-ui/dist/dialogs/ModelSelector.js";
 import { getAppStorage } from "@mariozechner/pi-web-ui/dist/storage/app-storage.js";
+import type { CustomProvider } from "@mariozechner/pi-web-ui/dist/storage/stores/custom-providers-store.js";
 import type { SessionData } from "@mariozechner/pi-web-ui/dist/storage/types.js";
 
 import { createOfficeStreamFn } from "../auth/stream-proxy.js";
@@ -20,7 +21,10 @@ import {
   validateOfficeProxyUrl,
 } from "../auth/proxy-validation.js";
 import { restoreCredentials } from "../auth/restore.js";
-import { collectCustomProviderRuntimeInfo } from "../auth/custom-gateways.js";
+import {
+  collectCustomProviderRuntimeInfo,
+  resolveCustomProviderModel,
+} from "../auth/custom-gateways.js";
 import { invalidateBlueprint } from "../context/blueprint.js";
 import { ChangeTracker } from "../context/change-tracker.js";
 import {
@@ -257,6 +261,7 @@ export async function initTaskpane(opts: {
   // 2. Resolve available providers (built-ins + configured custom providers)
   let availableProviders: string[] = [];
   let customProviderApiKeys = new Map<string, string | undefined>();
+  let configuredCustomProviders: CustomProvider[] = [];
   let defaultCustomModel: ReturnType<typeof collectCustomProviderRuntimeInfo>["defaultModel"] = null;
   let defaultModel = pickDefaultModel([], null);
 
@@ -274,9 +279,11 @@ export async function initTaskpane(opts: {
       console.warn("[auth] Built-in provider lookup failed:", error);
     }
 
+    let nextConfiguredCustomProviders: CustomProvider[] = [];
+
     try {
-      const configuredCustomProviders = await customProviders.getAll();
-      const customInfo = collectCustomProviderRuntimeInfo(configuredCustomProviders);
+      nextConfiguredCustomProviders = await customProviders.getAll();
+      const customInfo = collectCustomProviderRuntimeInfo(nextConfiguredCustomProviders);
       nextCustomApiKeys = customInfo.apiKeys;
       nextDefaultCustomModel = customInfo.defaultModel;
 
@@ -288,14 +295,23 @@ export async function initTaskpane(opts: {
     }
 
     availableProviders = Array.from(combinedProviders);
+    configuredCustomProviders = nextConfiguredCustomProviders;
     customProviderApiKeys = nextCustomApiKeys;
     defaultCustomModel = nextDefaultCustomModel;
     defaultModel = pickDefaultModel(availableProviders, defaultCustomModel);
     setActiveProviders(combinedProviders);
   };
 
+  let onProvidersChanged: (() => void) | null = null;
+
   document.addEventListener("pi:providers-changed", () => {
-    void refreshConfiguredProviders();
+    void refreshConfiguredProviders()
+      .then(() => {
+        onProvidersChanged?.();
+      })
+      .catch((error: unknown) => {
+        console.warn("[auth] Provider refresh after settings change failed:", error);
+      });
   });
 
   // 2b. Restore auth (bounded to avoid indefinite startup hang).
@@ -534,6 +550,48 @@ export async function initTaskpane(opts: {
   const getActiveQueueDisplay = () => getActiveRuntime()?.queueDisplay ?? null;
   const getActiveActionQueue = () => getActiveRuntime()?.actionQueue ?? null;
   const getActiveLockState = () => getActiveRuntime()?.lockState ?? "idle";
+
+  const areRuntimeModelsEquivalent = (
+    left: Agent["state"]["model"],
+    right: Agent["state"]["model"],
+  ): boolean => (
+    left.api === right.api &&
+    left.id === right.id &&
+    left.provider === right.provider &&
+    left.baseUrl === right.baseUrl &&
+    left.contextWindow === right.contextWindow &&
+    left.maxTokens === right.maxTokens
+  );
+
+  const refreshRuntimeModelsFromCustomProviders = (): void => {
+    const activeRuntimeId = getActiveRuntime()?.runtimeId ?? null;
+    let activeRuntimeChanged = false;
+    let anyRuntimeChanged = false;
+
+    for (const runtime of runtimeManager.listRuntimes()) {
+      const currentModel = runtime.agent.state.model;
+      const refreshedModel = resolveCustomProviderModel(configuredCustomProviders, currentModel);
+      if (!refreshedModel || areRuntimeModelsEquivalent(currentModel, refreshedModel)) {
+        continue;
+      }
+
+      runtime.agent.setModel(refreshedModel);
+      anyRuntimeChanged = true;
+      if (runtime.runtimeId === activeRuntimeId) {
+        activeRuntimeChanged = true;
+      }
+    }
+
+    if (!anyRuntimeChanged) {
+      return;
+    }
+
+    document.dispatchEvent(new CustomEvent("pi:status-update"));
+    if (activeRuntimeChanged) {
+      requestAnimationFrame(() => sidebar.requestUpdate());
+    }
+  };
+  onProvidersChanged = refreshRuntimeModelsFromCustomProviders;
 
   const workbookRecoveryLog = getWorkbookRecoveryLog();
   const manualFullBackupStore = getManualFullWorkbookBackupStore();
@@ -980,6 +1038,7 @@ export async function initTaskpane(opts: {
       agent,
       sessions,
       settings,
+      customProvidersStore: customProviders,
       initialSessionId: runtimeSessionId,
       autoRestoreLatest: optsForRuntime.autoRestoreLatest,
     });

--- a/src/taskpane/sessions.ts
+++ b/src/taskpane/sessions.ts
@@ -7,13 +7,16 @@
  * - session identity lifecycle (new / rename / resume)
  */
 
-import type { Model } from "@mariozechner/pi-ai";
 import { getModel } from "@mariozechner/pi-ai";
 import type { Agent, AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionData } from "@mariozechner/pi-web-ui/dist/storage/types.js";
 import type { SessionsStore } from "@mariozechner/pi-web-ui/dist/storage/stores/sessions-store.js";
 import type { SettingsStore } from "@mariozechner/pi-web-ui/dist/storage/stores/settings-store.js";
 
+import {
+  resolveCustomProviderModel,
+  type CustomProvidersStoreLike,
+} from "../auth/custom-gateways.js";
 import { extractTextFromContent } from "../utils/content.js";
 import { getWorkbookContext } from "../workbook/context.js";
 import {
@@ -38,6 +41,7 @@ export interface SessionPersistenceController {
 }
 
 type SessionId = string;
+type PersistedSessionModel = SessionData["model"];
 
 type UserLikeMessage = AgentMessage & {
   role: "user" | "user-with-attachments";
@@ -48,16 +52,37 @@ type UserLikeMessage = AgentMessage & {
  * Re-resolve a persisted model against the current registry so that
  * metadata like `contextWindow` picks up upstream changes (e.g. a dep
  * bump that raised Opus 4.6 from 200k → 1M). Falls back to the
- * persisted model if the registry doesn't have it (custom gateways, etc.).
+ * persisted model if the registry doesn't have it, then tries the live
+ * custom-provider store before finally reusing the persisted snapshot.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Model<any> from session store
-function refreshModelFromRegistry(persisted: Model<any>): Model<any> {
+async function refreshPersistedModel(args: {
+  persisted: PersistedSessionModel;
+  customProvidersStore?: CustomProvidersStoreLike;
+}): Promise<PersistedSessionModel> {
+  const { persisted, customProvidersStore } = args;
+
   try {
     const fresh = getModel(persisted.provider as never, persisted.id as never);
-    return fresh ?? persisted;
+    if (fresh) {
+      return fresh;
+    }
   } catch {
-    return persisted;
+    // Fall through to custom-provider lookup / persisted snapshot.
   }
+
+  if (customProvidersStore) {
+    try {
+      const customProviders = await customProvidersStore.getAll();
+      const freshCustomModel = resolveCustomProviderModel(customProviders, persisted);
+      if (freshCustomModel) {
+        return freshCustomModel;
+      }
+    } catch {
+      // Fall through to the persisted snapshot.
+    }
+  }
+
+  return persisted;
 }
 
 function hasAssistantMessage(messages: AgentMessage[]): boolean {
@@ -121,6 +146,7 @@ export async function setupSessionPersistence(opts: {
   agent: Agent;
   sessions: SessionsStore;
   settings: SettingsStore;
+  customProvidersStore?: CustomProvidersStoreLike;
   initialSessionId?: string;
   autoRestoreLatest?: boolean;
 }): Promise<SessionPersistenceController> {
@@ -299,7 +325,10 @@ export async function setupSessionPersistence(opts: {
     agent.replaceMessages(sessionData.messages);
 
     if (sessionData.model) {
-      agent.setModel(refreshModelFromRegistry(sessionData.model));
+      agent.setModel(await refreshPersistedModel({
+        persisted: sessionData.model,
+        customProvidersStore: opts.customProvidersStore,
+      }));
     }
     if (sessionData.thinkingLevel) {
       agent.setThinkingLevel(sessionData.thinkingLevel);

--- a/tests/custom-gateways.test.ts
+++ b/tests/custom-gateways.test.ts
@@ -73,6 +73,21 @@ void test("saveOpenAiGatewayConfig stores custom context window metadata", async
   assert.equal(listed[0]?.contextWindow, 131_072);
 });
 
+void test("saveOpenAiGatewayConfig clamps maxTokens to the configured context window", async () => {
+  const store = new MemoryCustomProvidersStore();
+
+  const saved = await saveOpenAiGatewayConfig(store, {
+    displayName: "Tight budget",
+    endpointUrl: "https://gateway.example.com/v1",
+    modelId: "small-model",
+    contextWindow: 2_048,
+  });
+
+  const storedModel = (await store.get(saved.id))?.models?.[0];
+  assert.equal(storedModel?.contextWindow, 2_048);
+  assert.equal(storedModel?.maxTokens, 2_048);
+});
+
 void test("saveOpenAiGatewayConfig rejects invalid context window values", async () => {
   const store = new MemoryCustomProvidersStore();
 
@@ -133,6 +148,30 @@ void test("resolveCustomProviderModel refreshes renamed gateway models by base U
   assert.ok(refreshed);
   assert.equal(refreshed?.contextWindow, 262_144);
   assert.match(refreshed?.provider ?? "", /^Gateway · Warehouse API EU/);
+});
+
+void test("resolveCustomProviderModel refuses ambiguous base-url fallback matches", async () => {
+  const store = new MemoryCustomProvidersStore();
+
+  await saveOpenAiGatewayConfig(store, {
+    displayName: "Warehouse API US",
+    endpointUrl: "https://warehouse.example.com/v1",
+    modelId: "supply-chain",
+  });
+  await saveOpenAiGatewayConfig(store, {
+    displayName: "Warehouse API EU",
+    endpointUrl: "https://warehouse.example.com/v1",
+    modelId: "supply-chain",
+  });
+
+  const resolved = resolveCustomProviderModel(await store.getAll(), {
+    api: "openai-completions",
+    id: "supply-chain",
+    provider: "Gateway · Warehouse API",
+    baseUrl: "https://warehouse.example.com/v1",
+  });
+
+  assert.equal(resolved, null);
 });
 
 void test("deleteOpenAiGatewayConfig only removes managed gateway entries", async () => {

--- a/tests/custom-gateways.test.ts
+++ b/tests/custom-gateways.test.ts
@@ -4,9 +4,11 @@ import { test } from "node:test";
 import type { CustomProvider } from "@mariozechner/pi-web-ui/dist/storage/stores/custom-providers-store.js";
 
 import {
+  DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW,
   collectCustomProviderRuntimeInfo,
   deleteOpenAiGatewayConfig,
   listOpenAiGatewayConfigs,
+  resolveCustomProviderModel,
   saveOpenAiGatewayConfig,
   type CustomProvidersStoreLike,
 } from "../src/auth/custom-gateways.ts";
@@ -47,10 +49,41 @@ void test("saveOpenAiGatewayConfig stores normalized endpoint/model/provider", a
   assert.equal(saved.modelId, "gpt-4o-mini");
   assert.equal(saved.apiKey, "sk-test");
   assert.match(saved.providerName, /^Gateway · gateway\.example\.com/);
+  assert.equal(saved.contextWindow, DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW);
 
   const listed = await listOpenAiGatewayConfigs(store);
   assert.equal(listed.length, 1);
   assert.equal(listed[0]?.providerName, saved.providerName);
+  assert.equal(listed[0]?.contextWindow, DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW);
+});
+
+void test("saveOpenAiGatewayConfig stores custom context window metadata", async () => {
+  const store = new MemoryCustomProvidersStore();
+
+  const saved = await saveOpenAiGatewayConfig(store, {
+    displayName: "Big context",
+    endpointUrl: "https://gateway.example.com/v1",
+    modelId: "big-model",
+    contextWindow: 131_072,
+  });
+
+  assert.equal(saved.contextWindow, 131_072);
+
+  const listed = await listOpenAiGatewayConfigs(store);
+  assert.equal(listed[0]?.contextWindow, 131_072);
+});
+
+void test("saveOpenAiGatewayConfig rejects invalid context window values", async () => {
+  const store = new MemoryCustomProvidersStore();
+
+  await assert.rejects(
+    saveOpenAiGatewayConfig(store, {
+      endpointUrl: "https://gateway.example.com/v1",
+      modelId: "too-small",
+      contextWindow: 512,
+    }),
+    /at least 1024/i,
+  );
 });
 
 void test("gateway provider names stay unique when display names collide", async () => {
@@ -70,6 +103,36 @@ void test("gateway provider names stay unique when display names collide", async
 
   assert.notEqual(first.providerName, second.providerName);
   assert.match(second.providerName, /\(2\)$/);
+});
+
+void test("resolveCustomProviderModel refreshes renamed gateway models by base URL and model id", async () => {
+  const store = new MemoryCustomProvidersStore();
+
+  const firstSave = await saveOpenAiGatewayConfig(store, {
+    displayName: "Warehouse API",
+    endpointUrl: "https://warehouse.example.com/v1",
+    modelId: "supply-chain",
+    contextWindow: 16_384,
+  });
+
+  const persistedModel = (await store.get(firstSave.id))?.models?.[0];
+  assert.ok(persistedModel);
+  if (!persistedModel) {
+    throw new Error("Persisted model missing");
+  }
+
+  await saveOpenAiGatewayConfig(store, {
+    id: firstSave.id,
+    displayName: "Warehouse API EU",
+    endpointUrl: "https://warehouse.example.com/v1",
+    modelId: "supply-chain",
+    contextWindow: 262_144,
+  });
+
+  const refreshed = resolveCustomProviderModel(await store.getAll(), persistedModel);
+  assert.ok(refreshed);
+  assert.equal(refreshed?.contextWindow, 262_144);
+  assert.match(refreshed?.provider ?? "", /^Gateway · Warehouse API EU/);
 });
 
 void test("deleteOpenAiGatewayConfig only removes managed gateway entries", async () => {


### PR DESCRIPTION
## Summary
- add a Max context tokens field for custom OpenAI-compatible gateways and show the configured budget in the settings card
- use saved custom-provider metadata to refresh restored sessions and live runtimes so compaction/status calculations pick up gateway context-window changes
- bump to v0.9.2-pre and credit @lifeishimeizi in the release notes

## Testing
- npm run check
- npm run build
- npm run test:context
- visual verify: taskpane settings overlay screenshot for the new custom gateway field + configured gateway card

Resolves #522