### PR TITLE
chore: refresh Pi model registry and model selection

### DIFF
--- a/docs/context-management-policy.md
+++ b/docs/context-management-policy.md
@@ -25,7 +25,7 @@ This policy sets clear guardrails so we can improve context quality while preser
 
 - Each model call is built from: `systemPrompt + messages + tools`.
 - Tool disclosure is deterministic on every call (including tool-result continuations) in `src/auth/stream-proxy.ts` (`selectToolBundle()`): when tools are present, runtime currently sends the full tool set.
-- Runtime capability refresh in `src/taskpane/init.ts` now calls `agent.setTools(...)` only when tool metadata fingerprint changes **or** extension tool revision changes (extension register/unregister/reload), avoiding no-op churn on unrelated refresh passes while preserving schema-stable hot-reload correctness.
+- Runtime capability refresh in `src/taskpane/init.ts` now assigns `agent.state.tools = ...` only when tool metadata fingerprint changes **or** extension tool revision changes (extension register/unregister/reload), avoiding no-op churn on unrelated refresh passes while preserving schema-stable hot-reload correctness.
 - Session IDs are stable per chat runtime (`agent.sessionId`), which is used by providers for cache continuity.
 - Status/debug UI already shows payload composition counters (`systemChars`, `toolSchemaChars`, `messageChars`, call count) plus prefix-churn counters (`prefixChanges`, split by model/system/tools).
 - Context window estimation uses provider usage anchored by `calculateContextTokens()` (`input + output + cacheRead + cacheWrite`) in `src/utils/context-tokens.ts`.

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,8 +1,8 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-04-23
+**Last verified:** 2026-04-24
 
-This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.4`, `gpt-5.3-codex`, `claude-opus-4-7`, `gemini-3.1-pro-preview`).
+This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.5`, `gpt-5.3-codex`, `claude-opus-4-7`, `gemini-3.1-pro-preview`).
 
 This doc describes how to update:
 - the **Pi dependency versions** we ship (`@mariozechner/pi-ai`, `@mariozechner/pi-web-ui`, `@mariozechner/pi-agent-core`)
@@ -65,7 +65,7 @@ npm install
 Search the local registry:
 
 ```bash
-rg -n "gpt-5\\.4"       node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
+rg -n "gpt-5\\.5"       node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 rg -n "gpt-5\\.3-codex" node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 rg -n "claude-opus-4-7"  node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 rg -n "gemini-3\\.1-pro-preview" node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
@@ -96,16 +96,16 @@ We intentionally avoid pinning exact versioned IDs now. Instead we:
     - Version compare uses `parseMajorMinor()` where `claude-opus-4-6` → `46`, `claude-opus-4-7` → `47`.
     - Important: IDs like `claude-opus-4-20250514` are treated as **major only** (`40`) and the `YYYYMMDD` part is considered a separate date suffix by `modelRecencyScore()`.
   - **OpenAI (`openai` + `openai-codex`):** latest general `gpt-5.x` *if* its version >= latest `gpt-5.x-codex`, then latest Codex
-    - `gpt-5.4` scores as `54`; `gpt-5.3-codex` scores as `53`.
+    - `gpt-5.5` scores as `55`; `gpt-5.3-codex` scores as `53`.
     - Major-only GPT-5 IDs are also handled (`gpt-5`, `gpt-5-pro`, `gpt-5-codex`).
-    - Plain `gpt-5.x` / `gpt-5` beats same-version suffixed variants (`gpt-5.4` before `gpt-5.4-pro`, `gpt-5` before `gpt-5-pro`).
+    - Plain `gpt-5.x` / `gpt-5` beats same-version suffixed variants (`gpt-5.5` before `gpt-5.5-pro`, `gpt-5` before `gpt-5-pro`).
   - **Google (API key):** latest `gemini-*-pro*` (regex: `/^gemini-.*-pro/i`)
   - **Google OAuth providers (`google-gemini-cli`, `google-antigravity`):** prefer stable Gemini before previews
 
   The ordering logic is driven by:
   - `providerPriority()` (Anthropic → OpenAI Codex → OpenAI → Google → …)
   - `familyPriority()` / `openAiFamilyPriority()` (Opus/Sonnet/Haiku, GPT vs Codex, etc.)
-  - `parseMajorMinor()` + `modelRecencyScore()` (treats `4-6` as `46`, `5.4` as `54`, keeps `YYYYMMDD` as a separate date suffix, and ignores later date-like suffixes such as `gpt-4o-2024-11-20` or `gemini-2.5-pro-preview-06-05` when extracting the family version)
+  - `parseMajorMinor()` + `modelRecencyScore()` (treats `4-6` / `4.6` as `46`, `5.5` as `55`, keeps embedded date suffixes such as `YYYYMMDD` separate, and ignores later date-like suffixes such as `gpt-4o-2024-11-20` or `gemini-2.5-pro-preview-06-05` when extracting the family version)
   - `compareModels()` (provider + family + recency tie-breaks; deterministic sorting)
 
   UI: the model picker is opened from the footer status bar (click the π model button).

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -34,9 +34,9 @@ This doc describes how to update:
 ### 1) Check current installed versions
 
 ```bash
-node -p "require('@mariozechner/pi-ai/package.json').version"
-node -p "require('@mariozechner/pi-web-ui/package.json').version"
-node -p "require('@mariozechner/pi-agent-core/package.json').version"
+node -p "require('./node_modules/@mariozechner/pi-ai/package.json').version"
+node -p "require('./node_modules/@mariozechner/pi-web-ui/package.json').version"
+node -p "require('./node_modules/@mariozechner/pi-agent-core/package.json').version"
 ```
 
 ### 2) Check latest published versions

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,8 +1,8 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-04-07
+**Last verified:** 2026-04-23
 
-This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.4`, `gpt-5.3-codex`, `claude-opus-4-6`).
+This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@mariozechner/pi-ai`) and will drift as new models ship (e.g. `gpt-5.4`, `gpt-5.3-codex`, `claude-opus-4-7`, `gemini-3.1-pro-preview`).
 
 This doc describes how to update:
 - the **Pi dependency versions** we ship (`@mariozechner/pi-ai`, `@mariozechner/pi-web-ui`, `@mariozechner/pi-agent-core`)
@@ -34,9 +34,9 @@ This doc describes how to update:
 ### 1) Check current installed versions
 
 ```bash
-node -p "require('./node_modules/@mariozechner/pi-ai/package.json').version"
-node -p "require('./node_modules/@mariozechner/pi-web-ui/package.json').version"
-node -p "require('./node_modules/@mariozechner/pi-agent-core/package.json').version"
+node -p "require('@mariozechner/pi-ai/package.json').version"
+node -p "require('@mariozechner/pi-web-ui/package.json').version"
+node -p "require('@mariozechner/pi-agent-core/package.json').version"
 ```
 
 ### 2) Check latest published versions
@@ -67,7 +67,8 @@ Search the local registry:
 ```bash
 rg -n "gpt-5\\.4"       node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 rg -n "gpt-5\\.3-codex" node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
-rg -n "claude-opus-4-6"  node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
+rg -n "claude-opus-4-7"  node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
+rg -n "gemini-3\\.1-pro-preview" node_modules/@mariozechner/pi-ai/dist/models.generated.js -S
 ```
 
 If an ID doesn’t appear there, **don’t** add it to the add-in yet—either:
@@ -92,18 +93,19 @@ We intentionally avoid pinning exact versioned IDs now. Instead we:
 
   Featured rules (current desired behavior):
   - **Anthropic:** latest **Sonnet** *if* its version >= latest **Opus**, then latest **Opus**
-    - Version compare uses `parseMajorMinor()` where `claude-opus-4-5` → `45`, `claude-opus-4-6` → `46`.
+    - Version compare uses `parseMajorMinor()` where `claude-opus-4-6` → `46`, `claude-opus-4-7` → `47`.
     - Important: IDs like `claude-opus-4-20250514` are treated as **major only** (`40`) and the `YYYYMMDD` part is considered a separate date suffix by `modelRecencyScore()`.
   - **OpenAI (`openai` + `openai-codex`):** latest general `gpt-5.x` *if* its version >= latest `gpt-5.x-codex`, then latest Codex
     - `gpt-5.4` scores as `54`; `gpt-5.3-codex` scores as `53`.
-    - Plain `gpt-5.x` beats same-version suffixed variants (`gpt-5.4` before `gpt-5.4-pro`).
+    - Major-only GPT-5 IDs are also handled (`gpt-5`, `gpt-5-pro`, `gpt-5-codex`).
+    - Plain `gpt-5.x` / `gpt-5` beats same-version suffixed variants (`gpt-5.4` before `gpt-5.4-pro`, `gpt-5` before `gpt-5-pro`).
   - **Google (API key):** latest `gemini-*-pro*` (regex: `/^gemini-.*-pro/i`)
   - **Google OAuth providers (`google-gemini-cli`, `google-antigravity`):** prefer stable Gemini before previews
 
   The ordering logic is driven by:
   - `providerPriority()` (Anthropic → OpenAI Codex → OpenAI → Google → …)
   - `familyPriority()` / `openAiFamilyPriority()` (Opus/Sonnet/Haiku, GPT vs Codex, etc.)
-  - `parseMajorMinor()` + `modelRecencyScore()` (treats `4-6` as `46`, `5.4` as `54`, and keeps `YYYYMMDD` as a separate date suffix)
+  - `parseMajorMinor()` + `modelRecencyScore()` (treats `4-6` as `46`, `5.4` as `54`, keeps `YYYYMMDD` as a separate date suffix, and ignores later date-like suffixes such as `gpt-4o-2024-11-20` or `gemini-2.5-pro-preview-06-05` when extracting the family version)
   - `compareModels()` (provider + family + recency tie-breaks; deterministic sorting)
 
   UI: the model picker is opened from the footer status bar (click the π model button).

--- a/docs/upstream-divergences.md
+++ b/docs/upstream-divergences.md
@@ -50,8 +50,8 @@ a different lifecycle. Pi-mono's tool set only changes when the user explicitly
 does something (e.g. `/tools`). In Excel, capability refresh passes run on many
 events (focus/visibility return, integrations/connections/skills/rules/execution-mode/experimental updates, extension activation).
 
-Each refresh rebuilds tool objects. Without a guard, every pass would call
-`agent.setTools(...)` even when schema metadata is identical.
+Each refresh rebuilds tool objects. Without a guard, every pass would assign
+`agent.state.tools = ...` even when schema metadata is identical.
 
 We therefore gate tool updates by:
 - stable metadata fingerprint (`name`, `label`, `description`, `parameters`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
-        "@mariozechner/pi-agent-core": "^0.58.1",
-        "@mariozechner/pi-ai": "^0.58.1",
-        "@mariozechner/pi-web-ui": "^0.58.1",
+        "@mariozechner/pi-agent-core": "^0.69.0",
+        "@mariozechner/pi-ai": "^0.69.0",
+        "@mariozechner/pi-web-ui": "^0.69.0",
         "@sinclair/typebox": "^0.34.41",
         "lit": "^3.2.1",
         "marked": "^17.0.4"
@@ -22,6 +22,7 @@
         "eslint": "^10.0.3",
         "office-addin-debugging": "^6.0.6",
         "office-addin-manifest": "^2.1.2",
+        "typebox": "^1.1.32",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.57.0",
         "vite": "^7.3.2"
@@ -248,122 +249,57 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.984.0.tgz",
-      "integrity": "sha512-iFrdkDXdo+ELZ5qD8ZYw9MHoOhcXyVutO8z7csnYpJO0rbET/X6B8cQlOCMsqJHxkyMwW21J4vt9S5k2/FgPCg==",
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1035.0.tgz",
+      "integrity": "sha512-XELIQk+znh53J2Bj0EmOftgcKRLw3tvI/P4WHLgSbSBWPh+wg0SvHu+bgIlzMHARbOC9auA0lsH+Eb9JwF1yjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/eventstream-handler-node": "^3.972.5",
-        "@aws-sdk/middleware-eventstream": "^3.972.3",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/middleware-websocket": "^3.972.5",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/token-providers": "3.984.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.984.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
-        "@smithy/eventstream-serde-node": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.982.0.tgz",
-      "integrity": "sha512-qJrIiivmvujdGqJ0ldSUvhN3k3N7GtPesoOI1BSt0fNXovVnMz4C/JmnkhZihU7hJhDvxJaBROLYTU+lpild4w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
-      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/credential-provider-node": "^3.972.35",
+        "@aws-sdk/eventstream-handler-node": "^3.972.14",
+        "@aws-sdk/middleware-eventstream": "^3.972.10",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
+        "@aws-sdk/middleware-websocket": "^3.972.16",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/token-providers": "3.1035.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.20",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.16",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/middleware-retry": "^4.5.4",
+        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.48",
+        "@smithy/util-defaults-mode-node": "^4.2.53",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-stream": "^4.5.24",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -371,23 +307,24 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.6.tgz",
-      "integrity": "sha512-pz4ZOw3BLG0NdF25HoB9ymSYyPbMiIjwQJ2aROXRhAzt+b+EOxStfFv8s5iZyP6Kiw7aYhyWxj5G3NhmkoOTKw==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/xml-builder": "^3.972.4",
-        "@smithy/core": "^3.22.0",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -395,15 +332,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.4.tgz",
-      "integrity": "sha512-/8dnc7+XNMmViEom2xsNdArQxQPSgy4Z/lm6qaFPTrMFesT1bV3PsBhb19n09nmxHdrtQskYmViddUIjUQElXg==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -411,20 +348,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.6.tgz",
-      "integrity": "sha512-5ERWqRljiZv44AIdvIRQ3k+EAV0Sq2WeJHvXuK7gL7bovSxOf8Al7MLH7Eh3rdovH4KHFnlIty7J71mzvQBl5Q==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -432,24 +369,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.4.tgz",
-      "integrity": "sha512-eRUg+3HaUKuXWn/lEMirdiA5HOKmEl8hEHVuszIDt2MMBUKgVX5XNGmb3XmbgU17h6DZ+RtjbxQpjhz3SbTjZg==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-env": "^3.972.4",
-        "@aws-sdk/credential-provider-http": "^3.972.6",
-        "@aws-sdk/credential-provider-login": "^3.972.4",
-        "@aws-sdk/credential-provider-process": "^3.972.4",
-        "@aws-sdk/credential-provider-sso": "^3.972.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-login": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -457,18 +394,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.4.tgz",
-      "integrity": "sha512-nLGjXuvWWDlQAp505xIONI7Gam0vw2p7Qu3P6on/W2q7rjJXtYjtpHbcsaOjJ/pAju3eTvEQuSuRedcRHVQIAQ==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -476,22 +413,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.5.tgz",
-      "integrity": "sha512-VWXKgSISQCI2GKN3zakTNHSiZ0+mux7v6YHmmbLQp/o3fvYUQJmKGcLZZzg2GFA+tGGBStplra9VFNf/WwxpYg==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.4",
-        "@aws-sdk/credential-provider-http": "^3.972.6",
-        "@aws-sdk/credential-provider-ini": "^3.972.4",
-        "@aws-sdk/credential-provider-process": "^3.972.4",
-        "@aws-sdk/credential-provider-sso": "^3.972.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-ini": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -499,16 +436,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.4.tgz",
-      "integrity": "sha512-TCZpWUnBQN1YPk6grvd5x419OfXjHvhj5Oj44GYb84dOVChpg/+2VoEj+YVA4F4E/6huQPNnX7UYbTtxJqgihw==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -516,18 +453,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.4.tgz",
-      "integrity": "sha512-wzsGwv9mKlwJ3vHLyembBvGE/5nPUIwRR2I51B1cBV4Cb4ql9nIIfpmHzm050XYTY5fqTOKJQnhLj7zj89VG8g==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.982.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/token-providers": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/token-providers": "3.1036.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -535,17 +472,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.982.0.tgz",
-      "integrity": "sha512-v3M0KYp2TVHYHNBT7jHD9lLTWAdS9CaWJ2jboRKt0WAB65bA7iUEpR+k4VqKYtpQN4+8kKSc4w+K6kUNZkHKQw==",
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -553,17 +490,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.4.tgz",
-      "integrity": "sha512-hIzw2XzrG8jzsUSEatehmpkd5rWzASg5IHUfA+m01k/RtvfAML7ZJVVohuKdhAYx+wV2AThLiQJVzqn7F0khrw==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -571,14 +508,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.5.tgz",
-      "integrity": "sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
+      "integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -586,14 +523,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.3.tgz",
-      "integrity": "sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
+      "integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -601,14 +538,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
-      "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -616,13 +553,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
-      "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -630,15 +567,40 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
-      "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -646,33 +608,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.6.tgz",
-      "integrity": "sha512-TehLN8W/kivl0U9HcS+keryElEWORROpghDXZBLfnb40DXM7hx/i+7OOjkogXQOF3QtUraJVRkHQ07bPhrWKlw==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@smithy/core": "^3.22.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
-      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -680,22 +627,22 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.5.tgz",
-      "integrity": "sha512-BN4A9K71WRIlpQ3+IYGdBC2wVyobZ95g6ZomodmJ8Te772GWo0iDk2Mv6JIHdr842tOTgi1b3npLIFDUS4hl4g==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
+      "integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-format-url": "^3.972.3",
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -703,64 +650,49 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.982.0.tgz",
-      "integrity": "sha512-VVkaH27digrJfdVrT64rjkllvOp4oRiZuuJvrylLXAKl18ujToJR7AqpDldL/LS63RVne3QWIpkygIymxFtliQ==",
+      "version": "3.997.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
-      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -768,15 +700,32 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
-      "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -784,66 +733,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.984.0.tgz",
-      "integrity": "sha512-UJ/+OzZv+4nAQ1bSspCSb4JlYbMB2Adn8CK7hySpKX5sjhRu1bm6w1PqQq59U67LZEKsPdhl1rzcZ7ybK8YQxw==",
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1035.0.tgz",
+      "integrity": "sha512-E6IO3Cn+OzBe6Sb5pnubd5Y8qSUMAsVKkD5QSwFfIx5fV1g5SkYwUDRDyPlm90RuIVcCo28wpMJU6W8wXH46Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.984.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.984.0.tgz",
-      "integrity": "sha512-E9Os+U9NWFoEJXbTVT8sCi+HMnzmsMA8cuCkvlUUfin/oWewUTnCkB/OwFwiUQ2N7v1oBk+i4ZSsI1PiuOy8/w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.984.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -851,12 +751,24 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -864,15 +776,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.984.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.984.0.tgz",
-      "integrity": "sha512-9ebjLA0hMKHeVvXEtTDCCOBtwjb0bOXiuUV06HNeVdgAjH6gj4x4Zwt4IBti83TiyTGOCl5YfZqGx4ehVsasbQ==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -880,14 +792,14 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.3.tgz",
-      "integrity": "sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -895,9 +807,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
-      "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -907,27 +819,28 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
-      "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.4.tgz",
-      "integrity": "sha512-3WFCBLiM8QiHDfosQq3Py+lIMgWlFWwFQliUHUqwEiRqLnKyhgbU3AKa7AWJF7lW2Oc/2kFNY4MlAYVnVc0i8A==",
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -943,13 +856,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -957,9 +870,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -3198,34 +3111,33 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.58.1.tgz",
-      "integrity": "sha512-7bnkMRgdbfH1A397K7OOQ8XGpZQtJ+kqT1WClj7W00eHTvTUxgJBMCAJXmsho4PqmUxHwIoOTr1mhPW14yH3Zw==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.69.0.tgz",
+      "integrity": "sha512-dYZjee7QEIwVVbDGCGriiLjDT34IdMlXMjMp4drVKcLEuVc+BztyODwu3w4ZORVvwaySGGlF9UALjJKUVoXiug==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.58.1"
+        "@mariozechner/pi-ai": "^0.69.0",
+        "typebox": "^1.1.24"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.58.1.tgz",
-      "integrity": "sha512-ZZ9+SiWVm55JlafOlv3InAUBrSzAji1n8otvSjS7VLHHpfEUeG5s+L1w8S76t8gn9+lqVLK4/UgkxQUdFWIyDw==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.69.0.tgz",
+      "integrity": "sha512-bl838sr57zx/apkiTeNPFQgbBkGXN4HHhm2oghzSRohJIBrR+H001bTeco7Osuke+EZTxO3V5Aev2qlZdUa2xw==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.73.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
         "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.14.1",
-        "@sinclair/typebox": "^0.34.41",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
+        "@mistralai/mistralai": "^2.2.0",
         "chalk": "^5.6.2",
         "openai": "6.26.0",
         "partial-json": "^0.1.7",
         "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
         "undici": "^7.19.1",
         "zod-to-json-schema": "^3.24.6"
       },
@@ -3237,9 +3149,9 @@
       }
     },
     "node_modules/@mariozechner/pi-ai/node_modules/@anthropic-ai/sdk": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
-      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -3257,9 +3169,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.58.1.tgz",
-      "integrity": "sha512-4cO6E4/zN3FFzfwvdBpBYaZagrEyuOzZV2PYiS+FFl8u4pC1TsrV2GYqjhVVpylgxoOTKNyiargZvthp0kc4xQ==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.69.0.tgz",
+      "integrity": "sha512-/82SOMzCA1srivwfcSO8r9XLdAgJNcgpWzNZY33IqqvGev8Q4iWY/hA1wAkLB0l7PKJJ4Dh57xS4IGHbyVM7lA==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -3288,19 +3200,20 @@
       }
     },
     "node_modules/@mariozechner/pi-web-ui": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.58.1.tgz",
-      "integrity": "sha512-nZcp9H3B/qqbBuoYaGRxB27EYcMYztxvZF/BL+MnugTKHSjR+WLTKESxihiVX7xoYDlgdAuB9Td6K+4Vfop/Kw==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.69.0.tgz",
+      "integrity": "sha512-n1n+fO19tcKiQAYdJomX7Ba/RdEvXPohpPXFZmM2ib6Bozd3tLNUc8NulYdy///qvZOGkin+EYPObY1NA6bIaA==",
       "license": "MIT",
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
-        "@mariozechner/pi-ai": "^0.58.1",
-        "@mariozechner/pi-tui": "^0.58.1",
+        "@mariozechner/pi-ai": "^0.69.0",
+        "@mariozechner/pi-tui": "^0.69.0",
         "docx-preview": "^0.3.7",
         "jszip": "^3.10.1",
         "lucide": "^0.544.0",
         "ollama": "^0.6.0",
         "pdfjs-dist": "5.4.394",
+        "typebox": "^1.1.24",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "peerDependencies": {
@@ -3932,13 +3845,14 @@
       }
     },
     "node_modules/@mistralai/mistralai": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
-      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
+        "zod-to-json-schema": "^3.25.0"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -4632,30 +4546,17 @@
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "license": "MIT"
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4663,20 +4564,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.22.1.tgz",
-      "integrity": "sha512-x3ie6Crr58MWrm4viHqqy2Du2rHYZjwu8BekasrQx4ca+Y24dzVAwq3yErdqIbc2G3I0kLQA13PQ+/rde+u65g==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.11",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4684,15 +4585,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4700,14 +4601,14 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
-      "integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4715,13 +4616,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.8.tgz",
-      "integrity": "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4729,12 +4630,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.8.tgz",
-      "integrity": "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4742,13 +4643,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.8.tgz",
-      "integrity": "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4756,13 +4657,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.8.tgz",
-      "integrity": "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4770,15 +4671,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4786,14 +4687,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4801,12 +4702,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4814,9 +4715,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4826,13 +4727,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4840,18 +4741,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.13.tgz",
-      "integrity": "sha512-x6vn0PjYmGdNuKh/juUJJewZh7MoQ46jYaJ2mvekF4EesMuFfrl4LaW/k97Zjf8PTCPQmPgMvwewg7eNoH9n5w==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.22.1",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4859,19 +4760,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.30",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.30.tgz",
-      "integrity": "sha512-CBGyFvN0f8hlnqKH/jckRDz78Snrp345+PVk8Ux7pnkUCW97Iinse59lY78hBt04h1GZ6hjBN94BRwZy1xC8Bg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
+      "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4879,13 +4781,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4893,12 +4796,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4906,14 +4809,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4921,15 +4824,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.9.tgz",
-      "integrity": "sha512-KX5Wml5mF+luxm1szW4QDz32e3NObgJ4Fyw+irhph4I/2geXwUy4jkIMUs5ZPGflRBeR6BUkC2wqIab4Llgm3w==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4937,12 +4839,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4950,12 +4852,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4963,13 +4865,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4977,12 +4879,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4990,24 +4892,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5015,18 +4917,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5034,17 +4936,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.2.tgz",
-      "integrity": "sha512-SCkGmFak/xC1n7hKRsUr6wOnBTJ3L22Qd4e8H1fQIuKTAjntwgU8lrdMe7uHdiT2mJAOWA/60qaW9tiMu69n1A==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.22.1",
-        "@smithy/middleware-endpoint": "^4.4.13",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.11",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5052,9 +4954,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5064,13 +4966,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5078,13 +4980,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5092,9 +4994,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5104,9 +5006,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5116,12 +5018,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5129,9 +5031,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5141,14 +5043,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.29",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.29.tgz",
-      "integrity": "sha512-nIGy3DNRmOjaYaaKcQDzmWsro9uxlaqUOhZDHQed9MW/GmkBZPtnU70Pu1+GT9IBmUXwRdDuiyaeiy9Xtpn3+Q==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5156,17 +5058,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.32",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.32.tgz",
-      "integrity": "sha512-7dtFff6pu5fsjqrVve0YMhrnzJtccCWDacNKOkiZjJ++fmjGExmmSu341x+WU6Oc1IccL7lDuaUj7SfrHpWc5Q==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
-        "@smithy/types": "^4.12.0",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5174,13 +5076,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5188,9 +5090,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5200,12 +5102,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5213,13 +5115,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
+      "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5227,18 +5129,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.11.tgz",
-      "integrity": "sha512-lKmZ0S/3Qj2OF5H1+VzvDLb6kRxGzZHq6f3rAsoSu5cTLGsn3v3VQBA8czkNNXlLjoFEtVu3OQT2jEeOtOE2CA==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.9",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5246,9 +5148,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5258,12 +5160,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5271,9 +5173,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5777,6 +5679,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5808,6 +5711,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -6175,9 +6079,9 @@
       "peer": true
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -7633,6 +7537,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -7661,6 +7566,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9120,6 +9026,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -9270,9 +9177,9 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
-      "integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
+      "integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11405,6 +11312,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12603,6 +12511,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typebox": {
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.32.tgz",
+      "integrity": "sha512-cbGoj7BCxGcFDJ/RR7wbyMe9IkO2SeNhwLdZWQ+xRtun9+ze9iM1pBND4SoFAxgonuJYrCIWnEQ7sE4bMVDYHA==",
+      "license": "MIT"
     },
     "node_modules/typedi": {
       "version": "0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4105,6 +4105,18 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -5572,9 +5584,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5965,9 +5977,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -7580,9 +7592,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -7595,9 +7607,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.10.tgz",
-      "integrity": "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
+      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
       "funding": [
         {
           "type": "github",
@@ -7606,9 +7618,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.1",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -7763,9 +7776,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -10859,9 +10872,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
-      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -11072,9 +11085,9 @@
       "peer": true
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
-        "@mariozechner/pi-agent-core": "^0.69.0",
-        "@mariozechner/pi-ai": "^0.69.0",
-        "@mariozechner/pi-web-ui": "^0.69.0",
+        "@mariozechner/pi-agent-core": "^0.70.0",
+        "@mariozechner/pi-ai": "^0.70.0",
+        "@mariozechner/pi-web-ui": "^0.70.0",
         "@sinclair/typebox": "^0.34.41",
         "lit": "^3.2.1",
         "marked": "^17.0.4"
@@ -3111,12 +3111,12 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.69.0.tgz",
-      "integrity": "sha512-dYZjee7QEIwVVbDGCGriiLjDT34IdMlXMjMp4drVKcLEuVc+BztyODwu3w4ZORVvwaySGGlF9UALjJKUVoXiug==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.0.tgz",
+      "integrity": "sha512-ZwfM5QPvSwza/apZhPIXjrI/blJBFqbVpK30ma4zNwH8VAyseKlzGDExCx/k+81Xydg60sQuG2BQVkYGmofuSg==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.69.0",
+        "@mariozechner/pi-ai": "^0.70.0",
         "typebox": "^1.1.24"
       },
       "engines": {
@@ -3124,9 +3124,9 @@
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.69.0.tgz",
-      "integrity": "sha512-bl838sr57zx/apkiTeNPFQgbBkGXN4HHhm2oghzSRohJIBrR+H001bTeco7Osuke+EZTxO3V5Aev2qlZdUa2xw==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.0.tgz",
+      "integrity": "sha512-lVT9bb0eFkNr5YXvZ5r00TNA5r110fOO8uJV9VLCQ5GdtunWIjcptWitzIjjl2MF0/NDs7Kb2EwZctXQWWP7eA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
@@ -3169,9 +3169,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.69.0.tgz",
-      "integrity": "sha512-/82SOMzCA1srivwfcSO8r9XLdAgJNcgpWzNZY33IqqvGev8Q4iWY/hA1wAkLB0l7PKJJ4Dh57xS4IGHbyVM7lA==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.0.tgz",
+      "integrity": "sha512-x/CwIMP8v9KNrmgEFA0+AWIwSWeNAitEI4eVQtQ6q2a0PpE+vx1+j2oc+iDPe7E1YqrMHXaNlHJVCaVAv/UYrg==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -3200,14 +3200,14 @@
       }
     },
     "node_modules/@mariozechner/pi-web-ui": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.69.0.tgz",
-      "integrity": "sha512-n1n+fO19tcKiQAYdJomX7Ba/RdEvXPohpPXFZmM2ib6Bozd3tLNUc8NulYdy///qvZOGkin+EYPObY1NA6bIaA==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-web-ui/-/pi-web-ui-0.70.0.tgz",
+      "integrity": "sha512-B+CDlInuO/FLoG/cxhWCKBWwmGcK2AypgjORAmLTl8eOEWN+nvMChCOA6pzUNK3PEkkdHrHhuTYsyy7COy9cog==",
       "license": "MIT",
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
-        "@mariozechner/pi-ai": "^0.69.0",
-        "@mariozechner/pi-tui": "^0.69.0",
+        "@mariozechner/pi-ai": "^0.70.0",
+        "@mariozechner/pi-tui": "^0.70.0",
         "docx-preview": "^0.3.7",
         "jszip": "^3.10.1",
         "lucide": "^0.544.0",

--- a/package.json
+++ b/package.json
@@ -64,9 +64,12 @@
     "axios": "1.15.0",
     "minimatch": "10.2.4",
     "rollup": "4.59.0",
-    "basic-ftp": "5.2.2",
+    "basic-ftp": "5.3.0",
     "underscore": "1.13.8",
     "tar": "7.5.11",
-    "fast-xml-parser": "5.5.10"
+    "fast-xml-parser": "5.7.0",
+    "@xmldom/xmldom": "0.8.13",
+    "protobufjs": "7.5.5",
+    "follow-redirects": "1.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@mariozechner/pi-agent-core": "^0.69.0",
-    "@mariozechner/pi-ai": "^0.69.0",
-    "@mariozechner/pi-web-ui": "^0.69.0",
+    "@mariozechner/pi-agent-core": "^0.70.0",
+    "@mariozechner/pi-ai": "^0.70.0",
+    "@mariozechner/pi-web-ui": "^0.70.0",
     "@sinclair/typebox": "^0.34.41",
     "lit": "^3.2.1",
     "marked": "^17.0.4"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@mariozechner/pi-agent-core": "^0.58.1",
-    "@mariozechner/pi-ai": "^0.58.1",
-    "@mariozechner/pi-web-ui": "^0.58.1",
+    "@mariozechner/pi-agent-core": "^0.69.0",
+    "@mariozechner/pi-ai": "^0.69.0",
+    "@mariozechner/pi-web-ui": "^0.69.0",
     "@sinclair/typebox": "^0.34.41",
     "lit": "^3.2.1",
     "marked": "^17.0.4"
@@ -46,6 +46,7 @@
     "eslint": "^10.0.3",
     "office-addin-debugging": "^6.0.6",
     "office-addin-manifest": "^2.1.2",
+    "typebox": "^1.1.32",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.57.0",
     "vite": "^7.3.2"

--- a/public/architecture/index.html
+++ b/public/architecture/index.html
@@ -1910,7 +1910,7 @@
         <code>createAllTools()</code> → <code>applyExperimentalToolGates()</code> → <code>createToolsForIntegrations()</code> → <code>extensionManager.getRegisteredTools()</code> → <code>normalizeRuntimeTools()</code> → <code>withWorkbookCoordinator()</code> → <code>withConnectionPreflight()</code> → <code>applyToolOutputTruncation()</code>
       </div>
       <ul class="ilist" style="margin-top:8px">
-        <li>Fingerprint comparison (FNV-1a hash of tool schemas) decides whether to call <code>agent.setTools()</code></li>
+        <li>Fingerprint comparison (FNV-1a hash of tool schemas) decides whether to assign <code>agent.state.tools = ...</code></li>
         <li>Extension tool revision counter (monotonic) also triggers refresh when extensions add/remove tools</li>
         <li>Static tool ordering preserved for prompt cache stability</li>
       </ul>
@@ -2498,7 +2498,7 @@
     </div>
     <div class="invariant-body">
       <span class="invariant-name">Runtime tool fingerprinting</span>
-      <span class="invariant-desc">Refresh passes rebuild tool objects but only call <code>agent.setTools()</code> when the metadata fingerprint actually differs. Schema-stable handler swaps are silent no-ops. <code style="font-size:11px;opacity:.6">src/taskpane/runtime-utils.ts</code></span>
+      <span class="invariant-desc">Refresh passes rebuild tool objects but only assign <code>agent.state.tools = ...</code> when the metadata fingerprint actually differs. Schema-stable handler swaps are silent no-ops. <code style="font-size:11px;opacity:.6">src/taskpane/runtime-utils.ts</code></span>
     </div>
   </div>
 </div>

--- a/src/commands/builtins/export.ts
+++ b/src/commands/builtins/export.ts
@@ -662,7 +662,7 @@ export function createCompactCommands(getActiveAgent: ActiveAgentProvider): Slas
             timestamp: now,
           });
 
-          agent.replaceMessages([archived, compacted, ...out.keptMessages]);
+          agent.state.messages = [archived, compacted, ...out.keptMessages];
 
           const iface = document.querySelector<PiSidebar>("pi-sidebar");
           iface?.requestUpdate();

--- a/src/commands/extension-api-types.ts
+++ b/src/commands/extension-api-types.ts
@@ -5,7 +5,7 @@ import type {
   AgentToolResult,
   AgentToolUpdateCallback,
 } from "@mariozechner/pi-agent-core";
-import type { Static, TSchema } from "@sinclair/typebox";
+import type { Static, TSchema } from "typebox";
 
 import type {
   ConnectionAuthKind,

--- a/src/extensions/runtime-manager-activation.ts
+++ b/src/extensions/runtime-manager-activation.ts
@@ -230,6 +230,7 @@ export interface BuildRuntimeManagerActivationBridgeOptions {
   settings: ExtensionSettingsStore;
   connectionManager: ConnectionManager;
   getRequiredActiveAgent: () => Agent;
+  afterInjectAgentContext?: () => Promise<void> | void;
   runExtensionLlmCompletion: (request: LlmCompletionRequest) => Promise<LlmCompletionResult>;
   runExtensionHttpFetch: (url: string, options?: HttpRequestOptions) => Promise<HttpResponse>;
   writeExtensionClipboard: (text: string) => Promise<void>;
@@ -248,6 +249,7 @@ export function buildRuntimeManagerActivationBridge(
     settings,
     connectionManager,
     getRequiredActiveAgent,
+    afterInjectAgentContext,
     runExtensionLlmCompletion,
     runExtensionHttpFetch,
     writeExtensionClipboard,
@@ -270,6 +272,9 @@ export function buildRuntimeManagerActivationBridge(
   const injectAgentContext = (content: string): void => {
     const agent = getRequiredActiveAgent();
     agent.state.messages.push(buildExtensionMessage("agent.injectContext content", content));
+    void Promise.resolve(afterInjectAgentContext?.()).catch((error: unknown) => {
+      console.warn("[pi] Failed to sync extension-injected context:", error);
+    });
   };
 
   const steerAgent = (content: string): void => {

--- a/src/extensions/runtime-manager-activation.ts
+++ b/src/extensions/runtime-manager-activation.ts
@@ -269,7 +269,7 @@ export function buildRuntimeManagerActivationBridge(
 
   const injectAgentContext = (content: string): void => {
     const agent = getRequiredActiveAgent();
-    agent.appendMessage(buildExtensionMessage("agent.injectContext content", content));
+    agent.state.messages.push(buildExtensionMessage("agent.injectContext content", content));
   };
 
   const steerAgent = (content: string): void => {

--- a/src/extensions/runtime-manager.ts
+++ b/src/extensions/runtime-manager.ts
@@ -141,6 +141,7 @@ export interface ExtensionRuntimeManagerOptions {
   getActiveAgent: () => Agent | null;
   refreshRuntimeTools: () => Promise<void>;
   reservedToolNames: ReadonlySet<string>;
+  afterInjectAgentContext?: () => Promise<void> | void;
   loadExtensionFromSource?: typeof loadExtension;
   activateInSandbox?: typeof activateExtensionInSandbox;
   showToastMessage?: typeof showToast;
@@ -152,6 +153,7 @@ export class ExtensionRuntimeManager {
   private readonly getActiveAgent: () => Agent | null;
   private readonly refreshRuntimeTools: () => Promise<void>;
   private readonly reservedToolNames: ReadonlySet<string>;
+  private readonly afterInjectAgentContext?: () => Promise<void> | void;
   private readonly loadExtensionFromSource: typeof loadExtension;
   private readonly activateInSandbox: typeof activateExtensionInSandbox;
   private readonly showToastMessage: typeof showToast;
@@ -173,6 +175,7 @@ export class ExtensionRuntimeManager {
     this.getActiveAgent = options.getActiveAgent;
     this.refreshRuntimeTools = options.refreshRuntimeTools;
     this.reservedToolNames = options.reservedToolNames;
+    this.afterInjectAgentContext = options.afterInjectAgentContext;
     this.loadExtensionFromSource = options.loadExtensionFromSource ?? loadExtension;
     this.activateInSandbox = options.activateInSandbox ?? activateExtensionInSandbox;
     this.showToastMessage = options.showToastMessage ?? showToast;
@@ -761,6 +764,7 @@ export class ExtensionRuntimeManager {
       settings: this.settings,
       connectionManager: this.connectionManager,
       getRequiredActiveAgent: () => this.getRequiredActiveAgent(),
+      afterInjectAgentContext: this.afterInjectAgentContext,
       runExtensionLlmCompletion: (request) => this.runExtensionLlmCompletion(entry, request),
       runExtensionHttpFetch: (url, options) => this.runExtensionHttpFetch(url, options),
       writeExtensionClipboard: (text) => this.writeExtensionClipboard(text),

--- a/src/extensions/sandbox-runtime.ts
+++ b/src/extensions/sandbox-runtime.ts
@@ -7,7 +7,7 @@
  */
 
 import type { AgentEvent, AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
-import type { TSchema } from "@sinclair/typebox";
+import type { TSchema } from "typebox";
 
 import type {
   ExtensionCommand,

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -24,12 +24,27 @@ const OPENAI_CODEX_RE = /^gpt-5(?:\.(\d+))?-codex(?:-|$)/;
 const OPENAI_PLAIN_GPT_RE = /^gpt-5(?:\.(\d+))?$/;
 const OPENAI_GPT_RE = /^gpt-5(?:[.-]|$)/;
 
-const CLAUDE_HYPHEN_VERSION_RE = /^claude(?:-[a-z]+)*-(\d+)-(\d{1,2})(?:-|$)/i;
-const CLAUDE_MAJOR_RE = /^claude(?:-[a-z]+)*-(\d+)(?:-|$)/i;
-const GPT_DOT_VERSION_RE = /^gpt-(\d+)\.(\d{1,2})(?:-|$)/i;
-const GPT_MAJOR_RE = /^gpt-(\d+)(?:[a-z]+)?(?:-|$)/i;
-const GEMINI_DOT_VERSION_RE = /^gemini(?:-[a-z]+)*-(\d+)\.(\d{1,2})(?:-|$)/i;
-const GEMINI_MAJOR_RE = /^gemini(?:-[a-z]+)*-(\d+)(?:-|$)/i;
+const MODEL_NAME_BOUNDARY = String.raw`(?:^|[\\/~.:])`;
+const MODEL_VERSION_BOUNDARY = String.raw`(?=$|[-/:])`;
+
+const CLAUDE_VERSION_RE = new RegExp(
+  `${MODEL_NAME_BOUNDARY}claude(?:-[a-z]+)*-(\\d+)[.-](\\d{1,2})${MODEL_VERSION_BOUNDARY}`,
+  "i",
+);
+const CLAUDE_MAJOR_RE = new RegExp(
+  `${MODEL_NAME_BOUNDARY}claude(?:-[a-z]+)*-(\\d+)${MODEL_VERSION_BOUNDARY}`,
+  "i",
+);
+const GPT_DOT_VERSION_RE = new RegExp(`${MODEL_NAME_BOUNDARY}gpt-(\\d+)\\.(\\d{1,2})${MODEL_VERSION_BOUNDARY}`, "i");
+const GPT_MAJOR_RE = new RegExp(`${MODEL_NAME_BOUNDARY}gpt-(\\d+)(?:[a-z]+)?${MODEL_VERSION_BOUNDARY}`, "i");
+const GEMINI_DOT_VERSION_RE = new RegExp(
+  `${MODEL_NAME_BOUNDARY}gemini(?:-[a-z]+)*-(\\d+)\\.(\\d{1,2})${MODEL_VERSION_BOUNDARY}`,
+  "i",
+);
+const GEMINI_MAJOR_RE = new RegExp(
+  `${MODEL_NAME_BOUNDARY}gemini(?:-[a-z]+)*-(\\d+)${MODEL_VERSION_BOUNDARY}`,
+  "i",
+);
 
 export function isOpenAiCodexModelId(id: string): boolean {
   return OPENAI_CODEX_RE.test(id);
@@ -77,12 +92,15 @@ export function parseMajorMinor(id: string): number {
   // Extract a comparable major/minor number from common model ID formats.
   // Important: only parse the leading version segment, not later date-like suffixes.
   // Examples:
-  // - claude-opus-4-6                 -> 46
-  // - claude-opus-4-20250514          -> 40 (major only; date handled separately)
-  // - gpt-5.4                         -> 54
-  // - gpt-4o-2024-11-20               -> 40 (not 202411)
-  // - gemini-2.5-pro-preview-06-05    -> 25 (not 65)
-  // - gemini-3-pro-preview            -> 30
+  // - claude-opus-4-6                         -> 46
+  // - claude-opus-4.7                         -> 47
+  // - anthropic.claude-opus-4-1-20250805-v1:0 -> 41 (date handled separately)
+  // - claude-opus-4-20250514                  -> 40 (major only; date handled separately)
+  // - gpt-5.5                                 -> 55
+  // - gpt-4o-2024-11-20                       -> 40 (not 202411)
+  // - gemini-2.5-pro-preview-06-05            -> 25 (not 65)
+  // - google/gemini-3.1-pro-preview           -> 31
+  // - gemini-3-pro-preview                    -> 30
 
   const pack = (major: number, minor: number | null): number => {
     if (minor === null) return major * 10;
@@ -92,9 +110,9 @@ export function parseMajorMinor(id: string): number {
     return major * 100 + minor;
   };
 
-  const claudeHyphenVer = id.match(CLAUDE_HYPHEN_VERSION_RE);
-  if (claudeHyphenVer) {
-    return pack(parseInt(claudeHyphenVer[1], 10), parseInt(claudeHyphenVer[2], 10));
+  const claudeVer = id.match(CLAUDE_VERSION_RE);
+  if (claudeVer) {
+    return pack(parseInt(claudeVer[1], 10), parseInt(claudeVer[2], 10));
   }
 
   const gptDotVer = id.match(GPT_DOT_VERSION_RE);
@@ -126,30 +144,25 @@ export function parseMajorMinor(id: string): number {
 }
 
 function parseDateSuffixScore(id: string): number {
-  const compactDateMatch = id.match(/(\d{8})$/);
-  if (compactDateMatch) {
-    return parseInt(compactDateMatch[1], 10);
+  let score = 0;
+
+  for (const match of id.matchAll(/(?:^|[-/:])(\d{8})(?=$|[-/:])/g)) {
+    score = Math.max(score, parseInt(match[1], 10));
   }
 
-  const yearMonthDayMatch = id.match(/(\d{4})-(\d{2})-(\d{2})$/);
-  if (yearMonthDayMatch) {
-    return parseInt(
-      `${yearMonthDayMatch[1]}${yearMonthDayMatch[2]}${yearMonthDayMatch[3]}`,
-      10,
-    );
+  for (const match of id.matchAll(/(?:^|[-/:])(\d{4})-(\d{2})-(\d{2})(?=$|[-/:])/g)) {
+    score = Math.max(score, parseInt(`${match[1]}${match[2]}${match[3]}`, 10));
   }
 
-  const monthYearMatch = id.match(/(\d{2})-(\d{4})$/);
-  if (monthYearMatch) {
-    return parseInt(`${monthYearMatch[2]}${monthYearMatch[1]}00`, 10);
+  for (const match of id.matchAll(/(?:^|[-/:])(\d{2})-(\d{4})(?=$|[-/:])/g)) {
+    score = Math.max(score, parseInt(`${match[2]}${match[1]}00`, 10));
   }
 
-  const monthDayMatch = id.match(/(\d{2})-(\d{2})$/);
-  if (monthDayMatch) {
-    return parseInt(`${monthDayMatch[1]}${monthDayMatch[2]}`, 10);
+  for (const match of id.matchAll(/(?:^|[-/:])(\d{2})-(\d{2})(?=$|[-/:])/g)) {
+    score = Math.max(score, parseInt(`${match[1]}${match[2]}`, 10));
   }
 
-  return 0;
+  return score;
 }
 
 export function modelRecencyScore(id: string): number {

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -125,13 +125,37 @@ export function parseMajorMinor(id: string): number {
   return 0;
 }
 
+function parseDateSuffixScore(id: string): number {
+  const compactDateMatch = id.match(/(\d{8})$/);
+  if (compactDateMatch) {
+    return parseInt(compactDateMatch[1], 10);
+  }
+
+  const yearMonthDayMatch = id.match(/(\d{4})-(\d{2})-(\d{2})$/);
+  if (yearMonthDayMatch) {
+    return parseInt(
+      `${yearMonthDayMatch[1]}${yearMonthDayMatch[2]}${yearMonthDayMatch[3]}`,
+      10,
+    );
+  }
+
+  const monthYearMatch = id.match(/(\d{2})-(\d{4})$/);
+  if (monthYearMatch) {
+    return parseInt(`${monthYearMatch[2]}${monthYearMatch[1]}00`, 10);
+  }
+
+  const monthDayMatch = id.match(/(\d{2})-(\d{2})$/);
+  if (monthDayMatch) {
+    return parseInt(`${monthDayMatch[1]}${monthDayMatch[2]}`, 10);
+  }
+
+  return 0;
+}
+
 export function modelRecencyScore(id: string): number {
   // Prefer higher major/minor first, then higher date suffix.
   const majorMinor = parseMajorMinor(id);
-
-  let date = 0;
-  const dateMatch = id.match(/(\d{8})/);
-  if (dateMatch) date = parseInt(dateMatch[1], 10);
+  const date = parseDateSuffixScore(id);
 
   // date is at most 8 digits → multiplier must exceed that range
   return majorMinor * 100_000_000 + date;

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -45,6 +45,7 @@ const GEMINI_MAJOR_RE = new RegExp(
   `${MODEL_NAME_BOUNDARY}gemini(?:-[a-z]+)*-(\\d+)${MODEL_VERSION_BOUNDARY}`,
   "i",
 );
+const LETTER_PREFIXED_DOT_VERSION_RE = /(?:^|[\/_.-])[a-z]+(\d{1,2})\.(\d{1,2})(?=$|[-/:._])/i;
 const GENERIC_VERSION_RE = /(?:^|[\w~/-][.-]|[-_/])v?(\d{1,2})(?:[.-](\d{1,2})(?:[a-z]+)?)?(?=$|[-/:._])/gi;
 
 export function isOpenAiCodexModelId(id: string): boolean {
@@ -102,6 +103,8 @@ export function parseMajorMinor(id: string): number {
   // - gemini-2.5-pro-preview-06-05            -> 25 (not 65)
   // - google/gemini-3.1-pro-preview           -> 31
   // - gemini-3-pro-preview                    -> 30
+  // - MiniMax-M2.7                            -> 27 (letter-prefixed fallback)
+  // - Qwen/Qwen3.5                            -> 35 (letter-prefixed fallback)
   // - gemma-4-31b-it                          -> 431 (generic fallback)
   // - zai.glm-5                               -> 50 (generic fallback)
 
@@ -141,6 +144,11 @@ export function parseMajorMinor(id: string): number {
   const geminiMajor = id.match(GEMINI_MAJOR_RE);
   if (geminiMajor) {
     return pack(parseInt(geminiMajor[1], 10), null);
+  }
+
+  const letterPrefixedDotVersion = id.match(LETTER_PREFIXED_DOT_VERSION_RE);
+  if (letterPrefixedDotVersion) {
+    return pack(parseInt(letterPrefixedDotVersion[1], 10), parseInt(letterPrefixedDotVersion[2], 10));
   }
 
   for (const genericVersion of id.matchAll(GENERIC_VERSION_RE)) {

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -20,9 +20,16 @@ export function providerPriority(provider: string): number {
   return PROVIDER_ORDER[provider] ?? 999;
 }
 
-const OPENAI_CODEX_RE = /^gpt-5\.(\d+)-codex(?:-|$)/;
-const OPENAI_PLAIN_GPT_RE = /^gpt-5\.(\d+)$/;
-const OPENAI_GPT_RE = /^gpt-5\./;
+const OPENAI_CODEX_RE = /^gpt-5(?:\.(\d+))?-codex(?:-|$)/;
+const OPENAI_PLAIN_GPT_RE = /^gpt-5(?:\.(\d+))?$/;
+const OPENAI_GPT_RE = /^gpt-5(?:[.-]|$)/;
+
+const CLAUDE_HYPHEN_VERSION_RE = /^claude(?:-[a-z]+)*-(\d+)-(\d{1,2})(?:-|$)/i;
+const CLAUDE_MAJOR_RE = /^claude(?:-[a-z]+)*-(\d+)(?:-|$)/i;
+const GPT_DOT_VERSION_RE = /^gpt-(\d+)\.(\d{1,2})(?:-|$)/i;
+const GPT_MAJOR_RE = /^gpt-(\d+)(?:[a-z]+)?(?:-|$)/i;
+const GEMINI_DOT_VERSION_RE = /^gemini(?:-[a-z]+)*-(\d+)\.(\d{1,2})(?:-|$)/i;
+const GEMINI_MAJOR_RE = /^gemini(?:-[a-z]+)*-(\d+)(?:-|$)/i;
 
 export function isOpenAiCodexModelId(id: string): boolean {
   return OPENAI_CODEX_RE.test(id);
@@ -68,14 +75,14 @@ export function familyPriority(provider: string, id: string): number {
 
 export function parseMajorMinor(id: string): number {
   // Extract a comparable major/minor number from common model ID formats.
-  // Important: don't misinterpret 8-digit date suffixes (e.g. 20250514) as "minor".
+  // Important: only parse the leading version segment, not later date-like suffixes.
   // Examples:
-  // - claude-opus-4-5           -> 45
-  // - claude-opus-4-6           -> 46
-  // - claude-opus-4-20250514    -> 40 (major only; date handled separately)
-  // - gpt-5.3-codex             -> 53
-  // - gemini-2.5-pro            -> 25
-  // - gemini-3-pro-preview      -> 30
+  // - claude-opus-4-6                 -> 46
+  // - claude-opus-4-20250514          -> 40 (major only; date handled separately)
+  // - gpt-5.4                         -> 54
+  // - gpt-4o-2024-11-20               -> 40 (not 202411)
+  // - gemini-2.5-pro-preview-06-05    -> 25 (not 65)
+  // - gemini-3-pro-preview            -> 30
 
   const pack = (major: number, minor: number | null): number => {
     if (minor === null) return major * 10;
@@ -85,22 +92,34 @@ export function parseMajorMinor(id: string): number {
     return major * 100 + minor;
   };
 
-  // Claude-style: -4-6 (but NOT -4-20250514)
-  const hyphenVer = id.match(/-(\d+)-(\d{1,2})(?:-|$)/);
-  if (hyphenVer) {
-    return pack(parseInt(hyphenVer[1], 10), parseInt(hyphenVer[2], 10));
+  const claudeHyphenVer = id.match(CLAUDE_HYPHEN_VERSION_RE);
+  if (claudeHyphenVer) {
+    return pack(parseInt(claudeHyphenVer[1], 10), parseInt(claudeHyphenVer[2], 10));
   }
 
-  // OpenAI/Gemini-style: 5.3 / 2.5
-  const dotVer = id.match(/(\d+)\.(\d{1,2})/);
-  if (dotVer) {
-    return pack(parseInt(dotVer[1], 10), parseInt(dotVer[2], 10));
+  const gptDotVer = id.match(GPT_DOT_VERSION_RE);
+  if (gptDotVer) {
+    return pack(parseInt(gptDotVer[1], 10), parseInt(gptDotVer[2], 10));
   }
 
-  // Fallback: first major number after hyphen
-  const majorMatch = id.match(/-(\d+)(?:-|$)/);
-  if (majorMatch) {
-    return pack(parseInt(majorMatch[1], 10), null);
+  const geminiDotVer = id.match(GEMINI_DOT_VERSION_RE);
+  if (geminiDotVer) {
+    return pack(parseInt(geminiDotVer[1], 10), parseInt(geminiDotVer[2], 10));
+  }
+
+  const claudeMajor = id.match(CLAUDE_MAJOR_RE);
+  if (claudeMajor) {
+    return pack(parseInt(claudeMajor[1], 10), null);
+  }
+
+  const gptMajor = id.match(GPT_MAJOR_RE);
+  if (gptMajor) {
+    return pack(parseInt(gptMajor[1], 10), null);
+  }
+
+  const geminiMajor = id.match(GEMINI_MAJOR_RE);
+  if (geminiMajor) {
+    return pack(parseInt(geminiMajor[1], 10), null);
   }
 
   return 0;

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -46,7 +46,7 @@ const GEMINI_MAJOR_RE = new RegExp(
   "i",
 );
 const LETTER_PREFIXED_DOT_VERSION_RE = /(?:^|[\/_.-])[a-z]+(\d{1,2})\.(\d{1,2})(?=$|[-/:._])/i;
-const GENERIC_VERSION_RE = /(?:^|[\w~/-][.-]|[-_/])v?(\d{1,2})(?:[.-](\d{1,2})(?:[a-z]+)?)?(?=$|[-/:._])/gi;
+const GENERIC_VERSION_RE = /(?:^|[\w~/-][.-]|[-_/])v?(\d{1,2})(?:[.-](\d{1,2})([a-z]+)?)?(?=$|[-/:._])/gi;
 
 export function isOpenAiCodexModelId(id: string): boolean {
   return OPENAI_CODEX_RE.test(id);
@@ -105,7 +105,7 @@ export function parseMajorMinor(id: string): number {
   // - gemini-3-pro-preview                    -> 30
   // - MiniMax-M2.7                            -> 27 (letter-prefixed fallback)
   // - Qwen/Qwen3.5                            -> 35 (letter-prefixed fallback)
-  // - gemma-4-31b-it                          -> 431 (generic fallback)
+  // - gemma-4-31b-it                          -> 40 (generic fallback; ignores size suffix)
   // - zai.glm-5                               -> 50 (generic fallback)
 
   const pack = (major: number, minor: number | null): number => {
@@ -159,7 +159,7 @@ export function parseMajorMinor(id: string): number {
     if (/\d{4}-\d{2}-\d{2}/.test(surrounding)) continue;
 
     const major = parseInt(genericVersion[1], 10);
-    const minor = genericVersion[2] ? parseInt(genericVersion[2], 10) : null;
+    const minor = genericVersion[2] && !genericVersion[3] ? parseInt(genericVersion[2], 10) : null;
     return pack(major, minor);
   }
 

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -45,6 +45,7 @@ const GEMINI_MAJOR_RE = new RegExp(
   `${MODEL_NAME_BOUNDARY}gemini(?:-[a-z]+)*-(\\d+)${MODEL_VERSION_BOUNDARY}`,
   "i",
 );
+const GENERIC_VERSION_RE = /(?:^|[\w~/-][.-]|[-_/])v?(\d{1,2})(?:[.-](\d{1,2})(?:[a-z]+)?)?(?=$|[-/:._])/gi;
 
 export function isOpenAiCodexModelId(id: string): boolean {
   return OPENAI_CODEX_RE.test(id);
@@ -101,6 +102,8 @@ export function parseMajorMinor(id: string): number {
   // - gemini-2.5-pro-preview-06-05            -> 25 (not 65)
   // - google/gemini-3.1-pro-preview           -> 31
   // - gemini-3-pro-preview                    -> 30
+  // - gemma-4-31b-it                          -> 431 (generic fallback)
+  // - zai.glm-5                               -> 50 (generic fallback)
 
   const pack = (major: number, minor: number | null): number => {
     if (minor === null) return major * 10;
@@ -138,6 +141,18 @@ export function parseMajorMinor(id: string): number {
   const geminiMajor = id.match(GEMINI_MAJOR_RE);
   if (geminiMajor) {
     return pack(parseInt(geminiMajor[1], 10), null);
+  }
+
+  for (const genericVersion of id.matchAll(GENERIC_VERSION_RE)) {
+    const matchIndex = genericVersion.index ?? 0;
+    const digitOffset = genericVersion[0].search(/\d/);
+    const digitIndex = matchIndex + Math.max(digitOffset, 0);
+    const surrounding = id.slice(Math.max(0, digitIndex - 5), digitIndex + 8);
+    if (/\d{4}-\d{2}-\d{2}/.test(surrounding)) continue;
+
+    const major = parseInt(genericVersion[1], 10);
+    const minor = genericVersion[2] ? parseInt(genericVersion[2], 10) : null;
+    return pack(major, minor);
   }
 
   return 0;

--- a/src/taskpane/default-model.ts
+++ b/src/taskpane/default-model.ts
@@ -117,5 +117,5 @@ export function pickDefaultModel(
   }
 
   // Absolute fallback: keep this resilient across pi-ai version bumps
-  return getModel("anthropic", "claude-opus-4-6");
+  return getModel("anthropic", "claude-opus-4-7");
 }

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -575,7 +575,7 @@ export async function initTaskpane(opts: {
         continue;
       }
 
-      runtime.agent.setModel(refreshedModel);
+      runtime.agent.state.model = refreshedModel;
       anyRuntimeChanged = true;
       if (runtime.runtimeId === activeRuntimeId) {
         activeRuntimeChanged = true;
@@ -993,13 +993,13 @@ export async function initTaskpane(opts: {
           nextExtensionToolRevision,
         })
       ) {
-        agent.setTools(next.tools);
+        agent.state.tools = next.tools;
         currentRuntimeToolsFingerprint = nextToolsFingerprint;
         currentExtensionToolRevision = nextExtensionToolRevision;
       }
 
       if (next.systemPrompt !== currentRuntimeSystemPrompt) {
-        agent.setSystemPrompt(next.systemPrompt);
+        agent.state.systemPrompt = next.systemPrompt;
         currentRuntimeSystemPrompt = next.systemPrompt;
       }
     };
@@ -1071,10 +1071,11 @@ export async function initTaskpane(opts: {
 
       if (!isActiveRuntime) return;
 
-      if (agent.state.error) {
-        const isAbort = wasUserAbort || /abort/i.test(agent.state.error) || /cancel/i.test(agent.state.error);
+      const errorMessage = agent.state.errorMessage;
+      if (errorMessage) {
+        const isAbort = wasUserAbort || /abort/i.test(errorMessage) || /cancel/i.test(errorMessage);
         if (!isAbort) {
-          const err = agent.state.error;
+          const err = errorMessage;
           if (isLikelyCorsErrorMessage(err)) {
             showErrorBanner(
               errorRoot,
@@ -1440,9 +1441,9 @@ export async function initTaskpane(opts: {
       autoRestoreLatest: false,
     });
 
-    clonedRuntime.agent.replaceMessages(args.sourceRuntime.agent.state.messages);
-    clonedRuntime.agent.setModel(args.targetModel);
-    clonedRuntime.agent.setThinkingLevel(args.sourceRuntime.agent.state.thinkingLevel);
+    clonedRuntime.agent.state.messages = args.sourceRuntime.agent.state.messages;
+    clonedRuntime.agent.state.model = args.targetModel;
+    clonedRuntime.agent.state.thinkingLevel = args.sourceRuntime.agent.state.thinkingLevel;
 
     await clonedRuntime.persistence.renameSession(args.targetTitle);
     clonedRuntime.queueDisplay.clear();
@@ -1618,7 +1619,7 @@ export async function initTaskpane(opts: {
     const behavior = getModelSwitchBehavior();
 
     if (!shouldForkModelSwitch({ behavior, hasMessages })) {
-      runtime.agent.setModel(nextModel);
+      runtime.agent.state.model = nextModel;
       document.dispatchEvent(new CustomEvent("pi:model-changed"));
       document.dispatchEvent(new CustomEvent("pi:status-update"));
       requestAnimationFrame(() => sidebar.requestUpdate());
@@ -1990,7 +1991,7 @@ export async function initTaskpane(opts: {
       activeLevel: activeAgent.state.thinkingLevel,
       onSelectLevel: (level) => {
         if (activeAgent.state.thinkingLevel === level) return;
-        activeAgent.setThinkingLevel(level);
+        activeAgent.state.thinkingLevel = level;
         document.dispatchEvent(new CustomEvent("pi:status-update"));
       },
     });

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -753,6 +753,17 @@ export async function initTaskpane(opts: {
     getActiveAgent,
     refreshRuntimeTools: refreshCapabilitiesForAllRuntimes,
     reservedToolNames,
+    afterInjectAgentContext: async () => {
+      const activeRuntime = getActiveRuntime();
+      if (!activeRuntime) {
+        return;
+      }
+
+      sidebar.syncFromAgent();
+      sidebar.requestUpdate();
+      document.dispatchEvent(new CustomEvent("pi:status-update"));
+      await activeRuntime.persistence.saveSession({ force: true });
+    },
   });
 
   connectionManager.subscribe(() => {

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -1452,7 +1452,7 @@ export async function initTaskpane(opts: {
       autoRestoreLatest: false,
     });
 
-    clonedRuntime.agent.state.messages = args.sourceRuntime.agent.state.messages;
+    clonedRuntime.agent.state.messages = structuredClone(args.sourceRuntime.agent.state.messages);
     clonedRuntime.agent.state.model = args.targetModel;
     clonedRuntime.agent.state.thinkingLevel = args.sourceRuntime.agent.state.thinkingLevel;
 

--- a/src/taskpane/keyboard-shortcuts.ts
+++ b/src/taskpane/keyboard-shortcuts.ts
@@ -187,7 +187,7 @@ export function cycleThinkingLevel(agent: Agent): ThinkingLevel {
   const idx = levels.indexOf(current);
   const next = levels[(idx >= 0 ? idx + 1 : 0) % levels.length];
 
-  agent.setThinkingLevel(next);
+  agent.state.thinkingLevel = next;
   updateStatusBarForAgent(agent);
   flashThinkingLevel(next, THINKING_COLORS[next] || "#a0a0a0");
 

--- a/src/taskpane/runtime-utils.ts
+++ b/src/taskpane/runtime-utils.ts
@@ -48,7 +48,7 @@ export function createRuntimeToolFingerprint(tools: readonly AgentTool[]): strin
 }
 
 /**
- * Decide whether a runtime refresh pass should call `agent.setTools(...)`.
+ * Decide whether a runtime refresh pass should assign `agent.state.tools = ...`.
  *
  * We update tools when either metadata changed (fingerprint delta) or when
  * extension-owned tool behavior changed without metadata deltas (revision delta).

--- a/src/taskpane/sessions.ts
+++ b/src/taskpane/sessions.ts
@@ -322,16 +322,16 @@ export async function setupSessionPersistence(opts: {
     firstAssistantSeen = hasAssistantMessage(sessionData.messages);
 
     agent.sessionId = sessionId;
-    agent.replaceMessages(sessionData.messages);
+    agent.state.messages = sessionData.messages;
 
     if (sessionData.model) {
-      agent.setModel(await refreshPersistedModel({
+      agent.state.model = await refreshPersistedModel({
         persisted: sessionData.model,
         customProvidersStore: opts.customProvidersStore,
-      }));
+      });
     }
     if (sessionData.thinkingLevel) {
-      agent.setThinkingLevel(sessionData.thinkingLevel);
+      agent.state.thinkingLevel = sessionData.thinkingLevel;
     }
 
     await updateWorkbookAssociation(sessionId);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import type { TSchema } from "@sinclair/typebox";
+import type { TSchema } from "typebox";
 
 import { createGetWorkbookOverviewTool } from "./get-workbook-overview.js";
 import { createReadRangeTool } from "./read-range.js";

--- a/src/tools/with-workbook-coordinator.ts
+++ b/src/tools/with-workbook-coordinator.ts
@@ -3,7 +3,7 @@
  */
 
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import type { TSchema } from "@sinclair/typebox";
+import type { TSchema } from "typebox";
 
 import {
   formatExecutionModeLabel,

--- a/tests/action-queue.test.ts
+++ b/tests/action-queue.test.ts
@@ -120,9 +120,9 @@ void test("queued prompt survives compact replaceMessages and runs after compact
         await compactGate.promise;
 
         // Simulate compaction replacing message history while a prompt is queued.
-        agent.replaceMessages([
+        agent.state.messages = [
           createUserMessage("compaction summary", Date.now()),
-        ]);
+        ];
 
         executionOrder.push("compact:end");
         compactFinished.resolve();

--- a/tests/extension-api-capabilities.test.ts
+++ b/tests/extension-api-capabilities.test.ts
@@ -222,7 +222,7 @@ void test("createExtensionAPI denies llm.complete when capability is blocked", a
     },
     llmComplete: () => Promise.resolve({
       content: "ok",
-      model: "anthropic/claude-opus-4-6",
+      model: "anthropic/claude-opus-4-7",
     }),
     isCapabilityEnabled: createCapabilityGate(new Set<ExtensionCapability>([
       "commands.register",

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -85,6 +85,9 @@ void test("parseMajorMinor falls back for non-Claude/GPT/Gemini registry familie
   assert.equal(parseMajorMinor("zai.glm-5"), 50);
   assert.equal(parseMajorMinor("zai.glm-4.7"), 47);
   assert.equal(parseMajorMinor("deepseek.v3.2"), 32);
+  assert.equal(parseMajorMinor("MiniMax-M2.7"), 27);
+  assert.equal(parseMajorMinor("moonshotai/Kimi-K2.6"), 26);
+  assert.equal(parseMajorMinor("Qwen/Qwen3.5-coder"), 35);
   assert.equal(parseMajorMinor("amazon.nova-2-lite-v1:0"), 20);
   assert.equal(parseMajorMinor("unknown-model-2024-11-20"), 0);
 });
@@ -187,6 +190,13 @@ void test("compareModels sorts generic versioned registry ids by parsed recency"
   ];
   zaiModels.sort(compareModels);
   assert.deepEqual(zaiModels.map((m) => m.id), ["zai.glm-5", "zai.glm-4.7"]);
+
+  const letterPrefixedModels = [
+    { provider: "openrouter", id: "MiniMax-M2.7" },
+    { provider: "openrouter", id: "MiniMax-M2.6" },
+  ];
+  letterPrefixedModels.sort(compareModels);
+  assert.deepEqual(letterPrefixedModels.map((m) => m.id), ["MiniMax-M2.7", "MiniMax-M2.6"]);
 });
 
 void test("compareModels sorts real namespaced registry ids by parsed recency", () => {

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -45,8 +45,8 @@ function pickExpectedOpenAiDefault(provider: OpenAiProvider): Model<Api> | null 
 }
 
 void test("parseMajorMinor packs Claude-style -major-minor as major*10+minor", () => {
-  assert.equal(parseMajorMinor("claude-opus-4-5"), 45);
   assert.equal(parseMajorMinor("claude-opus-4-6"), 46);
+  assert.equal(parseMajorMinor("claude-opus-4-7"), 47);
 });
 
 void test("parseMajorMinor does not treat YYYYMMDD as a minor version", () => {
@@ -59,24 +59,47 @@ void test("parseMajorMinor handles dot-style versions", () => {
   assert.equal(parseMajorMinor("gemini-2.5-pro"), 25);
 });
 
+void test("parseMajorMinor ignores OpenAI dated suffixes after the family name", () => {
+  assert.equal(parseMajorMinor("gpt-4o-2024-11-20"), 40);
+});
+
+void test("parseMajorMinor ignores Gemini preview date suffixes", () => {
+  assert.equal(parseMajorMinor("gemini-2.5-pro-preview-06-05"), 25);
+});
+
 void test("parseMajorMinor supports 2-digit minors (e.g. 5.12)", () => {
   assert.equal(parseMajorMinor("gpt-5.12"), 512);
 });
 
+void test("OpenAI model helpers handle major-only GPT-5 ids and Codex variants", () => {
+  assert.equal(isOpenAiGeneralGptModelId("gpt-5"), true);
+  assert.equal(isOpenAiGeneralGptModelId("gpt-5-pro"), true);
+  assert.equal(isOpenAiGeneralGptModelId("gpt-5-codex"), false);
+  assert.equal(isOpenAiCodexModelId("gpt-5-codex"), true);
+  assert.equal(isOpenAiCodexModelId("gpt-5.1-codex-max"), true);
+});
+
 void test("openAiFamilyPriority prefers base GPT-5 over Codex variants", () => {
-  assert.ok(openAiFamilyPriority("gpt-5.4") < openAiFamilyPriority("gpt-5.4-pro"));
-  assert.ok(openAiFamilyPriority("gpt-5.4-pro") < openAiFamilyPriority("gpt-5.3-codex"));
+  assert.ok(openAiFamilyPriority("gpt-5") < openAiFamilyPriority("gpt-5-pro"));
+  assert.ok(openAiFamilyPriority("gpt-5-pro") < openAiFamilyPriority("gpt-5-codex"));
 });
 
 void test("compareOpenAiModelIds prefers newer versions before family tie-breaks", () => {
-  const ids = ["gpt-5.4-pro", "gpt-5.5-codex", "gpt-5.5"];
+  const ids = ["gpt-4o-2024-11-20", "gpt-5.4-pro", "gpt-5.3-codex"];
   ids.sort(compareOpenAiModelIds);
-  assert.deepEqual(ids, ["gpt-5.5", "gpt-5.5-codex", "gpt-5.4-pro"]);
+  assert.deepEqual(ids, ["gpt-5.4-pro", "gpt-5.3-codex", "gpt-4o-2024-11-20"]);
+});
+
+void test("compareOpenAiModelIds prefers plain GPT-5 over other same-version variants", () => {
+  const ids = ["gpt-5-pro", "gpt-5-codex", "gpt-5"];
+  ids.sort(compareOpenAiModelIds);
+  assert.deepEqual(ids, ["gpt-5", "gpt-5-pro", "gpt-5-codex"]);
 });
 
 void test("shouldPreferOpenAiGeneralModel only prefers GPT when it is as new or newer", () => {
+  assert.equal(shouldPreferOpenAiGeneralModel("gpt-5", "gpt-5-codex"), true);
   assert.equal(shouldPreferOpenAiGeneralModel("gpt-5.4", "gpt-5.3-codex"), true);
-  assert.equal(shouldPreferOpenAiGeneralModel("gpt-5.4-pro", "gpt-5.5-codex"), false);
+  assert.equal(shouldPreferOpenAiGeneralModel("gpt-5-pro", "gpt-5.1-codex-max"), false);
 });
 
 void test("current OpenAI providers expose at least one default-model candidate", () => {
@@ -97,6 +120,12 @@ void test("pickDefaultModel matches the current OpenAI default-selection contrac
   }
 });
 
+void test("pickDefaultModel falls back to the latest hardcoded Anthropic default", () => {
+  const selected = pickDefaultModel([]);
+  assert.equal(selected.provider, "anthropic");
+  assert.equal(selected.id, "claude-opus-4-7");
+});
+
 void test("modelRecencyScore prefers higher version, then later date suffix", () => {
   assert.ok(
     modelRecencyScore("claude-opus-4-20250201") > modelRecencyScore("claude-opus-4-20250101"),
@@ -112,10 +141,10 @@ void test("modelRecencyScore prefers higher version, then later date suffix", ()
 
 void test("compareModels sorts non-OpenAI models by provider, family, then recency", () => {
   const models = [
-    { provider: "openai", id: "gpt-5.3" },
-    { provider: "anthropic", id: "claude-opus-4-6" },
+    { provider: "openai", id: "gpt-5.4" },
+    { provider: "anthropic", id: "claude-opus-4-7" },
     { provider: "anthropic", id: "claude-sonnet-4-6" },
-    { provider: "anthropic", id: "claude-opus-4-5" },
+    { provider: "anthropic", id: "claude-opus-4-6" },
     { provider: "google", id: "gemini-2.5-pro" },
   ];
 
@@ -128,27 +157,27 @@ void test("compareModels sorts non-OpenAI models by provider, family, then recen
   assert.ok(last);
   assert.equal(last.provider, "google");
 
-  // Within anthropic: opus family first; within opus: 4-6 before 4-5.
+  // Within anthropic: opus family first; within opus: 4-7 before 4-6.
   const anthropic = models.filter((m) => m.provider === "anthropic");
   assert.deepEqual(
     anthropic.map((m) => m.id),
-    ["claude-opus-4-6", "claude-opus-4-5", "claude-sonnet-4-6"],
+    ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"],
   );
 
   // Sanity: providerPriority is stable
   assert.ok(providerPriority("anthropic") < providerPriority("openai"));
 });
 
-void test("openai compareModels prefers newer Codex over older GPT variants", () => {
+void test("openai compareModels does not mistake dated GPT-4o ids for newer versions", () => {
   const models = [
+    { provider: "openai", id: "gpt-4o-2024-11-20" },
     { provider: "openai", id: "gpt-5.4-pro" },
-    { provider: "openai", id: "gpt-5.5-codex" },
-    { provider: "openai", id: "gpt-5.5" },
+    { provider: "openai", id: "gpt-5.3-codex" },
   ];
 
   models.sort(compareModels);
 
-  assert.deepEqual(models.map((m) => m.id), ["gpt-5.5", "gpt-5.5-codex", "gpt-5.4-pro"]);
+  assert.deepEqual(models.map((m) => m.id), ["gpt-5.4-pro", "gpt-5.3-codex", "gpt-4o-2024-11-20"]);
 });
 
 void test("provider-map keeps openai-codex distinct from openai", () => {

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -132,6 +132,16 @@ void test("modelRecencyScore prefers higher version, then later date suffix", ()
     "expected 20250201 > 20250101 for same major",
   );
 
+  assert.ok(
+    modelRecencyScore("gpt-4o-2024-11-20") > modelRecencyScore("gpt-4o-2024-05-13"),
+    "expected 2024-11-20 > 2024-05-13 for dated GPT snapshots",
+  );
+
+  assert.ok(
+    modelRecencyScore("gemini-2.5-flash-preview-05-20") > modelRecencyScore("gemini-2.5-flash-preview-04-17"),
+    "expected 05-20 > 04-17 for dated Gemini previews",
+  );
+
   // Version beats date.
   assert.ok(
     modelRecencyScore("claude-opus-4-6") > modelRecencyScore("claude-opus-4-20250201"),

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -80,6 +80,15 @@ void test("parseMajorMinor supports 2-digit minors (e.g. 5.12)", () => {
   assert.equal(parseMajorMinor("gpt-5.12"), 512);
 });
 
+void test("parseMajorMinor falls back for non-Claude/GPT/Gemini registry families", () => {
+  assert.equal(parseMajorMinor("gemma-4-31b-it"), 431);
+  assert.equal(parseMajorMinor("zai.glm-5"), 50);
+  assert.equal(parseMajorMinor("zai.glm-4.7"), 47);
+  assert.equal(parseMajorMinor("deepseek.v3.2"), 32);
+  assert.equal(parseMajorMinor("amazon.nova-2-lite-v1:0"), 20);
+  assert.equal(parseMajorMinor("unknown-model-2024-11-20"), 0);
+});
+
 void test("OpenAI model helpers handle major-only GPT-5 ids and Codex variants", () => {
   assert.equal(isOpenAiGeneralGptModelId("gpt-5"), true);
   assert.equal(isOpenAiGeneralGptModelId("gpt-5-pro"), true);
@@ -162,6 +171,22 @@ void test("modelRecencyScore prefers higher version, then later date suffix", ()
     modelRecencyScore("claude-opus-4-6") > modelRecencyScore("claude-opus-4-20250201"),
     "expected 4-6 to outrank 4-YYYYMMDD",
   );
+});
+
+void test("compareModels sorts generic versioned registry ids by parsed recency", () => {
+  const gemmaModels = [
+    { provider: "opencode", id: "gemma-3-27b-it" },
+    { provider: "opencode", id: "gemma-4-31b-it" },
+  ];
+  gemmaModels.sort(compareModels);
+  assert.deepEqual(gemmaModels.map((m) => m.id), ["gemma-4-31b-it", "gemma-3-27b-it"]);
+
+  const zaiModels = [
+    { provider: "openrouter", id: "zai.glm-4.7" },
+    { provider: "openrouter", id: "zai.glm-5" },
+  ];
+  zaiModels.sort(compareModels);
+  assert.deepEqual(zaiModels.map((m) => m.id), ["zai.glm-5", "zai.glm-4.7"]);
 });
 
 void test("compareModels sorts real namespaced registry ids by parsed recency", () => {

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -49,6 +49,13 @@ void test("parseMajorMinor packs Claude-style -major-minor as major*10+minor", (
   assert.equal(parseMajorMinor("claude-opus-4-7"), 47);
 });
 
+void test("parseMajorMinor handles namespaced and dotted Claude registry ids", () => {
+  assert.equal(parseMajorMinor("claude-opus-4.7"), 47);
+  assert.equal(parseMajorMinor("anthropic.claude-opus-4-1-20250805-v1:0"), 41);
+  assert.equal(parseMajorMinor("eu.anthropic.claude-sonnet-4-6"), 46);
+  assert.equal(parseMajorMinor("anthropic/claude-opus-4.7"), 47);
+});
+
 void test("parseMajorMinor does not treat YYYYMMDD as a minor version", () => {
   // This used to incorrectly parse as 4.20250514.
   assert.equal(parseMajorMinor("claude-opus-4-20250514"), 40);
@@ -56,7 +63,9 @@ void test("parseMajorMinor does not treat YYYYMMDD as a minor version", () => {
 
 void test("parseMajorMinor handles dot-style versions", () => {
   assert.equal(parseMajorMinor("gpt-5.3-codex"), 53);
+  assert.equal(parseMajorMinor("gpt-5.5"), 55);
   assert.equal(parseMajorMinor("gemini-2.5-pro"), 25);
+  assert.equal(parseMajorMinor("google/gemini-3.1-pro-preview"), 31);
 });
 
 void test("parseMajorMinor ignores OpenAI dated suffixes after the family name", () => {
@@ -85,9 +94,9 @@ void test("openAiFamilyPriority prefers base GPT-5 over Codex variants", () => {
 });
 
 void test("compareOpenAiModelIds prefers newer versions before family tie-breaks", () => {
-  const ids = ["gpt-4o-2024-11-20", "gpt-5.4-pro", "gpt-5.3-codex"];
+  const ids = ["gpt-4o-2024-11-20", "gpt-5.5", "gpt-5.4-pro", "gpt-5.3-codex"];
   ids.sort(compareOpenAiModelIds);
-  assert.deepEqual(ids, ["gpt-5.4-pro", "gpt-5.3-codex", "gpt-4o-2024-11-20"]);
+  assert.deepEqual(ids, ["gpt-5.5", "gpt-5.4-pro", "gpt-5.3-codex", "gpt-4o-2024-11-20"]);
 });
 
 void test("compareOpenAiModelIds prefers plain GPT-5 over other same-version variants", () => {
@@ -98,7 +107,7 @@ void test("compareOpenAiModelIds prefers plain GPT-5 over other same-version var
 
 void test("shouldPreferOpenAiGeneralModel only prefers GPT when it is as new or newer", () => {
   assert.equal(shouldPreferOpenAiGeneralModel("gpt-5", "gpt-5-codex"), true);
-  assert.equal(shouldPreferOpenAiGeneralModel("gpt-5.4", "gpt-5.3-codex"), true);
+  assert.equal(shouldPreferOpenAiGeneralModel("gpt-5.5", "gpt-5.3-codex"), true);
   assert.equal(shouldPreferOpenAiGeneralModel("gpt-5-pro", "gpt-5.1-codex-max"), false);
 });
 
@@ -138,6 +147,12 @@ void test("modelRecencyScore prefers higher version, then later date suffix", ()
   );
 
   assert.ok(
+    modelRecencyScore("anthropic.claude-opus-4-1-20250805-v1:0") >
+      modelRecencyScore("anthropic.claude-opus-4-1-20250101-v1:0"),
+    "expected embedded Bedrock compact dates to affect recency",
+  );
+
+  assert.ok(
     modelRecencyScore("gemini-2.5-flash-preview-05-20") > modelRecencyScore("gemini-2.5-flash-preview-04-17"),
     "expected 05-20 > 04-17 for dated Gemini previews",
   );
@@ -149,9 +164,37 @@ void test("modelRecencyScore prefers higher version, then later date suffix", ()
   );
 });
 
+void test("compareModels sorts real namespaced registry ids by parsed recency", () => {
+  const copilotModels = [
+    { provider: "github-copilot", id: "claude-opus-4.5" },
+    { provider: "github-copilot", id: "claude-opus-4.7" },
+    { provider: "github-copilot", id: "claude-opus-4.6" },
+  ];
+  copilotModels.sort(compareModels);
+  assert.deepEqual(
+    copilotModels.map((m) => m.id),
+    ["claude-opus-4.7", "claude-opus-4.6", "claude-opus-4.5"],
+  );
+
+  const bedrockModels = [
+    { provider: "amazon-bedrock", id: "anthropic.claude-opus-4-20250514-v1:0" },
+    { provider: "amazon-bedrock", id: "anthropic.claude-opus-4-1-20250805-v1:0" },
+    { provider: "amazon-bedrock", id: "anthropic.claude-opus-4-7" },
+  ];
+  bedrockModels.sort(compareModels);
+  assert.deepEqual(
+    bedrockModels.map((m) => m.id),
+    [
+      "anthropic.claude-opus-4-7",
+      "anthropic.claude-opus-4-1-20250805-v1:0",
+      "anthropic.claude-opus-4-20250514-v1:0",
+    ],
+  );
+});
+
 void test("compareModels sorts non-OpenAI models by provider, family, then recency", () => {
   const models = [
-    { provider: "openai", id: "gpt-5.4" },
+    { provider: "openai", id: "gpt-5.5" },
     { provider: "anthropic", id: "claude-opus-4-7" },
     { provider: "anthropic", id: "claude-sonnet-4-6" },
     { provider: "anthropic", id: "claude-opus-4-6" },
@@ -181,13 +224,14 @@ void test("compareModels sorts non-OpenAI models by provider, family, then recen
 void test("openai compareModels does not mistake dated GPT-4o ids for newer versions", () => {
   const models = [
     { provider: "openai", id: "gpt-4o-2024-11-20" },
+    { provider: "openai", id: "gpt-5.5" },
     { provider: "openai", id: "gpt-5.4-pro" },
     { provider: "openai", id: "gpt-5.3-codex" },
   ];
 
   models.sort(compareModels);
 
-  assert.deepEqual(models.map((m) => m.id), ["gpt-5.4-pro", "gpt-5.3-codex", "gpt-4o-2024-11-20"]);
+  assert.deepEqual(models.map((m) => m.id), ["gpt-5.5", "gpt-5.4-pro", "gpt-5.3-codex", "gpt-4o-2024-11-20"]);
 });
 
 void test("provider-map keeps openai-codex distinct from openai", () => {

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -81,7 +81,8 @@ void test("parseMajorMinor supports 2-digit minors (e.g. 5.12)", () => {
 });
 
 void test("parseMajorMinor falls back for non-Claude/GPT/Gemini registry families", () => {
-  assert.equal(parseMajorMinor("gemma-4-31b-it"), 431);
+  assert.equal(parseMajorMinor("gemma-4-31b-it"), 40);
+  assert.equal(parseMajorMinor("gemma-3-27b-it"), 30);
   assert.equal(parseMajorMinor("zai.glm-5"), 50);
   assert.equal(parseMajorMinor("zai.glm-4.7"), 47);
   assert.equal(parseMajorMinor("deepseek.v3.2"), 32);
@@ -212,6 +213,7 @@ void test("compareModels sorts real namespaced registry ids by parsed recency", 
   );
 
   const bedrockModels = [
+    { provider: "amazon-bedrock", id: "google.gemma-3-27b-it" },
     { provider: "amazon-bedrock", id: "anthropic.claude-opus-4-20250514-v1:0" },
     { provider: "amazon-bedrock", id: "anthropic.claude-opus-4-1-20250805-v1:0" },
     { provider: "amazon-bedrock", id: "anthropic.claude-opus-4-7" },
@@ -223,6 +225,7 @@ void test("compareModels sorts real namespaced registry ids by parsed recency", 
       "anthropic.claude-opus-4-7",
       "anthropic.claude-opus-4-1-20250805-v1:0",
       "anthropic.claude-opus-4-20250514-v1:0",
+      "google.gemma-3-27b-it",
     ],
   );
 });

--- a/tests/runtime-manager-activation-http-auth.test.ts
+++ b/tests/runtime-manager-activation-http-auth.test.ts
@@ -45,6 +45,8 @@ function buildBridge(args: {
   entry: StoredExtensionEntry;
   settings: MemorySettingsStore;
   connectionManager: ConnectionManager;
+  getRequiredActiveAgent?: () => Agent;
+  afterInjectAgentContext?: () => Promise<void> | void;
   runExtensionHttpFetch: (url: string, options?: {
     method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
     headers?: Record<string, string>;
@@ -58,15 +60,16 @@ function buildBridge(args: {
     body: string;
   }>;
 }) {
-  const getRequiredActiveAgent = (): Agent => {
+  const getRequiredActiveAgent = args.getRequiredActiveAgent ?? (() => {
     throw new Error("agent access should not be used in this test");
-  };
+  });
 
   return buildRuntimeManagerActivationBridge({
     entry: args.entry,
     settings: args.settings,
     connectionManager: args.connectionManager,
     getRequiredActiveAgent,
+    afterInjectAgentContext: args.afterInjectAgentContext,
     runExtensionLlmCompletion: () => Promise.resolve({
       content: "",
       model: "test/model",
@@ -80,6 +83,53 @@ function buildBridge(args: {
     widgetApiV2Enabled: false,
   });
 }
+
+void test("injectContext appends a message and triggers host sync hook", async () => {
+  const settings = new MemorySettingsStore();
+  const entry = createEntry("ext.inject");
+  const connectionManager = new ConnectionManager({ settings });
+  const messages: Agent["state"]["messages"] = [];
+  let syncCalls = 0;
+
+  const agent = {
+    state: { messages },
+    steer: () => {},
+    followUp: () => {},
+  } as unknown as Agent;
+
+  const bridge = buildBridge({
+    entry,
+    settings,
+    connectionManager,
+    getRequiredActiveAgent: () => agent,
+    afterInjectAgentContext: () => {
+      syncCalls += 1;
+    },
+    runExtensionHttpFetch: () => Promise.resolve({
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: "ok",
+    }),
+  });
+
+  bridge.host.injectAgentContext?.("context please");
+  await Promise.resolve();
+
+  assert.equal(syncCalls, 1);
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0]?.role, "user");
+
+  const firstContent = messages[0]?.content[0];
+  assert.ok(firstContent && firstContent.type === "text");
+  if (!firstContent || firstContent.type !== "text") {
+    assert.fail("expected extension context injection to append a text message");
+  }
+
+  const injectedMessageJson = JSON.stringify(messages[0]);
+  assert.match(injectedMessageJson, /\[Extension Acme Extension\]/);
+  assert.match(injectedMessageJson, /context please/);
+});
 
 void test("connection-aware http fetch injects auth header for allowed hosts", async () => {
   const settings = new MemorySettingsStore();


### PR DESCRIPTION
## Summary
- bump the Pi stack to 0.69.0 and update the model-update playbook/docs
- refresh default/featured model selection for the latest Anthropic/OpenAI/Gemini registries
- adapt to the latest agent-core state API so the repo still typechecks/builds on the new Pi versions

## Testing
- npm run test:models
- npm run check
- npm run build
- npm run test:context