### PR TITLE
fix: align browser OAuth client parameters

### DIFF
--- a/src/auth/anthropic-browser-oauth.ts
+++ b/src/auth/anthropic-browser-oauth.ts
@@ -14,7 +14,7 @@ import type {
 
 import { generatePKCE } from "./pkce.js";
 
-const CLIENT_ID = "9d1c250a-e61b-44d5-88ed-5944d1962f5e";
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
 const REDIRECT_URI = "http://localhost:53692/callback";

--- a/src/auth/openai-codex-browser-oauth.ts
+++ b/src/auth/openai-codex-browser-oauth.ts
@@ -19,7 +19,7 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
-const SCOPE = "openid profile email offline_access api.connectors.read api.connectors.invoke";
+const SCOPE = "openid profile email offline_access";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 
 type ParsedAuthorizationInput = { code?: string; state?: string };
@@ -217,7 +217,7 @@ async function createAuthorizationFlow(): Promise<{ verifier: string; state: str
   authUrl.searchParams.set("state", state);
   authUrl.searchParams.set("id_token_add_organizations", "true");
   authUrl.searchParams.set("codex_cli_simplified_flow", "true");
-  authUrl.searchParams.set("originator", "codex_vscode");
+  authUrl.searchParams.set("originator", "pi");
 
   return {
     verifier,

--- a/tests/browser-oauth.test.ts
+++ b/tests/browser-oauth.test.ts
@@ -64,6 +64,7 @@ void test("Anthropic OAuth provider uses the browser-safe implementation", async
 
   const authorizeUrl = new URL(authUrl);
   assert.equal(authorizeUrl.hostname, "claude.ai");
+  assert.equal(authorizeUrl.searchParams.get("client_id"), "9d1c250a-e61b-44d9-88ed-5944d1962f5e");
   assert.equal(authorizeUrl.searchParams.get("redirect_uri"), "http://localhost:53692/callback");
 
   assert.equal(requests.length, 1);
@@ -74,7 +75,7 @@ void test("Anthropic OAuth provider uses the browser-safe implementation", async
   assert.equal(body.state, new URL(authUrl).searchParams.get("state"));
 });
 
-void test("OpenAI Codex browser OAuth requests the current Codex connector scopes", async (t) => {
+void test("OpenAI Codex browser OAuth matches current Codex identity scopes", async (t) => {
   const originalFetch = globalThis.fetch;
   const requests: Array<{ url: string; body: unknown }> = [];
   const accessToken = fakeJwt({
@@ -116,11 +117,8 @@ void test("OpenAI Codex browser OAuth requests the current Codex connector scope
 
   const authorizeUrl = new URL(authUrl);
   assert.equal(authorizeUrl.hostname, "auth.openai.com");
-  assert.equal(
-    authorizeUrl.searchParams.get("scope"),
-    "openid profile email offline_access api.connectors.read api.connectors.invoke",
-  );
-  assert.equal(authorizeUrl.searchParams.get("originator"), "codex_vscode");
+  assert.equal(authorizeUrl.searchParams.get("scope"), "openid profile email offline_access");
+  assert.equal(authorizeUrl.searchParams.get("originator"), "pi");
 
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.url, "https://auth.openai.com/oauth/token");


### PR DESCRIPTION
## Summary
- Fix Anthropic browser OAuth client ID typo (`44d5` -> `44d9`), matching upstream Pi/Claude Code client ID.
- Revert OpenAI Codex browser OAuth to identity-only scopes and `originator=pi`, matching upstream/current Codex token shape.
- Add/adjust browser OAuth tests for both authorize URLs.

## Verification
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/browser-oauth.test.ts`
- `npm run check`
- `npm run build`

## Notes
- The Anthropic typo directly caused Claude's web UI: `Invalid client id provided`.
- The OpenAI connector scopes worked for a personal account but failed for the Nexcade ChatGPT Team account; official Codex-authenticated Nexcade tokens use the identity-only scope shape.
