### PR TITLE
chore: prepare v0.9.3-pre

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This folder contains **current** docs that should match shipped behavior.
 ## Guides
 - [Install Pi for Excel](./install.md)
 - [Deploy hosted build on Vercel](./deploy-vercel.md)
-- [Release notes (`v0.9.2-pre`)](./release-notes/v0.9.2-pre.md)
+- [Release notes (`v0.9.3-pre`)](./release-notes/v0.9.3-pre.md)
 - [Release smoke test checklist](./release-smoke-test-checklist.md)
 - [Release smoke run logs](./release-smoke-runs/README.md)
 

--- a/docs/release-notes/v0.9.3-pre.md
+++ b/docs/release-notes/v0.9.3-pre.md
@@ -1,0 +1,48 @@
+# v0.9.3-pre release notes
+
+_Pre-release. Changes since `v0.9.2-pre`._
+
+## Highlights
+
+- **GPT-5.5 is now the preferred default when OpenAI is available**
+  - Refreshed the Pi stack to `0.70.0` and pulled the latest model registry through `@mariozechner/pi-ai`.
+  - Updated model ordering/default selection for GPT-5.5, GPT-5.x/Codex variants, Claude Opus/Sonnet 4.x, Gemini 3/3.1, namespaced IDs, dotted IDs, and date-suffixed model families.
+  - Hardened parser fallbacks so parameter-size suffixes and embedded dates do not accidentally outrank newer model families.
+
+- **Browser OAuth logins are repaired for Office WebView**
+  - Added a browser-safe Anthropic Claude Pro/Max OAuth flow instead of using Pi's Node-only callback-server provider.
+  - Fixed the Anthropic client ID typo and routed the current `platform.claude.com` token endpoint through dev/prod proxy plumbing.
+  - Updated OpenAI Codex browser OAuth to match the current official Codex CLI request shape more closely: connector scopes, `originator=codex_cli_rs`, Codex CLI simplified flow, 64-byte PKCE verifier, and access-token account-claim validation.
+  - Versioned stored OpenAI Codex OAuth credentials so old identity-only grants are cleared and users are forced through the fresh authorize flow instead of silently refreshing insufficient scopes.
+  - Updated the local proxy and Vite dev proxy to strip browser-only headers before forwarding OAuth token exchanges.
+
+- **Custom gateway and overlay polish**
+  - Fixed deletion of custom OpenAI-compatible gateway API keys.
+  - Improved nested overlay Escape handling so confirmation dialogs do not accidentally close the wrong overlay.
+
+## Dependency and security notes
+
+- Pi packages (`@mariozechner/pi-ai`, `@mariozechner/pi-agent-core`, `@mariozechner/pi-web-ui`) remain in lockstep at `0.70.0`.
+- Targeted npm overrides keep high/critical audit findings clear without broad dependency downgrades.
+- The local OAuth CORS proxy package version is bumped to `0.2.3-pre` for the updated allowlist/header-forwarding behavior.
+
+## Verification
+
+- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/browser-oauth.test.ts`
+- `node --test --experimental-strip-types tests/cors-proxy-server.security.test.mjs tests/oauth-proxy-routing.test.ts`
+- `npm run test:models`
+- `npm run test:context`
+- `npm run test:security`
+- `npm run check`
+- `npm run build`
+- Manual Excel OAuth smoke: Anthropic Claude Pro/Max and OpenAI Codex browser OAuth from the local sideloaded taskpane.
+
+## Commit range reviewed
+
+Since `v0.9.2-pre`, this release incorporates:
+
+- `0711084` — refresh Pi model registry/model selection and Pi dependencies.
+- `b91eed0` — fix custom gateway API key deletion and nested overlay Escape behavior.
+- `1157851` — default to GPT-5.5 and repair browser OAuth plumbing.
+- `97b7b0a` — align browser OAuth client parameters.
+- This release patch — match current official Codex CLI OAuth details and harden proxy header stripping.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.2-pre",
+  "version": "0.9.3-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-for-excel",
-      "version": "0.9.2-pre",
+      "version": "0.9.3-pre",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.2-pre",
+  "version": "0.9.3-pre",
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {

--- a/pkg/proxy/package.json
+++ b/pkg/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel-proxy",
-  "version": "0.2.2-pre",
+  "version": "0.2.3-pre",
   "description": "One-command local HTTPS proxy helper for Pi for Excel OAuth logins.",
   "type": "module",
   "bin": {

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -229,11 +229,14 @@ function buildOutboundHeaders(inHeaders) {
     if (lower === "host") continue;
     if (lower === "content-length") continue;
     if (lower === "accept-encoding") continue;
+    if (lower === "user-agent") continue;
+    if (lower === "accept-language") continue;
 
     // Strip browser-only / CORS-triggering headers (mimic server requests)
     if (lower === "origin") continue;
     if (lower === "referer") continue;
     if (lower.startsWith("sec-fetch-")) continue;
+    if (lower.startsWith("sec-ch-")) continue;
 
     // Anthropic uses this header to explicitly enable direct browser access.
     // When proxying we want the upstream to behave like a server-to-server call.

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -5,4 +5,4 @@
  */
 
 export const APP_NAME = "pi-for-excel";
-export const APP_VERSION = "0.9.2-pre";
+export const APP_VERSION = "0.9.3-pre";

--- a/src/auth/openai-codex-browser-oauth.ts
+++ b/src/auth/openai-codex-browser-oauth.ts
@@ -19,7 +19,10 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
-const SCOPE = "openid profile email offline_access";
+const SCOPE = "openid profile email offline_access api.connectors.read api.connectors.invoke";
+const ORIGINATOR = "codex_cli_rs";
+const CREDENTIAL_VERSION = "codex-cli-rs-connector-scopes-2026-04";
+const STALE_CREDENTIAL_ERROR = "OpenAI login needs to be refreshed for current Codex scopes";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 
 type ParsedAuthorizationInput = { code?: string; state?: string };
@@ -31,19 +34,28 @@ type TokenPayload = {
   expiresInSeconds: number;
 };
 
+type VersionedOpenAICodexCredentials = OAuthCredentials & {
+  codexOAuthVersion?: string;
+  scopes?: string;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function createState(): string {
-  const bytes = new Uint8Array(16);
+  const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
 
-  let out = "";
+  let binary = "";
   for (const byte of bytes) {
-    out += byte.toString(16).padStart(2, "0");
+    binary += String.fromCharCode(byte);
   }
-  return out;
+
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
 }
 
 function parseAuthorizationInput(input: string): ParsedAuthorizationInput {
@@ -110,10 +122,10 @@ async function exchangeAuthorizationCode(code: string, verifier: string): Promis
     },
     body: new URLSearchParams({
       grant_type: "authorization_code",
-      client_id: CLIENT_ID,
       code,
-      code_verifier: verifier,
       redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      code_verifier: verifier,
     }),
   });
 
@@ -203,8 +215,36 @@ function getAccountId(accessToken: string): string | null {
   return accountId;
 }
 
+export function isOpenAICodexCredentialRefreshRequired(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(STALE_CREDENTIAL_ERROR);
+}
+
+function isCurrentOpenAICodexCredential(credentials: OAuthCredentials): boolean {
+  const versioned = credentials as VersionedOpenAICodexCredentials;
+  return versioned.codexOAuthVersion === CREDENTIAL_VERSION && versioned.scopes === SCOPE;
+}
+
+function assertCurrentOpenAICodexCredential(credentials: OAuthCredentials): void {
+  if (!isCurrentOpenAICodexCredential(credentials)) {
+    throw new Error(`${STALE_CREDENTIAL_ERROR}. Please disconnect and log in again.`);
+  }
+}
+
+function buildOpenAICodexCredentials(tokens: TokenPayload, accountId: string): OAuthCredentials {
+  const credentials: VersionedOpenAICodexCredentials = {
+    access: tokens.accessToken,
+    refresh: tokens.refreshToken,
+    expires: Date.now() + tokens.expiresInSeconds * 1000,
+    accountId,
+    codexOAuthVersion: CREDENTIAL_VERSION,
+    scopes: SCOPE,
+  };
+
+  return credentials;
+}
+
 async function createAuthorizationFlow(): Promise<{ verifier: string; state: string; url: string }> {
-  const { verifier, challenge } = await generatePKCE();
+  const { verifier, challenge } = await generatePKCE(64);
   const state = createState();
 
   const authUrl = new URL(AUTHORIZE_URL);
@@ -214,10 +254,10 @@ async function createAuthorizationFlow(): Promise<{ verifier: string; state: str
   authUrl.searchParams.set("scope", SCOPE);
   authUrl.searchParams.set("code_challenge", challenge);
   authUrl.searchParams.set("code_challenge_method", "S256");
-  authUrl.searchParams.set("state", state);
   authUrl.searchParams.set("id_token_add_organizations", "true");
   authUrl.searchParams.set("codex_cli_simplified_flow", "true");
-  authUrl.searchParams.set("originator", "pi");
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set("originator", ORIGINATOR);
 
   return {
     verifier,
@@ -266,17 +306,14 @@ export async function loginOpenAICodexInBrowser(
     throw new Error("OpenAI login failed: access token is missing ChatGPT account ID");
   }
 
-  return {
-    access: tokens.accessToken,
-    refresh: tokens.refreshToken,
-    expires: Date.now() + tokens.expiresInSeconds * 1000,
-    accountId,
-  };
+  return buildOpenAICodexCredentials(tokens, accountId);
 }
 
 export async function refreshOpenAICodexBrowserToken(
   credentials: OAuthCredentials,
 ): Promise<OAuthCredentials> {
+  assertCurrentOpenAICodexCredential(credentials);
+
   const refreshToken = credentials.refresh;
   if (typeof refreshToken !== "string" || refreshToken.trim().length === 0) {
     throw new Error("OpenAI refresh failed: missing refresh token");
@@ -288,12 +325,7 @@ export async function refreshOpenAICodexBrowserToken(
     throw new Error("OpenAI refresh failed: access token is missing ChatGPT account ID");
   }
 
-  return {
-    access: tokens.accessToken,
-    refresh: tokens.refreshToken,
-    expires: Date.now() + tokens.expiresInSeconds * 1000,
-    accountId,
-  };
+  return buildOpenAICodexCredentials(tokens, accountId);
 }
 
 export const openaiCodexBrowserOAuthProvider: OAuthProviderInterface = {
@@ -309,6 +341,7 @@ export const openaiCodexBrowserOAuthProvider: OAuthProviderInterface = {
   },
 
   getApiKey(credentials: OAuthCredentials): string {
+    assertCurrentOpenAICodexCredential(credentials);
     return credentials.access;
   },
 };

--- a/src/auth/pkce.ts
+++ b/src/auth/pkce.ts
@@ -16,8 +16,8 @@ function base64urlEncode(bytes: Uint8Array): string {
     .replace(/=/g, "");
 }
 
-export async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {
-  const verifierBytes = new Uint8Array(32);
+export async function generatePKCE(byteLength: number = 32): Promise<{ verifier: string; challenge: string }> {
+  const verifierBytes = new Uint8Array(byteLength);
   crypto.getRandomValues(verifierBytes);
   const verifier = base64urlEncode(verifierBytes);
 

--- a/src/auth/restore.ts
+++ b/src/auth/restore.ts
@@ -11,7 +11,8 @@ import type { ProviderKeysStore } from "@mariozechner/pi-web-ui/dist/storage/sto
 import type { SettingsStore } from "@mariozechner/pi-web-ui/dist/storage/stores/settings-store.js";
 
 import { originalFetch } from "./cors-proxy.js";
-import { loadOAuthCredentials, saveOAuthCredentials } from "./oauth-storage.js";
+import { clearOAuthCredentials, loadOAuthCredentials, saveOAuthCredentials } from "./oauth-storage.js";
+import { isOpenAICodexCredentialRefreshRequired } from "./openai-codex-browser-oauth.js";
 import { mapToApiProvider, BROWSER_OAUTH_PROVIDERS } from "./provider-map.js";
 import { getOAuthProvider } from "./oauth-provider-registry.js";
 import { getErrorMessage } from "../utils/errors.js";
@@ -121,6 +122,15 @@ async function restoreFromPiAuth(
   }
 }
 
+async function clearBrowserOAuthProvider(
+  providerKeys: ProviderKeysStore,
+  settings: SettingsStore,
+  providerId: string,
+): Promise<void> {
+  await clearOAuthCredentials(settings, providerId).catch(() => {});
+  await providerKeys.delete(mapToApiProvider(providerId)).catch(() => {});
+}
+
 async function restoreFromBrowserOAuthStorage(
   providerKeys: ProviderKeysStore,
   settings: SettingsStore,
@@ -143,14 +153,24 @@ async function restoreFromBrowserOAuthStorage(
           await providerKeys.set(apiProvider, provider.getApiKey(refreshed));
           console.log(`[auth] ${provider.name}: token refreshed from IndexedDB`);
         } catch (e: unknown) {
-          console.warn(`[auth] ${provider.name}: refresh failed (${getErrorMessage(e)}), please login again`);
+          if (providerId === "openai-codex" && isOpenAICodexCredentialRefreshRequired(e)) {
+            await clearBrowserOAuthProvider(providerKeys, settings, providerId);
+            console.warn(`[auth] ${provider.name}: stored OAuth grant is stale; cleared credentials, please login again`);
+          } else {
+            console.warn(`[auth] ${provider.name}: refresh failed (${getErrorMessage(e)}), please login again`);
+          }
         }
       } else {
         await providerKeys.set(apiProvider, provider.getApiKey(credentials));
         console.log(`[auth] ${provider.name}: session restored from IndexedDB`);
       }
     } catch (e: unknown) {
-      console.warn(`[auth] ${providerId}: failed to restore (${getErrorMessage(e)})`);
+      if (providerId === "openai-codex" && isOpenAICodexCredentialRefreshRequired(e)) {
+        await clearBrowserOAuthProvider(providerKeys, settings, providerId);
+        console.warn("[auth] OpenAI (ChatGPT Plus/Pro): stored OAuth grant is stale; cleared credentials, please login again");
+      } else {
+        console.warn(`[auth] ${providerId}: failed to restore (${getErrorMessage(e)})`);
+      }
     }
   }
 }

--- a/tests/browser-oauth.test.ts
+++ b/tests/browser-oauth.test.ts
@@ -75,7 +75,7 @@ void test("Anthropic OAuth provider uses the browser-safe implementation", async
   assert.equal(body.state, new URL(authUrl).searchParams.get("state"));
 });
 
-void test("OpenAI Codex browser OAuth matches current Codex identity scopes", async (t) => {
+void test("OpenAI Codex browser OAuth matches official Codex CLI authorize parameters", async (t) => {
   const originalFetch = globalThis.fetch;
   const requests: Array<{ url: string; body: unknown }> = [];
   const accessToken = fakeJwt({
@@ -114,17 +114,52 @@ void test("OpenAI Codex browser OAuth matches current Codex identity scopes", as
 
   const credentials = await provider.login(callbacks);
   assert.equal(credentials.accountId, "acct_browser_test");
+  assert.equal(credentials.codexOAuthVersion, "codex-cli-rs-connector-scopes-2026-04");
+  assert.equal(
+    credentials.scopes,
+    "openid profile email offline_access api.connectors.read api.connectors.invoke",
+  );
 
   const authorizeUrl = new URL(authUrl);
   assert.equal(authorizeUrl.hostname, "auth.openai.com");
-  assert.equal(authorizeUrl.searchParams.get("scope"), "openid profile email offline_access");
-  assert.equal(authorizeUrl.searchParams.get("originator"), "pi");
+  assert.equal(
+    authorizeUrl.searchParams.get("scope"),
+    "openid profile email offline_access api.connectors.read api.connectors.invoke",
+  );
+  assert.equal(authorizeUrl.searchParams.get("originator"), "codex_cli_rs");
+  assert.equal(authorizeUrl.searchParams.get("codex_cli_simplified_flow"), "true");
+  assert.equal(authorizeUrl.searchParams.get("id_token_add_organizations"), "true");
+  assert.match(authorizeUrl.searchParams.get("state") ?? "", /^[A-Za-z0-9_-]{43}$/);
 
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.url, "https://auth.openai.com/oauth/token");
   const body = new URLSearchParams(String(requests[0]?.body));
   assert.equal(body.get("grant_type"), "authorization_code");
   assert.equal(body.get("code"), "openai-code");
+  assert.equal(body.get("redirect_uri"), "http://localhost:1455/auth/callback");
+  assert.equal(body.get("client_id"), "app_EMoamEEZ73f0CkXaXp7hrann");
+  assert.match(body.get("code_verifier") ?? "", /^[A-Za-z0-9_-]{86}$/);
+});
+
+void test("OpenAI Codex browser OAuth rejects stale pre-scope-upgrade credentials", async () => {
+  const provider = getOAuthProvider("openai-codex");
+  assert.ok(provider);
+
+  const staleCredentials = {
+    access: "old-access-token",
+    refresh: "old-refresh-token",
+    expires: Date.now() + 3600_000,
+  };
+
+  assert.throws(
+    () => provider.getApiKey(staleCredentials),
+    /OpenAI login needs to be refreshed for current Codex scopes/,
+  );
+
+  await assert.rejects(
+    () => provider.refreshToken(staleCredentials),
+    /OpenAI login needs to be refreshed for current Codex scopes/,
+  );
 });
 
 void test("OpenAI Codex browser OAuth requires account ID on the access token", async (t) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -192,9 +192,14 @@ function stripBrowserHeaders(proxy: ProxyServerLike) {
   proxy.on("proxyReq", (proxyReq) => {
     proxyReq.removeHeader("origin");
     proxyReq.removeHeader("referer");
+    proxyReq.removeHeader("user-agent");
+    proxyReq.removeHeader("accept-language");
     proxyReq.removeHeader("sec-fetch-mode");
     proxyReq.removeHeader("sec-fetch-site");
     proxyReq.removeHeader("sec-fetch-dest");
+    proxyReq.removeHeader("sec-ch-ua");
+    proxyReq.removeHeader("sec-ch-ua-mobile");
+    proxyReq.removeHeader("sec-ch-ua-platform");
     proxyReq.removeHeader("anthropic-dangerous-direct-browser-access");
 
     // Cloud Code Assist endpoints use a colon in the path


### PR DESCRIPTION
## Summary
- Bump Pi for Excel to `0.9.3-pre` and proxy helper package to `0.2.3-pre`.
- Add `docs/release-notes/v0.9.3-pre.md`, summarizing changes since `v0.9.2-pre` / the last version bump.
- Finish the OpenAI Codex browser OAuth fix by matching current official Codex CLI request shape more closely: connector scopes, `originator=codex_cli_rs`, 64-byte PKCE verifier, Codex simplified flow, and access-token account-claim validation.
- Version stored OpenAI Codex OAuth credentials and clear stale pre-scope-upgrade credentials so users are forced through a fresh login instead of silently refreshing insufficient scopes.
- Harden local/Vite OAuth proxy forwarding by stripping browser-only headers from token exchange requests.

## What changed since the last version
Reviewed commits since the `v0.9.2-pre` release note/version bump:
- `0711084` — refreshed Pi stack/model registry/model selection through `0.70.0`, including GPT-5.5.
- `b91eed0` — fixed custom gateway API key deletion + nested overlay Escape handling.
- `1157851` — defaulted to GPT-5.5 and repaired browser OAuth plumbing.
- `97b7b0a` — fixed Anthropic client ID and aligned browser OAuth client parameters.
- This patch — matched current official Codex CLI OAuth details, invalidated stale OpenAI Codex OAuth grants, and hardened proxy header stripping.

## Verification
- `node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/browser-oauth.test.ts`
- `node --test --experimental-strip-types tests/cors-proxy-server.security.test.mjs tests/oauth-proxy-routing.test.ts`
- `npm run test:models`
- `npm run test:context`
- `npm run test:security`
- `npm run check`
- `npm run build`
- Manual Excel OAuth smoke: Anthropic works; OpenAI Codex works after forcing Excel onto the local patched sideload.
- `pr-reviewer` re-review after stale-credential fix: no P0-P2 findings.

## Notes
- `npm audit --audit-level=high` still reports only the existing moderate `uuid` chain under Office tooling; it does not block high-level audit.
- Build still emits the existing KaTeX font/chunk warnings.
