### PR TITLE
feat: add Claude Fable 5 model support

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,8 +1,8 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-05-29
+**Last verified:** 2026-06-09
 
-This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@earendil-works/pi-ai`) and will drift as new models ship (e.g. `gpt-5.5`, `gpt-5.3-codex`, `claude-opus-4-7`, `gemini-3.1-pro-preview`).
+This repo hardcodes a small set of "featured" and "preferred" model IDs (for sorting + default selection). Those IDs come from Pi’s model registry (`@earendil-works/pi-ai`) and will drift as new models ship (e.g. `gpt-5.5`, `gpt-5.3-codex`, `claude-fable-5`, `claude-opus-4-8`, `gemini-3.1-pro-preview`).
 
 This doc describes how to update:
 - the **Pi dependency versions** we ship (`@earendil-works/pi-ai`, `@earendil-works/pi-web-ui`, `@earendil-works/pi-agent-core`)
@@ -27,7 +27,7 @@ This doc describes how to update:
   - `@earendil-works/pi-web-ui`
   - `@earendil-works/pi-agent-core`
 - `.github/workflows/dependabot-pi-automerge.yml` auto-approves + enables auto-merge for that Dependabot group (merge still waits for green checks).
-- `npm run check` includes `scripts/check-pi-deps-lockstep.mjs`, which fails if those three package versions drift in either `package.json` specs or `package-lock.json` resolved versions.
+- `npm run check` includes `scripts/check-pi-deps-lockstep.mjs`, which enforces the dependency policy below (`pi-ai` === `pi-agent-core`, exact pins, single shared `pi-ai` copy in the lockfile).
 
 ## Step-by-step
 
@@ -55,21 +55,25 @@ npm view @earendil-works/pi-web-ui versions --json
 npm view @earendil-works/pi-agent-core versions --json
 ```
 
-Use the newest version that is published for **all three** lockstep packages. As of 2026-05-29, `pi-ai` and `pi-agent-core` are published beyond `0.75.3`, but `pi-web-ui` is not; the latest common lockstep version is therefore `0.75.3`.
+**Dependency policy (since 2026-06-09):** upstream stopped publishing `pi-web-ui` in lockstep after `0.75.3`, while `pi-ai` / `pi-agent-core` kept moving (and new models like `claude-fable-5` only exist in newer `pi-ai`). The rules are now:
+
+- `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` move **together** to the newest common version.
+- `@earendil-works/pi-web-ui` stays at the newest *published* version (currently `0.75.3`) and is allowed to lag.
+- All three must be **exact-pinned** in `package.json`.
+- The root `package.json` `overrides` entry for `@earendil-works/pi-ai` (`"$@earendil-works/pi-ai"`) forces `pi-web-ui`'s nested `^0.75.x` range onto the root version so the lockfile resolves **exactly one** copy of `pi-ai`. Two copies = two model registries = the ModelSelector and the app disagree about available models.
+- `scripts/check-pi-deps-lockstep.mjs` (run via `npm run check:pi-lockstep`) enforces all of this.
+- When bumping past `pi-web-ui`'s compiled-against version, re-verify the runtime APIs it imports from `pi-ai` still exist (`complete`, `streamSimple`, `getModel`, `getModels`, `getProviders`, `modelsAreEqual`, `StringEnum`) and check the pi changelog for breaking OAuth/streaming surface changes (e.g. 0.79.x made `onDeviceCode` / `onSelect` required in `OAuthLoginCallbacks`).
 
 ### 3) Bump dependencies in `package.json`
 
-Update these to the same latest common version (keep them in lockstep unless you *know* otherwise):
-- `@earendil-works/pi-ai`
-- `@earendil-works/pi-web-ui`
-- `@earendil-works/pi-agent-core`
+```bash
+npm install @earendil-works/pi-ai@<version> @earendil-works/pi-agent-core@<version> --save-exact
+```
 
-When one package lags behind the others, use exact pins for the common version rather than `^` ranges; otherwise npm can resolve `pi-ai` / `pi-agent-core` past the latest available `pi-web-ui` and fail `npm run check:pi-lockstep`.
-
-Then:
+Only bump `@earendil-works/pi-web-ui` when upstream actually publishes a newer version:
 
 ```bash
-npm install @earendil-works/pi-ai@<version> @earendil-works/pi-web-ui@<version> @earendil-works/pi-agent-core@<version> --save-exact
+npm install @earendil-works/pi-web-ui@<version> --save-exact
 ```
 
 ### 4) Verify the new model IDs exist in the registry
@@ -79,7 +83,8 @@ Search the local registry:
 ```bash
 rg -n "gpt-5\\.5"       node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
 rg -n "gpt-5\\.3-codex" node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
-rg -n "claude-opus-4-7"  node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
+rg -n "claude-fable-5"   node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
+rg -n "claude-opus-4-8"  node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
 rg -n "gemini-3\\.1-pro-preview" node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
 npm run test:models
 ```
@@ -105,8 +110,8 @@ We intentionally avoid pinning exact versioned IDs now. Instead we:
   3) then the rest sorted deterministically
 
   Featured rules (current desired behavior):
-  - **Anthropic:** latest **Sonnet** *if* its version >= latest **Opus**, then latest **Opus**
-    - Version compare uses `parseMajorMinor()` where `claude-opus-4-6` → `46`, `claude-opus-4-7` → `47`.
+  - **Anthropic:** latest **Fable** first (post-4.x flagship family, e.g. `claude-fable-5`), then latest **Sonnet** *if* its version >= latest **Opus**, then latest **Opus**
+    - Version compare uses `parseMajorMinor()` where `claude-opus-4-6` → `46`, `claude-opus-4-7` → `47`, `claude-fable-5` → `50`.
     - Important: IDs like `claude-opus-4-20250514` are treated as **major only** (`40`) and the `YYYYMMDD` part is considered a separate date suffix by `modelRecencyScore()`.
   - **OpenAI (`openai` + `openai-codex`):** latest general `gpt-5.x` *if* its version >= latest `gpt-5.x-codex`, then latest Codex
     - `gpt-5.5` scores as `55`; `gpt-5.3-codex` scores as `53`.
@@ -124,7 +129,7 @@ We intentionally avoid pinning exact versioned IDs now. Instead we:
   UI: the model picker is opened from the footer status bar (click the π model button).
 
 - Pick the default model via provider-aware rules:
-  - Anthropic is a small special-case (Sonnet when version ties or is newer than Opus; version compare uses `parseMajorMinor`)
+  - Anthropic is a small special-case (latest Fable when its version is >= both Opus and Sonnet; otherwise Sonnet when version ties or is newer than Opus; version compare uses `parseMajorMinor`)
   - OpenAI (`openai` + `openai-codex`) prefers the newest general GPT-5 when it is at least as new as Codex, with Codex as fallback
   - otherwise `DEFAULT_MODEL_RULES` + `pickLatestMatchingModel()` (uses `getModels(provider)` to find the newest available ID)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
-        "@earendil-works/pi-agent-core": "0.75.3",
-        "@earendil-works/pi-ai": "0.75.3",
+        "@earendil-works/pi-agent-core": "0.79.1",
+        "@earendil-works/pi-ai": "0.79.1",
         "@earendil-works/pi-web-ui": "0.75.3",
         "@sinclair/typebox": "^0.34.41",
         "lit": "^3.2.1",
@@ -198,17 +198,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
-      "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.5",
-        "@smithy/signature-v4": "^5.4.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -217,15 +217,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
-      "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -233,17 +233,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
-      "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -251,13 +251,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
-      "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -265,23 +265,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.46.tgz",
-      "integrity": "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/credential-provider-env": "^3.972.41",
-        "@aws-sdk/credential-provider-http": "^3.972.43",
-        "@aws-sdk/credential-provider-login": "^3.972.45",
-        "@aws-sdk/credential-provider-process": "^3.972.41",
-        "@aws-sdk/credential-provider-sso": "^3.972.45",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/credential-provider-imds": "^4.3.6",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -289,16 +289,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
-      "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.51.tgz",
+      "integrity": "sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -306,21 +306,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.47",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.47.tgz",
-      "integrity": "sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.41",
-        "@aws-sdk/credential-provider-http": "^3.972.43",
-        "@aws-sdk/credential-provider-ini": "^3.972.46",
-        "@aws-sdk/credential-provider-process": "^3.972.41",
-        "@aws-sdk/credential-provider-sso": "^3.972.45",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/credential-provider-imds": "^4.3.6",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -328,15 +328,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
-      "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -344,17 +344,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
-      "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/token-providers": "3.1056.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -362,16 +362,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1056.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
-      "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -379,16 +379,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
-      "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -396,14 +396,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.18.tgz",
-      "integrity": "sha512-QPQhwY/fstR8fMZFWrsJRNoTP6D1RjRPHGRX7u9/VkF3opCsvD0oXPz6qzkX94SchzvuS5vyFZbJbPcMEs2Jeg==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.21.tgz",
+      "integrity": "sha512-mVC0hOmwGJmNFezZ+wM8Sqfap/LjsMavEf2Evl0YWrLAcrdZOEdjnY8nRvgakVViWJSGm2eJxLuPVHGdeV06kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -411,14 +411,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.14.tgz",
-      "integrity": "sha512-DoZ4djVj/74XQ6M/IwxuKh543tTvLCL7u1Dx+VDHMgW9yGNrFSJJ1l0LrUQRaekic5CB12wUiiOoHL0VI6H0gg==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.17.tgz",
+      "integrity": "sha512-tdbnXbw73ww62ABWP0G0Z/euvFowEEvAoi/zG4NaZo7HJFpfGho/Z65HyVzkJLT1cMsUregr4pTyxljlarT0wA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -426,17 +426,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.23.tgz",
-      "integrity": "sha512-F0d4A9pJFiwljyKgSwU1Z5n+CXSv8bp+V5SthbS2rftB8wBN9z1K2Yyv3xbeK0AM2T0g4q6Ptf0shFF+oQZyiA==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.28.tgz",
+      "integrity": "sha512-SCW06Zjugn86pq7+dxGnFcyWJuEWHT753HTU/Vj/OzVxP+NoShwdAr4ynxAcvWL883OgRVbSqW3ohnjIxwXjjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/signature-v4": "^5.4.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -444,20 +444,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
-      "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -465,13 +465,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
-      "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -479,14 +479,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
-      "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
+      "version": "3.996.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
+      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/signature-v4": "^5.4.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -511,12 +511,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -524,9 +524,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -536,12 +536,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
-      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -1092,15 +1092,15 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.3.tgz",
-      "integrity": "sha512-azg09GSrckQa3ffbH09YEZC7DyHgmNSX+vmWEoEhQvp4icbzqbqLfIeMayMNEK/aGusm1SghZC4bPlDdagDALg==",
+      "version": "0.79.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.1.tgz",
+      "integrity": "sha512-PBPjBa2YBm9jauiLtHAKaSfVJ4Dvm3/nK/bR/oHebLjwBCS2tGx3aQDX7MSGAOXi6BejlhzbB/z82BkyAyNjjQ==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.3",
-        "ignore": "^7.0.5",
-        "typebox": "^1.1.24",
-        "yaml": "^2.8.2"
+        "@earendil-works/pi-ai": "^0.79.1",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1116,20 +1116,21 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.3.tgz",
-      "integrity": "sha512-UKccS+ADlkSVJ49a00346jUfXmUi6zzzB+pPWotsyA6SxhKr2ejjkGQksGyR1DyNVrsEP/WWlsOSTUUwVlzNaA==",
+      "version": "0.79.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.1.tgz",
+      "integrity": "sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "^2.2.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "typebox": "^1.1.24"
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -4549,13 +4550,13 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
-      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4563,13 +4564,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.6.tgz",
-      "integrity": "sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4577,13 +4578,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
-      "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4617,13 +4618,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
-      "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4631,9 +4632,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -7294,9 +7295,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -7437,9 +7438,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@earendil-works/pi-agent-core": "0.75.3",
-    "@earendil-works/pi-ai": "0.75.3",
+    "@earendil-works/pi-agent-core": "0.79.1",
+    "@earendil-works/pi-ai": "0.79.1",
     "@earendil-works/pi-web-ui": "0.75.3",
     "@sinclair/typebox": "^0.34.41",
     "lit": "^3.2.1",
@@ -70,6 +70,7 @@
     "fast-xml-parser": "5.7.0",
     "@xmldom/xmldom": "0.8.13",
     "protobufjs": "7.6.2",
-    "follow-redirects": "1.16.0"
+    "follow-redirects": "1.16.0",
+    "@earendil-works/pi-ai": "$@earendil-works/pi-ai"
   }
 }

--- a/scripts/check-pi-deps-lockstep.mjs
+++ b/scripts/check-pi-deps-lockstep.mjs
@@ -1,10 +1,25 @@
 import { promises as fs } from "node:fs";
 
-const PI_DEPENDENCIES = [
-  "@earendil-works/pi-ai",
-  "@earendil-works/pi-web-ui",
-  "@earendil-works/pi-agent-core",
-];
+/**
+ * Pi dependency policy:
+ *
+ * - `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` must stay in
+ *   exact lockstep (same spec in package.json, same resolved version in
+ *   package-lock.json).
+ * - `@earendil-works/pi-web-ui` is allowed to lag: upstream stopped publishing
+ *   it in lockstep after 0.75.3. It must still be exact-pinned.
+ * - The lockfile must resolve exactly ONE copy of `pi-ai` and `pi-agent-core`
+ *   (no nested duplicates). Duplicate pi-ai copies mean two model registries:
+ *   the ModelSelector (pi-web-ui) and the app would disagree about available
+ *   models. The root `overrides` entry for pi-ai keeps pi-web-ui's nested
+ *   range deduped onto the root version — this check verifies the effect.
+ */
+
+const LOCKSTEP_PAIR = ["@earendil-works/pi-ai", "@earendil-works/pi-agent-core"];
+const SINGLETON_PACKAGES = ["@earendil-works/pi-ai", "@earendil-works/pi-agent-core"];
+const PI_DEPENDENCIES = [...LOCKSTEP_PAIR, "@earendil-works/pi-web-ui"];
+
+const EXACT_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 
 function findMissing(entries) {
   return entries.filter(([, version]) => typeof version !== "string");
@@ -25,12 +40,47 @@ function failIfNotLockstep(sourceName, entries) {
   const versions = new Set(entries.map(([, version]) => version));
   if (versions.size <= 1) return false;
 
-  console.error(`\n✗ Pi dependencies are out of lockstep in ${sourceName}:\n`);
+  console.error(`\n✗ Pi core dependencies are out of lockstep in ${sourceName}:\n`);
   for (const [name, version] of entries) {
     console.error(`  - ${name}: ${version}`);
   }
-  console.error("\nExpected all three Pi package versions to match exactly.");
+  console.error("\nExpected pi-ai and pi-agent-core versions to match exactly.");
   return true;
+}
+
+function failIfNotExactPins(entries) {
+  const loose = entries.filter(([, version]) => !EXACT_VERSION_RE.test(version));
+  if (loose.length === 0) return false;
+
+  console.error("\n✗ Pi dependencies must be exact-pinned in package.json:\n");
+  for (const [name, version] of loose) {
+    console.error(`  - ${name}: ${version}`);
+  }
+  return true;
+}
+
+function failIfDuplicateResolutions(lockPackages) {
+  let hasErrors = false;
+
+  for (const name of SINGLETON_PACKAGES) {
+    const suffix = `node_modules/${name}`;
+    const resolutions = Object.keys(lockPackages).filter(
+      (key) => key === suffix || key.endsWith(`/${suffix}`),
+    );
+
+    if (resolutions.length > 1) {
+      console.error(`\n✗ ${name} resolves to multiple copies in package-lock.json:\n`);
+      for (const key of resolutions) {
+        console.error(`  - ${key}: ${lockPackages[key]?.version}`);
+      }
+      console.error(
+        "\nExpected a single shared copy. Check the root \"overrides\" entry for pi-ai.",
+      );
+      hasErrors = true;
+    }
+  }
+
+  return hasErrors;
 }
 
 async function main() {
@@ -51,20 +101,27 @@ async function main() {
     lockPackages[`node_modules/${name}`]?.version,
   ]);
 
+  const pairFrom = (entries) => entries.filter(([name]) => LOCKSTEP_PAIR.includes(name));
+
   const hasErrors =
     failMissing("package.json", findMissing(packageJsonEntries)) ||
     failMissing("package-lock.json", findMissing(lockEntries)) ||
-    failIfNotLockstep("package.json", packageJsonEntries) ||
-    failIfNotLockstep("package-lock.json", lockEntries);
+    failIfNotExactPins(packageJsonEntries) ||
+    failIfNotLockstep("package.json", pairFrom(packageJsonEntries)) ||
+    failIfNotLockstep("package-lock.json", pairFrom(lockEntries)) ||
+    failIfDuplicateResolutions(lockPackages);
 
   if (hasErrors) {
     process.exitCode = 1;
     return;
   }
 
-  const specVersion = packageJsonEntries[0]?.[1] ?? "(unknown)";
-  const resolvedVersion = lockEntries[0]?.[1] ?? "(unknown)";
-  console.log(`✓ Pi dependencies are in lockstep (spec: ${specVersion}, resolved: ${resolvedVersion}).`);
+  const coreVersion = packageJsonEntries[0]?.[1] ?? "(unknown)";
+  const webUiVersion =
+    packageJsonEntries.find(([name]) => name === "@earendil-works/pi-web-ui")?.[1] ?? "(unknown)";
+  console.log(
+    `✓ Pi dependencies OK (pi-ai/pi-agent-core: ${coreVersion}, pi-web-ui: ${webUiVersion}, single shared pi-ai copy).`,
+  );
 }
 
 void main();

--- a/src/compat/model-selector-patch.ts
+++ b/src/compat/model-selector-patch.ts
@@ -89,7 +89,8 @@ export function installModelSelectorPatch(): void {
     // "Latest for each" behavior:
     // - keep current model at the very top
     // - then show "featured" models (latest per provider, pattern-based)
-    //   - Anthropic: latest Sonnet if its version >= latest Opus, then latest Opus
+    //   - Anthropic: latest Fable first (post-4.x flagship family), then
+    //     latest Sonnet if its version >= latest Opus, then latest Opus
     //   - OpenAI (API + ChatGPT): latest GPT-5 when its version >= latest Codex,
     //     then latest Codex
     //   - Google API-key: latest gemini-*-pro*
@@ -165,6 +166,11 @@ export function installModelSelectorPatch(): void {
 
       // Provider-specific "latest" rules
       if (provider === "anthropic") {
+        const bestFable = pickBestByRecency(models, (m) => m.id.startsWith("claude-fable-"));
+        if (bestFable) {
+          featured.push(bestFable);
+        }
+
         const bestOpus = pickBestByRecency(models, (m) => m.id.startsWith("claude-opus-"));
         const bestSonnet = pickBestByRecency(models, (m) => m.id.startsWith("claude-sonnet-"));
 
@@ -186,6 +192,11 @@ export function installModelSelectorPatch(): void {
 
         if (bestSonnet) {
           featured.push(bestSonnet);
+          continue;
+        }
+
+        if (bestFable) {
+          // Fable-only provider list — already featured above.
           continue;
         }
 

--- a/src/models/model-ordering.ts
+++ b/src/models/model-ordering.ts
@@ -69,9 +69,11 @@ export function openAiFamilyPriority(id: string): number {
 
 export function familyPriority(provider: string, id: string): number {
   if (provider === "anthropic") {
-    if (id.startsWith("claude-opus-")) return 0;
-    if (id.startsWith("claude-sonnet-")) return 1;
-    if (id.startsWith("claude-haiku-")) return 2;
+    // Fable is the post-4.x flagship family (e.g. claude-fable-5).
+    if (id.startsWith("claude-fable-")) return 0;
+    if (id.startsWith("claude-opus-")) return 1;
+    if (id.startsWith("claude-sonnet-")) return 2;
+    if (id.startsWith("claude-haiku-")) return 3;
     return 9;
   }
 
@@ -96,6 +98,7 @@ export function parseMajorMinor(id: string): number {
   // Examples:
   // - claude-opus-4-6                         -> 46
   // - claude-opus-4.7                         -> 47
+  // - claude-fable-5                          -> 50 (major only)
   // - anthropic.claude-opus-4-1-20250805-v1:0 -> 41 (date handled separately)
   // - claude-opus-4-20250514                  -> 40 (major only; date handled separately)
   // - gpt-5.5                                 -> 55

--- a/src/taskpane/default-model.ts
+++ b/src/taskpane/default-model.ts
@@ -91,16 +91,28 @@ export function pickDefaultModel(
   }
 
   // Anthropic special-case:
-  // Prefer Sonnet when its major/minor version is >= Opus (e.g. Sonnet 4-6 over Opus 4-6).
-  // Otherwise prefer Opus.
+  // Prefer the latest Fable when its major/minor version is >= both Opus and
+  // Sonnet (e.g. Fable 5 over Opus 4-8) — Fable is the post-4.x flagship family.
+  // Otherwise prefer Sonnet when its major/minor version is >= Opus
+  // (e.g. Sonnet 4-6 over Opus 4-6), then Opus.
   if (availableProviders.includes("anthropic")) {
     const models: Model<Api>[] = getProviderModels("anthropic");
-    const opus = models
-      .filter((m) => m.id.startsWith("claude-opus-"))
-      .sort((a, b) => modelRecencyScore(b.id) - modelRecencyScore(a.id))[0];
-    const sonnet = models
-      .filter((m) => m.id.startsWith("claude-sonnet-"))
-      .sort((a, b) => modelRecencyScore(b.id) - modelRecencyScore(a.id))[0];
+    const latestWithPrefix = (prefix: string): Model<Api> | undefined =>
+      models
+        .filter((m) => m.id.startsWith(prefix))
+        .sort((a, b) => modelRecencyScore(b.id) - modelRecencyScore(a.id))[0];
+
+    const fable = latestWithPrefix("claude-fable-");
+    const opus = latestWithPrefix("claude-opus-");
+    const sonnet = latestWithPrefix("claude-sonnet-");
+
+    if (
+      fable &&
+      (!opus || parseMajorMinor(fable.id) >= parseMajorMinor(opus.id)) &&
+      (!sonnet || parseMajorMinor(fable.id) >= parseMajorMinor(sonnet.id))
+    ) {
+      return fable;
+    }
 
     if (opus && sonnet) {
       return parseMajorMinor(sonnet.id) >= parseMajorMinor(opus.id) ? sonnet : opus;

--- a/src/ui/provider-login.ts
+++ b/src/ui/provider-login.ts
@@ -317,6 +317,132 @@ function normalizeApiKeyForProvider(
   return { ok: true, key };
 }
 
+/**
+ * Show a non-blocking dialog with a device-code login code (e.g. GitHub
+ * Copilot). The login flow keeps polling in the background, so the dialog
+ * only informs the user; the caller closes it when login settles.
+ */
+function showDeviceCodeDialog(info: { userCode: string; verificationUri: string }): () => void {
+  closeOverlayById(PROVIDER_PROMPT_OVERLAY_ID);
+
+  const dialog = createOverlayDialog({
+    overlayId: PROVIDER_PROMPT_OVERLAY_ID,
+    cardClassName: "pi-welcome-card pi-prompt-card",
+    restoreFocusOnClose: false,
+  });
+
+  const title = document.createElement("h2");
+  title.className = "pi-prompt-title";
+  title.textContent = "Finish sign-in in your browser";
+
+  const message = document.createElement("p");
+  message.className = "pi-prompt-message";
+  message.textContent = "Enter this code on the verification page that just opened:";
+
+  const codeRow = document.createElement("div");
+  codeRow.style.cssText = "display:flex;align-items:center;gap:8px;margin:12px 0;";
+
+  const codeEl = document.createElement("code");
+  codeEl.style.cssText =
+    "flex:1;padding:8px 10px;border-radius:6px;text-align:center;" +
+    "background:var(--pi-code-bg, #1e1e1e);color:var(--pi-code-fg, #d4d4d4);" +
+    "font-size:16px;letter-spacing:2px;font-family:var(--pi-monospace, monospace);user-select:all;";
+  codeEl.textContent = info.userCode;
+
+  const copyBtn = document.createElement("button");
+  copyBtn.type = "button";
+  copyBtn.textContent = "Copy";
+  copyBtn.style.cssText = "padding:6px 12px;border-radius:6px;font-size:13px;cursor:pointer;";
+  copyBtn.addEventListener("click", () => {
+    void navigator.clipboard.writeText(info.userCode).then(() => {
+      copyBtn.textContent = "Copied!";
+      setTimeout(() => { copyBtn.textContent = "Copy"; }, 1500);
+    });
+  });
+
+  codeRow.append(codeEl, copyBtn);
+
+  const helper = document.createElement("p");
+  helper.className = "pi-prompt-helper";
+  helper.textContent = `If no window opened, visit ${info.verificationUri} and enter the code there.`;
+
+  dialog.card.append(title, message, codeRow, helper);
+  dialog.mount();
+
+  return () => dialog.close();
+}
+
+/**
+ * Show a select dialog for OAuth flows that need the user to pick between
+ * options (pi-ai `OAuthLoginCallbacks.onSelect`). Resolves the selected
+ * option id, or `undefined` if the user cancels.
+ */
+function promptForSelect(opts: {
+  title: string;
+  message: string;
+  options: { id: string; label: string }[];
+}): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    closeOverlayById(PROVIDER_PROMPT_OVERLAY_ID);
+
+    const dialog = createOverlayDialog({
+      overlayId: PROVIDER_PROMPT_OVERLAY_ID,
+      cardClassName: "pi-welcome-card pi-prompt-card",
+      restoreFocusOnClose: false,
+    });
+
+    const titleEl = document.createElement("h2");
+    titleEl.className = "pi-prompt-title";
+    titleEl.textContent = opts.title;
+
+    const messageEl = document.createElement("p");
+    messageEl.className = "pi-prompt-message";
+    messageEl.textContent = opts.message;
+
+    const optionList = document.createElement("div");
+    optionList.style.cssText = "display:flex;flex-direction:column;gap:8px;margin:12px 0;";
+
+    let settled = false;
+
+    const settle = (value: string | undefined): void => {
+      if (settled) return;
+      settled = true;
+      dialog.close();
+      resolve(value);
+    };
+
+    for (const option of opts.options) {
+      const optionBtn = document.createElement("button");
+      optionBtn.type = "button";
+      optionBtn.className = "pi-prompt-ok";
+      optionBtn.textContent = option.label;
+      optionBtn.addEventListener("click", () => settle(option.id));
+      optionList.append(optionBtn);
+    }
+
+    const actions = document.createElement("div");
+    actions.className = "pi-prompt-actions";
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.className = "pi-prompt-cancel";
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.addEventListener("click", () => settle(undefined));
+    actions.append(cancelBtn);
+
+    dialog.card.append(titleEl, messageEl, optionList, actions);
+
+    dialog.addCleanup(() => {
+      if (!settled) {
+        settled = true;
+        resolve(undefined);
+      }
+    });
+
+    dialog.mount();
+  });
+}
+
 function promptForText(opts: {
   title: string;
   message: string;
@@ -552,37 +678,57 @@ export function buildProviderRow(
             }
           }
 
-          const cred = await oauthProvider.login({
-            onAuth: (info) => {
-              // Prevent the OAuth page from gaining a handle to the add-in window.
-              const w = window.open(info.url, "_blank", "noopener,noreferrer");
-              if (w) w.opener = null;
-            },
-            onPrompt: async (prompt) => {
-              const helperText = id === "anthropic"
-                ? "After completing login, your browser may show a localhost page that cannot be reached — that's normal. Copy the full URL from the browser address bar and paste it here."
-                : id === "openai-codex"
-                  ? "After login, your browser will show a page that says \"can't be reached\" \u2014 that's normal! Copy the full URL from the browser address bar and paste it here."
-                  : id === "google-gemini-cli" || id === "google-antigravity"
-                    ? "After sign-in, your browser will show a page that says \"can't be reached\" \u2014 that's normal! Copy the full URL from the browser address bar and paste it here."
-                    : undefined;
+          const deviceCodeDialogRef: { close: (() => void) | null } = { close: null };
 
-              const value = await promptForText({
-                title: `Login with ${label}`,
-                message: prompt.message,
-                placeholder: prompt.placeholder || "",
-                helperText,
-                submitLabel: "Continue",
-              });
+          let cred;
+          try {
+            cred = await oauthProvider.login({
+              onAuth: (info) => {
+                // Prevent the OAuth page from gaining a handle to the add-in window.
+                const w = window.open(info.url, "_blank", "noopener,noreferrer");
+                if (w) w.opener = null;
+              },
+              onDeviceCode: (info) => {
+                // Device-code flows (e.g. GitHub Copilot): open the verification
+                // page and show the user code to enter there.
+                const w = window.open(info.verificationUri, "_blank", "noopener,noreferrer");
+                if (w) w.opener = null;
+                deviceCodeDialogRef.close = showDeviceCodeDialog(info);
+              },
+              onSelect: (prompt) =>
+                promptForSelect({
+                  title: `Login with ${label}`,
+                  message: prompt.message,
+                  options: prompt.options,
+                }),
+              onPrompt: async (prompt) => {
+                const helperText = id === "anthropic"
+                  ? "After completing login, your browser may show a localhost page that cannot be reached — that's normal. Copy the full URL from the browser address bar and paste it here."
+                  : id === "openai-codex"
+                    ? "After login, your browser will show a page that says \"can't be reached\" \u2014 that's normal! Copy the full URL from the browser address bar and paste it here."
+                    : id === "google-gemini-cli" || id === "google-antigravity"
+                      ? "After sign-in, your browser will show a page that says \"can't be reached\" \u2014 that's normal! Copy the full URL from the browser address bar and paste it here."
+                      : undefined;
 
-              if (id === "anthropic") {
-                return normalizeAnthropicAuthorizationInput(value);
-              }
+                const value = await promptForText({
+                  title: `Login with ${label}`,
+                  message: prompt.message,
+                  placeholder: prompt.placeholder || "",
+                  helperText,
+                  submitLabel: "Continue",
+                });
 
-              return value;
-            },
-            onProgress: (msg) => { oauthBtn.textContent = msg; },
-          });
+                if (id === "anthropic") {
+                  return normalizeAnthropicAuthorizationInput(value);
+                }
+
+                return value;
+              },
+              onProgress: (msg) => { oauthBtn.textContent = msg; },
+            });
+          } finally {
+            deviceCodeDialogRef.close?.();
+          }
 
           const apiKey = oauthProvider.getApiKey(cred);
           await storage.providerKeys.set(id, apiKey);

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -50,6 +50,12 @@ void test("parseMajorMinor packs Claude-style -major-minor as major*10+minor", (
   assert.equal(parseMajorMinor("claude-opus-4-7"), 47);
 });
 
+void test("parseMajorMinor scores Claude Fable ids as a new major version", () => {
+  assert.equal(parseMajorMinor("claude-fable-5"), 50);
+  assert.equal(parseMajorMinor("anthropic/claude-fable-5"), 50);
+  assert.equal(parseMajorMinor("us.anthropic.claude-fable-5"), 50);
+});
+
 void test("parseMajorMinor handles namespaced and dotted Claude registry ids", () => {
   assert.equal(parseMajorMinor("claude-opus-4.7"), 47);
   assert.equal(parseMajorMinor("anthropic.claude-opus-4-1-20250805-v1:0"), 41);
@@ -127,9 +133,31 @@ void test("shouldPreferOpenAiGeneralModel only prefers GPT when it is as new or 
 
 void test("current Pi registry exposes the refreshed preferred model ids", () => {
   assert.equal(getModel("openai", "gpt-5.5").id, "gpt-5.5");
-  assert.equal(getModel("openai-codex", "gpt-5.3-codex").id, "gpt-5.3-codex");
+  // pi-ai 0.79.x moved gpt-5.3-codex off the ChatGPT (openai-codex) provider;
+  // it remains available via the OpenAI API provider.
+  assert.equal(getModel("openai-codex", "gpt-5.5").id, "gpt-5.5");
+  assert.equal(getModel("openai", "gpt-5.3-codex").id, "gpt-5.3-codex");
   assert.equal(getModel("anthropic", "claude-opus-4-7").id, "claude-opus-4-7");
+  assert.equal(getModel("anthropic", "claude-fable-5").id, "claude-fable-5");
   assert.equal(getModel("google", "gemini-3.1-pro-preview").id, "gemini-3.1-pro-preview");
+});
+
+void test("Claude Fable 5 registry metadata is usable by the add-in", () => {
+  const fable = getModel("anthropic", "claude-fable-5");
+  assert.equal(fable.provider, "anthropic");
+  assert.equal(fable.api, "anthropic-messages");
+  assert.ok(fable.reasoning, "expected Fable 5 to support reasoning");
+  assert.ok(fable.contextWindow >= 1_000_000, "expected a 1M-token context window");
+});
+
+void test("pickDefaultModel prefers the latest Fable for Anthropic-only setups", () => {
+  const models = getModels("anthropic");
+  const fable = models.filter((m) => m.id.startsWith("claude-fable-"));
+  assert.ok(fable.length > 0, "expected at least one Fable model in the registry");
+
+  const selected = pickDefaultModel(["anthropic"]);
+  assert.equal(selected.provider, "anthropic");
+  assert.equal(selected.id, "claude-fable-5");
 });
 
 void test("current OpenAI providers expose at least one default-model candidate", () => {
@@ -292,6 +320,22 @@ void test("compareModels sorts non-OpenAI models by provider, family, then recen
 
   // Sanity: providerPriority is stable
   assert.ok(providerPriority("anthropic") < providerPriority("openai"));
+});
+
+void test("compareModels puts the Fable family before Opus/Sonnet/Haiku for Anthropic", () => {
+  const models = [
+    { provider: "anthropic", id: "claude-haiku-4-5" },
+    { provider: "anthropic", id: "claude-opus-4-8" },
+    { provider: "anthropic", id: "claude-fable-5" },
+    { provider: "anthropic", id: "claude-sonnet-4-6" },
+  ];
+
+  models.sort(compareModels);
+
+  assert.deepEqual(
+    models.map((m) => m.id),
+    ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
+  );
 });
 
 void test("openai compareModels does not mistake dated GPT-4o ids for newer versions", () => {


### PR DESCRIPTION
## Summary

Adds **Claude Fable 5** (`claude-fable-5`) — Anthropic's post-4.x flagship (1M context, adaptive thinking, `xhigh` effort) — to the add-in: registry, model picker ordering/featured models, and default-model selection.

## Why a dependency policy change was needed

`claude-fable-5` only exists in `@earendil-works/pi-ai` ≥ 0.79.1 (driver-level adaptive-thinking support landed there too — defining it as a custom model on 0.75.3 would send malformed thinking params). But upstream stopped publishing `pi-web-ui` in lockstep after 0.75.3, so the old "all three identical" rule is no longer satisfiable (this is also why Dependabot's pi-stack PR #560 fails CI).

New policy (enforced by `scripts/check-pi-deps-lockstep.mjs`, documented in `docs/model-updates.md`):
- `pi-ai` === `pi-agent-core` exactly (now 0.79.1); `pi-web-ui` exact-pinned, allowed to lag (0.75.3)
- Root npm `overrides` pins `pi-web-ui`'s nested `^0.75.x` pi-ai range onto the root version → the lockfile resolves **exactly one** pi-ai copy (one model registry — the original hazard the lockstep rule guarded against). The check now verifies this invariant directly.
- Runtime compat verified: every API `pi-web-ui@0.75.3` imports from pi-ai (`complete`, `streamSimple`, `getModel`, `getModels`, `getProviders`, `modelsAreEqual`, `StringEnum`) exists in 0.79.1; its pi-agent-core imports are type-only.

## Model UX changes

- `familyPriority`: Fable is the top Anthropic family (Fable → Opus → Sonnet → Haiku)
- Featured models: latest Fable first, then the existing Sonnet/Opus version rules
- Default model (Anthropic): latest Fable when its version ≥ both Opus and Sonnet (`claude-fable-5` → 50 vs `claude-opus-4-8` → 48), otherwise unchanged
- `parseMajorMinor` already handled `claude-fable-5` → 50 via the generic Claude regex (comment + tests added)

## Required collateral from the 0.79.x bump

- pi-ai 0.79.x made `onDeviceCode` / `onSelect` **required** in `OAuthLoginCallbacks`. `provider-login.ts` now implements both: a non-blocking device-code dialog (copyable code; GitHub Copilot's 0.79.x flow moved the code from `onAuth` instructions — which we previously dropped on the floor — to `onDeviceCode`), and a button-based select dialog for future flows.
- `gpt-5.3-codex` moved off the `openai-codex` (ChatGPT) provider in 0.79.x; registry-pin test updated (still on `openai`).

## Verification

- `npm run check` ✓ (incl. new lockstep check), `npm run test:models` ✓ (38/38), `npm run test:context` ✓ (648/648), `npm run test:security` ✓ (46/46), `npm run test:recovery` ✓, `npm run build` ✓
- **Real API round-trip**: `completeSimple(getModel("anthropic", "claude-fable-5"), …, { reasoning: "xhigh" })` through the bundled pi-ai 0.79.1 driver → `stopReason: stop`, correct text reply
- **End-to-end in the taskpane** (dev server + real browser): footer defaults to "Claude Fable 5", model picker lists `claude-fable-5` first (current/featured) → `claude-opus-4-8` (featured) → rest deterministically sorted; sent a live chat message and got a streamed Fable 5 reply with usage/cost and 2%-of-1M context tracking. No console/page errors.
- In-Excel sideload verification not run: the manifest hardcodes `https://localhost:3000`, and port 3000 is currently occupied by an unrelated live demo process on this machine (avoiding interference per parallel-work constraints). The browser taskpane exercises the same code path minus Office.js.
