### PR TITLE
chore: prepare v0.9.4-pre

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This folder contains **current** docs that should match shipped behavior.
 ## Guides
 - [Install Pi for Excel](./install.md)
 - [Deploy hosted build on Vercel](./deploy-vercel.md)
-- [Release notes (`v0.9.3-pre`)](./release-notes/v0.9.3-pre.md)
+- [Release notes (`v0.9.4-pre`)](./release-notes/v0.9.4-pre.md)
 - [Release smoke test checklist](./release-smoke-test-checklist.md)
 - [Release smoke run logs](./release-smoke-runs/README.md)
 

--- a/docs/release-notes/v0.9.4-pre.md
+++ b/docs/release-notes/v0.9.4-pre.md
@@ -1,0 +1,49 @@
+# v0.9.4-pre release notes
+
+_Pre-release. Changes since `v0.9.3-pre`._
+
+## Highlights
+
+- **Claude Fable 5 support**
+  - `claude-fable-5` — Anthropic's new flagship (1M-token context window, adaptive thinking, `xhigh` effort) — is now available in the model picker for Anthropic users.
+  - Fable is the new top Anthropic family in picker ordering and featured models (latest Fable first, then the existing Sonnet/Opus rules).
+  - Default model selection prefers the latest Fable when its version is at least as new as Opus and Sonnet, so Anthropic-connected users get Fable 5 by default.
+
+- **Refreshed model registry (Pi stack `0.70.0` → `0.79.1`)**
+  - Pulled the latest model registry through `@earendil-works/pi-ai`. New models in this range include Claude Fable 5 and Claude Opus 4.8, plus updated registry metadata across the Anthropic, OpenAI, and Google providers.
+  - Note: `gpt-5.3-codex` moved off the ChatGPT (`openai-codex`) provider upstream; it remains available via the OpenAI API provider.
+
+- **OAuth login fixes**
+  - Device-code logins (GitHub Copilot) now show the verification code in a copyable dialog and open the verification page — previously the code was never displayed.
+  - Added support for selection prompts in OAuth flows (button-based dialog), required by the updated Pi auth surface.
+
+## Dependency and security notes
+
+- Pi packages migrated to the `@earendil-works` npm namespace (previously `@mariozechner`).
+- `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` are pinned together at `0.79.1`; `@earendil-works/pi-web-ui` stays at `0.75.3` (the newest published version — upstream stopped publishing it in lockstep).
+- A root npm override guarantees a **single shared `pi-ai` copy** (one model registry), so the model picker and the runtime always agree about available models. `npm run check:pi-lockstep` enforces this invariant.
+- No changes to the local proxy / bridge packages in this release.
+
+## Known quirk
+
+- Claude Fable 5 rejects requests with thinking explicitly disabled (`thinking.type: "disabled"`). The add-in's agent runtime omits the thinking parameter when the thinking level is "off" (the API then defaults to adaptive thinking), so every thinking level in the picker works. This matches upstream Pi behavior.
+
+## Verification
+
+- `npm run check` (incl. the new Pi dependency policy check)
+- `npm run test:models` (38/38)
+- `npm run test:context` (648/648)
+- `npm run test:security` (46/46)
+- `npm run test:recovery`
+- `npm run build`
+- Live API round-trip with `claude-fable-5` through the bundled `pi-ai` driver (real completion, adaptive thinking with `xhigh` effort).
+- Browser end-to-end against the dev-server taskpane: Fable 5 selected as default, listed first/featured in the model picker, and completed a live streamed chat turn with usage/cost and 1M-context tracking; no console or page errors.
+
+## Commit range reviewed
+
+Since `v0.9.3-pre`, this release incorporates:
+
+- `fffefb1` — migrate Pi packages to the `@earendil-works` namespace (#542).
+- `80671a0` — fix overlapping Dependabot npm config (#544).
+- `599fd9e` — refresh Pi stack to `0.75.3` (#559).
+- `b9e0dbf` — add Claude Fable 5 model support, Pi stack `0.79.1`, dependency single-registry policy, OAuth device-code/select dialogs (#563).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.3-pre",
+  "version": "0.9.4-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-for-excel",
-      "version": "0.9.3-pre",
+      "version": "0.9.4-pre",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.3-pre",
+  "version": "0.9.4-pre",
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -5,4 +5,4 @@
  */
 
 export const APP_NAME = "pi-for-excel";
-export const APP_VERSION = "0.9.3-pre";
+export const APP_VERSION = "0.9.4-pre";


### PR DESCRIPTION
Release prep for **v0.9.4-pre**, following the v0.9.3-pre convention (#535):

- Bump version to `0.9.4-pre` in `package.json`, `package-lock.json`, and `src/app/metadata.ts` (`APP_VERSION`)
- Add `docs/release-notes/v0.9.4-pre.md` (Claude Fable 5, Pi stack 0.79.1 + single-registry policy, OAuth device-code/select fixes, known Fable thinking-disabled quirk, verification summary)
- Point `docs/README.md` at the new notes

After merge: tag `v0.9.4-pre` and publish the GitHub pre-release with these notes. No npm publish needed — the app ships via the Vercel production deploy (already serving the Fable build), and `pkg/proxy` is unchanged this release.

Verification: `npm run check` ✓, `npm run test:models` 38/38 ✓ on the bumped tree.