### PR TITLE
Prepare v0.9.5-pre

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This folder contains **current** docs that should match shipped behavior.
 ## Guides
 - [Install Pi for Excel](./install.md)
 - [Deploy hosted build on Vercel](./deploy-vercel.md)
-- [Release notes (`v0.9.4-pre`)](./release-notes/v0.9.4-pre.md)
+- [Release notes (`v0.9.5-pre`)](./release-notes/v0.9.5-pre.md)
 - [Release smoke test checklist](./release-smoke-test-checklist.md)
 - [Release smoke run logs](./release-smoke-runs/README.md)
 

--- a/docs/release-notes/v0.9.5-pre.md
+++ b/docs/release-notes/v0.9.5-pre.md
@@ -1,0 +1,37 @@
+# v0.9.5-pre release notes
+
+_Pre-release. Changes since `v0.9.4-pre`._
+
+## Highlights
+
+- **Anthropic default restored to Opus**
+  - Anthropic-only setups now default to the latest Opus (`claude-opus-4-8`) instead of `claude-fable-5`, because Fable is present in the registry but currently unavailable for normal Anthropic use.
+  - Sonnet and Fable remain fallback candidates if Opus is absent.
+  - The model picker can still surface Fable in its featured ordering; this release only changes default selection.
+
+- **Small-context model resilience**
+  - Added graceful handling for context-overflow cases with small-context-window models, so failures are surfaced more cleanly instead of derailing the session path.
+
+- **CI/dependency maintenance**
+  - Upgraded Vite to `8.0.16`, clearing the high-severity esbuild audit finding reported by CI.
+  - Added a manifest-validation wrapper that retries Microsoft validation service 5xx/unreachable responses and soft-passes only repeated service outages; actual manifest validation errors still fail.
+  - Incorporated routine dependency maintenance from Dependabot.
+
+## Verification
+
+- `npm run validate` (Microsoft validation service returned 502 locally; wrapper retried and soft-passed as external outage)
+- `npm audit --audit-level=high`
+- `npm run test:models`
+- `npm run check`
+- `npm run build`
+
+## Commit range reviewed
+
+Since `v0.9.4-pre`, this release incorporates:
+
+- `1ddb213` — fix(proxy): keep our CORS headers when copying upstream response headers (#555).
+- `6c6406f` — chore(deps): bump hono from 4.12.18 to 4.12.25 (#564).
+- `45f0fda` — chore(deps): bump actions/dependency-review-action from 4 to 5 (#548).
+- `6495a1a` — chore(deps): bump the npm-minor-and-patch group across 1 directory with 7 updates (#561).
+- `c57a736` — graceful context-overflow handling for small-context-window models (#567).
+- `b9d2722` — default Anthropic model selection to Opus (#576).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.4-pre",
+  "version": "0.9.5-pre",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-for-excel",
-      "version": "0.9.4-pre",
+      "version": "0.9.5-pre",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.104.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-for-excel",
-  "version": "0.9.4-pre",
+  "version": "0.9.5-pre",
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -5,4 +5,4 @@
  */
 
 export const APP_NAME = "pi-for-excel";
-export const APP_VERSION = "0.9.4-pre";
+export const APP_VERSION = "0.9.5-pre";


### PR DESCRIPTION
## Summary
- Bump package/runtime version from 0.9.4-pre to 0.9.5-pre
- Add v0.9.5-pre release notes covering the Opus default restoration, small-context overflow handling, and CI/dependency maintenance
- Update docs index to point at the new release notes

## Verification
- npm run check
- npm run validate (Microsoft validation service returned 502; wrapper retried and soft-passed as external outage)