### PR TITLE
docs + deps: fix Windows sideload instructions (#585), declare mini-lit directly (#580)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,18 @@ cp manifest.xml ~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/
 ```
 Then open Excel → **Insert** → **My Add-ins** → **Pi for Excel**.
 
-**Windows** ([Microsoft docs](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing)):
+**Windows** ([Microsoft docs](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins)):
 
-Open Excel → **Insert** → **My Add-ins** → **Upload My Add-in** → select `manifest.xml`.
+Windows desktop Excel can't upload a manifest directly — it installs from a trusted shared-folder catalog:
+
+1. Share a local folder (folder **Properties** → **Sharing** → **Share**) and note its network path.
+2. In Excel: **File** → **Options** → **Trust Center** → **Trust Center Settings** → **Trusted Add-in Catalogs** → add the network path as **Catalog Url**, tick **Show in Menu**, restart Excel.
+3. Copy `manifest.xml` into the shared folder.
+4. **Home** → **Add-ins** → **Advanced** → **SHARED FOLDER** → **Pi for Excel**.
+
+**Excel on the web** ([Microsoft docs](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing)):
+
+**Home** → **Add-ins** → **More Settings** → **Upload My Add-in** → select `manifest.xml`.
 
 The dev manifest points to `https://localhost:3000`. The production manifest (`manifest.prod.xml`) points to the hosted Vercel deployment.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@earendil-works/pi-agent-core": "0.80.3",
         "@earendil-works/pi-ai": "0.80.3",
         "@earendil-works/pi-web-ui": "0.75.3",
+        "@mariozechner/mini-lit": "^0.2.0",
         "@sinclair/typebox": "^0.34.49",
         "lit": "^3.3.3",
         "marked": "^18.0.5"
@@ -2472,7 +2473,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/mini-lit/-/mini-lit-0.2.1.tgz",
       "integrity": "sha512-u300euLgCsDDlb8o2Wbz+55eSJga5X2vB58s9XBuFIr2Bi3iI+GMR7t/NYo/O6Vr6obXShXgYjR3SRUJVgo+kQ==",
-      "peer": true,
       "dependencies": {
         "@preact/signals-core": "^1.12.1",
         "class-variance-authority": "^0.7.1",
@@ -2495,7 +2495,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
       "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3771,7 +3770,6 @@
       "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
       "integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -4640,7 +4638,6 @@
       "resolved": "https://registry.npmjs.org/@webreflection/alien-signals/-/alien-signals-0.3.2.tgz",
       "integrity": "sha512-DmNjD8Kq5iM+Toirp3llS/izAiI3Dwav5nHRvKdR/YJBTgun3y4xK76rs9CFYD2bZwZJN/rP+HjEqKTteGK+Yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "alien-signals": "^2.0.6"
       }
@@ -4778,8 +4775,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.8.tgz",
       "integrity": "sha512-844G1VLkk0Pe2SJjY0J8vp8ADI73IM4KliNu2OGlYzWpO28NexEUvjHTcFjFX3VXoiUtwTbHxLNI9ImkcoBqzA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -5281,7 +5277,6 @@
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.1.1"
       },
@@ -5397,7 +5392,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5439,7 +5433,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -5857,7 +5850,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
       "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -7131,7 +7123,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -7159,8 +7150,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/html-parse-string/-/html-parse-string-0.0.9.tgz",
       "integrity": "sha512-wyGnsOolHbNrcb8N6bdJF4EHyzd3zVGCb9/mBxeNjAYBDOZqD7YkqLBz7kXtdgHwNnV8lN/BpSDpsI1zm8Sd8g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -7790,7 +7780,6 @@
         "https://github.com/sponsors/katex"
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -10978,7 +10967,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
       "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -10989,7 +10977,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-3.2.2.tgz",
       "integrity": "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.x",
         "pnpm": ">=7.x"
@@ -11349,7 +11336,6 @@
       "resolved": "https://registry.npmjs.org/uhtml/-/uhtml-5.0.9.tgz",
       "integrity": "sha512-qPyu3vGilaLe6zrjOCD/xezWEHLwdevxmbY3hzyhT25KBDF4F7YYW3YZcL3kylD/6dMoVISHjn8ggV3+9FY+5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webreflection/alien-signals": "^0.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@earendil-works/pi-agent-core": "0.80.3",
     "@earendil-works/pi-ai": "0.80.3",
     "@earendil-works/pi-web-ui": "0.75.3",
+    "@mariozechner/mini-lit": "^0.2.0",
     "@sinclair/typebox": "^0.34.49",
     "lit": "^3.3.3",
     "marked": "^18.0.5"


### PR DESCRIPTION
Two small hygiene fixes:

- **README Windows sideload (#585):** the Windows section linked the Office-on-the-web page and described its *Upload My Add-in* flow, which doesn't exist in Windows desktop Excel. Now links the network-shared-folder catalog docs and describes the real desktop flow, with Excel on the web kept as its own entry. Thanks @fnsii for the catch.
- **Direct mini-lit dependency (#580):** `@mariozechner/mini-lit` is imported directly by eight modules but was only available transitively via pi-web-ui. Declared with the same `^0.2.0` range so npm dedupes to one copy (`npm ls` verified single instance).

Verification: `npm run check` and `npm run build` green.

Fixes #585
Fixes #580