### PR TITLE
chore: migrate to TypeScript 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "marked": "^18.0.5"
       },
       "devDependencies": {
+        "@types/node": "^22.20.0",
         "@types/office-js": "^1.0.598",
         "eslint": "^10.6.0",
         "office-addin-debugging": "^6.0.6",
@@ -1635,6 +1636,17 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@inquirer/editor": {
@@ -4316,9 +4328,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.31.tgz",
-      "integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "office-addin-debugging": "^6.0.6",
         "office-addin-manifest": "^2.1.2",
         "typebox": "^1.3.3",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
         "vite": "^8.1.3"
       },
@@ -11279,9 +11279,9 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "office-addin-debugging": "^6.0.6",
     "office-addin-manifest": "^2.1.2",
     "typebox": "^1.3.3",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",
     "vite": "^8.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "marked": "^18.0.5"
   },
   "devDependencies": {
+    "@types/node": "^22.20.0",
     "@types/office-js": "^1.0.598",
     "eslint": "^10.6.0",
     "office-addin-debugging": "^6.0.6",

--- a/src/ui/proxy-banner.ts
+++ b/src/ui/proxy-banner.ts
@@ -127,7 +127,9 @@ export function createProxyBanner(): ProxyBannerHandle {
   details.append(detailsIntro, codeRow, hint, guideLink);
 
   action.addEventListener("click", () => {
-    const shouldOpen = details.hidden;
+    // TS6 DOM lib types `hidden` as `boolean | "until-found"`; we only ever
+    // assign booleans here, so coerce for classList.toggle.
+    const shouldOpen = details.hidden === true;
     details.hidden = !shouldOpen;
     root.classList.toggle("is-open", shouldOpen);
     action.textContent = shouldOpen ? "Hide steps" : "How to fix →";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,10 +16,13 @@
     "declaration": false,
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": ".",
+    // TypeScript 6.0 changed the `types` default from "everything under
+    // node_modules/@types" to []. Globals-only packages must be listed
+    // explicitly (module imports like node:assert still resolve on their own).
+    "types": ["office-js", "node"],
     "paths": {
-      "@/*": ["src/*"],
-      "@earendil-works/pi-web-ui/dist/*": ["node_modules/@earendil-works/pi-web-ui/dist/*"]
+      "@/*": ["./src/*"],
+      "@earendil-works/pi-web-ui/dist/*": ["./node_modules/@earendil-works/pi-web-ui/dist/*"]
     }
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
Supersedes #569 (Dependabot), which failed because TS 6.0 is a breaking release needing real migration:

- **tsconfig:** drop deprecated `baseUrl` (slated for removal in TS7); make `paths` tsconfig-relative
- **tsconfig:** set `types: ["office-js", "node"]` explicitly — TS 6.0 [changed the default](https://github.com/microsoft/TypeScript/issues/62508) from *everything under node_modules/@types* to `[]`. Globals-only packages (Excel/Office namespaces; node globals used by tests + vite config through the eslint projectService default project) must now be listed. This was also the cause of the 4,156 typed-lint errors on the Dependabot branch.
- **deps:** add `@types/node` ^22 as a direct devDependency (matches CI's node 22) — previously only transitively available
- **src fix:** TS6's DOM lib types `hidden` as `boolean | "until-found"`; coerce in proxy-banner before `classList.toggle`

Verification: `npm run check` (lint 0 errors, typecheck clean), `build`, `test:context` 665, `test:models` 47, `test:security` 47, `validate` — all green.

Closes #569