### PR TITLE
chore: move default dev port 3000 → 3141 (π) to dodge port collisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Available gallery sections (use as argument):
 
 Or use agent-browser directly for interactive inspection:
 ```bash
-npx agent-browser --session pi-ui open http://localhost:3000/src/ui-gallery.html
+npx agent-browser --session pi-ui open http://localhost:3141/src/ui-gallery.html
 npx agent-browser --session pi-ui wait 2000
 npx agent-browser --session pi-ui snapshot -i          # See interactive elements
 npx agent-browser --session pi-ui screenshot shot.png  # Capture
@@ -98,7 +98,7 @@ npx agent-browser --session pi-ui close                # Clean up
 
 For **full taskpane** inspection (boots without Excel after 3s timeout):
 ```bash
-npx agent-browser open http://localhost:3000/src/taskpane.html
+npx agent-browser open http://localhost:3141/src/taskpane.html
 npx agent-browser wait 4000           # Wait for Office.js fallback
 npx agent-browser snapshot -i -c      # Interactive snapshot
 npx agent-browser console --json      # Check for JS errors
@@ -119,7 +119,7 @@ Excel loads a sideloaded manifest from:
 `~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/{add-in-id}.manifest.xml`
 
 If local changes do not show up:
-1. Verify sideloaded manifest points to `https://localhost:3000/...` (not production URL).
+1. Verify sideloaded manifest points to `https://localhost:3141/...` (not production URL).
 2. Recopy manifest:
    `cp manifest.xml ~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/a1b2c3d4-e5f6-7890-abcd-ef1234567890.manifest.xml`
 3. Quit Excel fully and reopen.

--- a/README.md
+++ b/README.md
@@ -90,8 +90,12 @@ mv localhost.pem cert.pem
 ### Run
 
 ```bash
-npm run dev        # Vite dev server on https://localhost:3000
+npm run dev        # Vite dev server on https://localhost:3141
 ```
+
+> **Note:** the dev port is `3141` (π) — deliberately off the crowded `:3000`.
+> If you sideloaded a manifest before the move from `:3000`, re-copy
+> `manifest.xml` into Excel's `wef` folder and fully restart Excel.
 
 > **Optional:** prefer a stable named URL (`https://pi-excel.localhost`, no mkcert, no fixed port)? See [docs/portless.md](./docs/portless.md) for the opt-in [portless](https://portless.sh) flow.
 
@@ -116,13 +120,13 @@ Windows desktop Excel can't upload a manifest directly — it installs from a tr
 
 **Home** → **Add-ins** → **More Settings** → **Upload My Add-in** → select `manifest.xml`.
 
-The dev manifest points to `https://localhost:3000`. The production manifest (`manifest.prod.xml`) points to the hosted Vercel deployment.
+The dev manifest points to `https://localhost:3141`. The production manifest (`manifest.prod.xml`) points to the hosted Vercel deployment.
 
 ### Useful commands
 
 | Command | Description |
 |---|---|
-| `npm run dev` | Start Vite dev server (port 3000, HTTPS) |
+| `npm run dev` | Start Vite dev server (port 3141, HTTPS) |
 | `npm run dev:portless` | Opt-in: dev server behind portless — [docs/portless.md](./docs/portless.md) |
 | `npm run build` | Production build → `dist/` |
 | `npm run check` | Lint + typecheck + CSS theme checks |

--- a/docs/deploy-vercel.md
+++ b/docs/deploy-vercel.md
@@ -43,7 +43,7 @@ Keep this URL stable; it becomes the base URL used by `manifest.prod.xml`.
 
 ## Generate / update the production manifest
 
-The dev manifest (`manifest.xml`) points at `https://localhost:3000`.
+The dev manifest (`manifest.xml`) points at `https://localhost:3141`.
 
 Generate the production manifest with the hosted base URL:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -167,7 +167,7 @@ Quick proxy sanity check (advanced):
 
 ```bash
 curl -k -i -s \
-  'https://localhost:3000/api-proxy/google-cloudcode/v1internal:streamGenerateContent?alt=sse' \
+  'https://localhost:3141/api-proxy/google-cloudcode/v1internal:streamGenerateContent?alt=sse' \
   -X POST -H 'content-type: application/json' -d '{}' | head
 ```
 

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -144,27 +144,29 @@ Reminder: **`openai-codex` is NOT `openai`** (different base URL). See `src/auth
 
 **Important:** our `manifest.xml` currently points at the **dev server**:
 
-- `https://localhost:3000/src/taskpane.html`
+- `https://localhost:3141/src/taskpane.html`
 
 That means:
 - `npm run build` is a *sanity check* (TypeScript + bundling), but it does **not** change what Excel loads.
-- To test changes in Excel, you need a dev server running on **port 3000**.
+- To test changes in Excel, you need a dev server running on **port 3141**.
 
 Recommended local loop:
 
 ```bash
-# 1) Start dev server (must be :3000 because manifest hardcodes it)
+# 1) Start dev server (must be :3141 because manifest hardcodes it)
 npm run dev
 
 # 2) (Re)register / launch Excel with the add-in
 npm run sideload
 ```
 
-If `npm run dev` says “Port 3000 is in use, trying another one…”, **stop the old server**.
-Excel will keep loading whatever is on `https://localhost:3000/`.
+If `npm run dev` fails with “Port 3141 is already in use” (the config sets
+`strictPort`, so Vite exits rather than silently picking another port),
+**stop the old server** — Excel will keep loading whatever is on
+`https://localhost:3141/`.
 
 ```bash
-lsof -nP -iTCP:3000 -sTCP:LISTEN
+lsof -nP -iTCP:3141 -sTCP:LISTEN
 # then kill the PID, or just stop the process in the terminal running it
 ```
 

--- a/docs/portless.md
+++ b/docs/portless.md
@@ -1,7 +1,7 @@
 # Dev server behind portless (opt-in)
 
 **Status:** opt-in recipe. The default dev flow (`npm run dev` on
-`https://localhost:3000` with mkcert certs) is unchanged and remains what the
+`https://localhost:3141` with mkcert certs) is unchanged and remains what the
 manifest, sideload docs, and CI assume. Use this page only if you want the
 [portless](https://portless.sh) flavor: a stable named URL
 (`https://pi-excel.localhost`) with no mkcert step and no fixed port.
@@ -50,7 +50,7 @@ How the Vite side switches over (see `vite.config.ts`):
 
 ## Sideload manifest
 
-`manifest.xml` stays pinned to `https://localhost:3000`. Generate a
+`manifest.xml` stays pinned to `https://localhost:3141`. Generate a
 dev-proxy manifest instead (never committed; it's gitignored):
 
 ```bash
@@ -67,21 +67,21 @@ cp manifest.dev.xml ~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/
 ```
 
 Note: the add-in Id is unchanged, so the dev-proxy manifest **replaces** the
-default `localhost:3000` sideload — you run one or the other, not both. To
+default `localhost:3141` sideload — you run one or the other, not both. To
 switch back, sideload `manifest.xml` again.
 
 ## Bridge / proxy servers (deliberate opt-in)
 
 The local CORS proxy and tmux/python bridges enforce strict origin
-allowlists pinned to `https://localhost:3000` (plus the hosted origin). The
+allowlists pinned to `https://localhost:3141` (plus the hosted origin). The
 portless origin is **deliberately not added by default** — extend the
 allowlist explicitly via the existing `ALLOWED_ORIGINS` env var when you run
 them:
 
 ```bash
-ALLOWED_ORIGINS="https://localhost:3000,https://pi-for-excel.vercel.app,https://pi-excel.localhost" npm run proxy:https
-ALLOWED_ORIGINS="https://localhost:3000,https://pi-for-excel.vercel.app,https://pi-excel.localhost" npm run tmux:bridge:https
-ALLOWED_ORIGINS="https://localhost:3000,https://pi-for-excel.vercel.app,https://pi-excel.localhost" npm run python:bridge:https
+ALLOWED_ORIGINS="https://localhost:3141,https://pi-for-excel.vercel.app,https://pi-excel.localhost" npm run proxy:https
+ALLOWED_ORIGINS="https://localhost:3141,https://pi-for-excel.vercel.app,https://pi-excel.localhost" npm run tmux:bridge:https
+ALLOWED_ORIGINS="https://localhost:3141,https://pi-for-excel.vercel.app,https://pi-excel.localhost" npm run python:bridge:https
 ```
 
 Note `ALLOWED_ORIGINS` **replaces** the default list, so include every origin

--- a/docs/release-smoke-test-checklist.md
+++ b/docs/release-smoke-test-checklist.md
@@ -24,7 +24,7 @@ This checklist maps directly to issue [#179](https://github.com/tmustier/pi-for-
 ## Prerequisites
 
 - Built from latest `origin/main`
-- Excel add-in sideloaded from `https://localhost:3000`
+- Excel add-in sideloaded from `https://localhost:3141`
 - `npm ci`
 - Local cert trusted (`mkcert` flow)
 - Optional local bridges available when testing power-user paths:

--- a/manifest.xml
+++ b/manifest.xml
@@ -12,8 +12,8 @@
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Pi for Excel" />
   <Description DefaultValue="Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi." />
-  <IconUrl DefaultValue="https://localhost:3000/assets/icon-32.png" />
-  <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-80.png" />
+  <IconUrl DefaultValue="https://localhost:3141/assets/icon-32.png" />
+  <HighResolutionIconUrl DefaultValue="https://localhost:3141/assets/icon-80.png" />
   <SupportUrl DefaultValue="https://github.com/tmustier/pi-for-excel/issues/new/choose" />
 
   <Hosts>
@@ -21,7 +21,7 @@
   </Hosts>
 
   <DefaultSettings>
-    <SourceLocation DefaultValue="https://localhost:3000/src/taskpane.html" />
+    <SourceLocation DefaultValue="https://localhost:3141/src/taskpane.html" />
   </DefaultSettings>
 
   <Permissions>ReadWriteDocument</Permissions>
@@ -64,12 +64,12 @@
 
     <Resources>
       <bt:Images>
-        <bt:Image id="Icon16" DefaultValue="https://localhost:3000/assets/icon-16.png" />
-        <bt:Image id="Icon32" DefaultValue="https://localhost:3000/assets/icon-32.png" />
-        <bt:Image id="Icon80" DefaultValue="https://localhost:3000/assets/icon-80.png" />
+        <bt:Image id="Icon16" DefaultValue="https://localhost:3141/assets/icon-16.png" />
+        <bt:Image id="Icon32" DefaultValue="https://localhost:3141/assets/icon-32.png" />
+        <bt:Image id="Icon80" DefaultValue="https://localhost:3141/assets/icon-80.png" />
       </bt:Images>
       <bt:Urls>
-        <bt:Url id="TaskpaneUrl" DefaultValue="https://localhost:3000/src/taskpane.html" />
+        <bt:Url id="TaskpaneUrl" DefaultValue="https://localhost:3141/src/taskpane.html" />
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GroupLabel" DefaultValue="Pi" />

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Open-source, multi-model AI sidebar add-in for Excel. Powered by Pi.",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 3000",
+    "dev": "vite --port 3141",
     "dev:portless": "portless pi-excel vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/public/architecture/index.html
+++ b/public/architecture/index.html
@@ -2826,7 +2826,7 @@
       </div>
       <div class="spec-row">
         <div class="spec-key">Manifest</div>
-        <div class="spec-val">Office TaskPaneApp, ReadWriteDocument permission, Home ribbon button. Dev = localhost:3000, prod = Vercel</div>
+        <div class="spec-val">Office TaskPaneApp, ReadWriteDocument permission, Home ribbon button. Dev = localhost:3141, prod = Vercel</div>
       </div>
       <div class="spec-row">
         <div class="spec-key">Pre-commit</div>

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -88,7 +88,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 // a browser tab on any origin can still call it unless we restrict CORS.
 // Default allowlist matches our dev + hosted origins; override via env var.
 const DEFAULT_ALLOWED_ORIGINS = new Set([
-  "https://localhost:3000",
+  "https://localhost:3141",
   "https://pi-for-excel.vercel.app",
 ]);
 

--- a/scripts/generate-dev-manifest.mjs
+++ b/scripts/generate-dev-manifest.mjs
@@ -9,21 +9,21 @@
  *   npm run manifest:dev -- my-addin.localhost    # custom hostname
  *   DEV_HOST=pi-excel.localhost node scripts/generate-dev-manifest.mjs
  *
- * Replaces the default dev base URL (https://localhost:3000) in manifest.xml
+ * Replaces the default dev base URL (https://localhost:3141) in manifest.xml
  * with the proxy origin and writes manifest.dev.xml (fixed output path).
  * manifest.xml itself stays untouched and nothing is published to public/.
  *
  * Notes:
  * - Office add-ins require HTTPS, so the proxy origin is always https://.
  * - The add-in Id is unchanged: sideloading manifest.dev.xml replaces the
- *   default localhost:3000 sideload (they are the same add-in to Excel).
+ *   default localhost:3141 sideload (they are the same add-in to Excel).
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-export const DEV_BASE_URL = "https://localhost:3000";
+export const DEV_BASE_URL = "https://localhost:3141";
 export const DEFAULT_DEV_PROXY_HOST = "pi-excel.localhost";
 
 /**

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -7,7 +7,7 @@
  *   ADDIN_BASE_URL="https://pi-for-excel.vercel.app" node scripts/generate-manifest.mjs
  *   ADDIN_BASE_URL="https://pi-for-excel.example.com" OUT=manifest.prod.xml node scripts/generate-manifest.mjs
  *
- * Replaces all occurrences of the dev base URL (https://localhost:3000) with ADDIN_BASE_URL.
+ * Replaces all occurrences of the dev base URL (https://localhost:3141) with ADDIN_BASE_URL.
  *
  * Notes:
  * - Office add-ins require HTTPS.
@@ -17,7 +17,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const DEV_BASE_URL = "https://localhost:3000";
+const DEV_BASE_URL = "https://localhost:3141";
 
 function fail(msg) {
   console.error(`[pi-for-excel] ${msg}`);

--- a/scripts/python-bridge-server.mjs
+++ b/scripts/python-bridge-server.mjs
@@ -61,7 +61,7 @@ const keyPath = resolveOptionalEnvPath("PI_FOR_EXCEL_KEY_PATH") ?? path.join(cer
 const certPath = resolveOptionalEnvPath("PI_FOR_EXCEL_CERT_PATH") ?? path.join(certDir, "cert.pem");
 
 const DEFAULT_ALLOWED_ORIGINS = new Set([
-  "https://localhost:3000",
+  "https://localhost:3141",
   "https://pi-for-excel.vercel.app",
 ]);
 

--- a/scripts/serve-dist-https.mjs
+++ b/scripts/serve-dist-https.mjs
@@ -16,7 +16,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const HOST = process.env.HOST || "localhost";
-const PORT = Number.parseInt(process.env.PORT || "3000", 10);
+const PORT = Number.parseInt(process.env.PORT || "3141", 10);
 
 const rootDir = path.resolve(process.cwd());
 const distDir = path.join(rootDir, "dist");

--- a/scripts/tmux-bridge-server.mjs
+++ b/scripts/tmux-bridge-server.mjs
@@ -55,7 +55,7 @@ const keyPath = resolveOptionalEnvPath("PI_FOR_EXCEL_KEY_PATH") ?? path.join(cer
 const certPath = resolveOptionalEnvPath("PI_FOR_EXCEL_CERT_PATH") ?? path.join(certDir, "cert.pem");
 
 const DEFAULT_ALLOWED_ORIGINS = new Set([
-  "https://localhost:3000",
+  "https://localhost:3141",
   "https://pi-for-excel.vercel.app",
 ]);
 

--- a/scripts/ui-verify.sh
+++ b/scripts/ui-verify.sh
@@ -14,7 +14,7 @@
 #
 # Prerequisites:
 #   - agent-browser CLI installed
-#   - npm run dev running on port 3000 (script starts it if needed)
+#   - npm run dev running on port 3141 (script starts it if needed)
 #
 set -euo pipefail
 
@@ -35,8 +35,8 @@ if [[ "$SCHEME" == "https" ]]; then
   BROWSER_FLAGS="--ignore-https-errors"
 fi
 
-GALLERY_URL="${SCHEME}://localhost:3000/src/ui-gallery.html"
-TASKPANE_URL="${SCHEME}://localhost:3000/src/taskpane.html"
+GALLERY_URL="${SCHEME}://localhost:3141/src/ui-gallery.html"
+TASKPANE_URL="${SCHEME}://localhost:3141/src/taskpane.html"
 SESSION_NAME="pi-ui-verify"
 SCREENSHOT_DIR="/tmp/pi-ui-verify"
 DEV_PID_FILE="$SCREENSHOT_DIR/dev.pid"
@@ -45,11 +45,11 @@ mkdir -p "$SCREENSHOT_DIR"
 
 # Start dev server if not running
 ensure_dev_server() {
-  if lsof -nP -iTCP:3000 -sTCP:LISTEN &>/dev/null; then
+  if lsof -nP -iTCP:3141 -sTCP:LISTEN &>/dev/null; then
     return 0
   fi
 
-  echo "Starting dev server on port 3000..."
+  echo "Starting dev server on port 3141..."
   cd "$(dirname "$0")/.."
   npm run dev &>/dev/null &
   DEV_PID=$!
@@ -57,7 +57,7 @@ ensure_dev_server() {
 
   # Wait for server
   for i in $(seq 1 30); do
-    if lsof -nP -iTCP:3000 -sTCP:LISTEN &>/dev/null; then
+    if lsof -nP -iTCP:3141 -sTCP:LISTEN &>/dev/null; then
       echo "Dev server ready (pid $DEV_PID)"
       return 0
     fi

--- a/src/ui-gallery.ts
+++ b/src/ui-gallery.ts
@@ -4,7 +4,7 @@
  * No Office.js dependency. Loads the same CSS as the real taskpane and
  * renders mock components for agent-browser screenshot verification.
  *
- * Access at: http://localhost:3000/src/ui-gallery.html
+ * Access at: http://localhost:3141/src/ui-gallery.html
  *
  * Each section has a data-gallery attribute for targeted screenshots:
  *   agent-browser screenshot --selector '[data-gallery="tool-cards"]'

--- a/tests/cors-proxy-server.security.test.mjs
+++ b/tests/cors-proxy-server.security.test.mjs
@@ -6,7 +6,7 @@ import http from "node:http";
 import net from "node:net";
 import { setTimeout as delay } from "node:timers/promises";
 
-const ORIGIN = "https://localhost:3000";
+const ORIGIN = "https://localhost:3141";
 const PROXY_SCRIPT_PATH = new URL("../scripts/cors-proxy-server.mjs", import.meta.url).pathname;
 
 async function getFreePort() {

--- a/tests/generate-dev-manifest.test.mjs
+++ b/tests/generate-dev-manifest.test.mjs
@@ -75,7 +75,13 @@ test("rejects unparseable input", () => {
 });
 
 test("rejects the default dev URL itself", () => {
-  assert.throws(() => resolveDevOrigin({ arg: "localhost:3000" }), /already the default/);
+  assert.throws(() => resolveDevOrigin({ arg: "localhost:3141" }), /already the default/);
+});
+
+test("accepts the retired :3000 default as a custom origin", () => {
+  // The dev default moved from :3000 to :3141; the old port is now just
+  // another custom origin.
+  assert.equal(resolveDevOrigin({ arg: "https://localhost:3000" }).origin, "https://localhost:3000");
 });
 
 // ── renderDevManifest ───────────────────────────────────────────────────────

--- a/tests/python-bridge-server.test.mjs
+++ b/tests/python-bridge-server.test.mjs
@@ -5,7 +5,7 @@ import net from "node:net";
 import { once } from "node:events";
 import { setTimeout as delay } from "node:timers/promises";
 
-const ORIGIN = "https://localhost:3000";
+const ORIGIN = "https://localhost:3141";
 const BRIDGE_SCRIPT_PATH = new URL("../scripts/python-bridge-server.mjs", import.meta.url).pathname;
 
 async function getFreePort() {

--- a/tests/tmux-bridge-server.test.mjs
+++ b/tests/tmux-bridge-server.test.mjs
@@ -5,7 +5,7 @@ import net from "node:net";
 import { once } from "node:events";
 import { setTimeout as delay } from "node:timers/promises";
 
-const ORIGIN = "https://localhost:3000";
+const ORIGIN = "https://localhost:3141";
 const BRIDGE_SCRIPT_PATH = new URL("../scripts/tmux-bridge-server.mjs", import.meta.url).pathname;
 
 function hasTmuxBinary() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -219,7 +219,7 @@ function buildBrowserAliases(): { find: string | RegExp; replacement: string }[]
  *
  * Opt-in only: set DEV_HOST=<hostname> explicitly, or run via
  * `npm run dev:portless` (portless injects PORTLESS_URL into the child
- * process). With neither set, the default https://localhost:3000 behavior
+ * process). With neither set, the default https://localhost:3141 behavior
  * is unchanged.
  */
 interface DevProxyConfig {
@@ -236,7 +236,7 @@ function resolveDevProxy(): DevProxyConfig | null {
 
   // Same strict validation as scripts/generate-dev-manifest.mjs (shared
   // helper): https-only bare origin, no credentials/path/query/hash, and
-  // never the default https://localhost:3000. Invalid values fail loud
+  // never the default https://localhost:3141. Invalid values fail loud
   // instead of silently activating (or silently skipping) proxy mode.
   const resolved = resolveDevOrigin({
     env: { DEV_HOST: devHost, PORTLESS_URL: portlessUrl },
@@ -251,7 +251,7 @@ function resolveDevProxy(): DevProxyConfig | null {
 /** Behind the proxy the port comes from PORT (portless-assigned); CLI --port wins over this either way. */
 function parseDevServerPort(raw: string | undefined): number {
   const parsed = Number.parseInt(raw ?? "", 10);
-  return Number.isInteger(parsed) && parsed > 0 && parsed < 65536 ? parsed : 3000;
+  return Number.isInteger(parsed) && parsed > 0 && parsed < 65536 ? parsed : 3141;
 }
 
 // ============================================================================
@@ -292,11 +292,11 @@ export default defineConfig({
           },
         }
       : {
-          // Must stay on :3000 because manifest hardcodes it.
+          // Must stay on :3141 because manifest hardcodes it.
           // Bind IPv6 too: Excel's webview may resolve localhost → ::1 and fail if we only listen on 127.0.0.1.
           host: "::",
           strictPort: true,
-          port: 3000,
+          port: 3141,
           https: hasHttpsCerts
             ? { key: fs.readFileSync(keyPath), cert: fs.readFileSync(certPath) }
             : undefined,


### PR DESCRIPTION
Follow-on from the portless discussion: portless stays opt-in (Node ≥ 24, unproven in-host, extra proxy in the trust path), but the default port moves off the crowded `:3000` so stale Next.js/CRA/Rails processes can't silently break the sideloaded add-in.

**Why a fixed port at all:** the Office manifest hardcodes the origin, so per-run random ports can't work. `3141` (π) is memorable and rarely squatted.

**Changes**
- `package.json` dev script + `vite.config.ts`: `--port 3141`, `strictPort` kept (fails loud on collision)
- `manifest.xml` + manifest generators: `DEV_BASE_URL` → `https://localhost:3141`; portless guard now rejects `:3141` as default and accepts `:3000` as a custom origin (regression test added)
- Bridge/proxy default origin allowlists (**cors-proxy, tmux-bridge, python-bridge**): `:3000` **replaced**, not appended — the vacated origin stays un-allowlisted
- `ui-verify.sh`, ui-gallery, docs, README migration note; fixed stale strictPort wording in `docs/model-updates.md`

**Verification**
- `npm run check` / `npm run build` ✅
- `test:security` 83/83, `test:manifest` 16/16 (incl. new test), `test:context` 665/665 ✅
- Live boot: vite serves `https://localhost:3141/src/taskpane.html` → HTTP 200 ✅ (this run also caught the `--port 3000` CLI flag in package.json that grep missed)

**Migration:** re-copy `manifest.xml` into Excel's `wef` folder + full Excel restart.