### PR TITLE
fix(proxy): fall back to random port when default is busy

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The dev manifest points to `https://localhost:3141`. The production manifest (`m
 | `npm run test:models` | Unit tests — model ordering |
 | `npm run test:context` | Unit tests — tools, context, sessions, extensions, integrations |
 | `npm run test:security` | Security policy tests — proxy, CORS, sandbox, OAuth |
-| `npm run proxy:https` | CORS proxy for OAuth flows (default `https://localhost:3003`) |
+| `npm run proxy:https` | CORS proxy for OAuth flows (default `https://localhost:3003`; auto-picks a random free port if the default is busy) |
 | `npm run validate` | Validate the Office add-in manifest |
 
 ### CORS proxy
@@ -143,8 +143,8 @@ The dev manifest points to `https://localhost:3141`. The production manifest (`m
 Some OAuth token endpoints are blocked by CORS inside Office webviews. If OAuth login fails:
 
 1. User setup command: `npx pi-for-excel-proxy` (or `curl -fsSL https://piforexcel.com/proxy | sh` if Node is missing)
-2. Dev/source setup command: `npm run proxy:https` (defaults to `https://localhost:3003`)
-3. In Pi → `/settings` → **Proxy** → enable and set the URL
+2. Dev/source setup command: `npm run proxy:https` (defaults to `https://localhost:3003`; if 3003 is busy, copy the random port printed in the terminal)
+3. In Pi → `/settings` → **Proxy** → enable and set the printed URL
 4. Retry login
 
 API-key auth generally works without the proxy.

--- a/docs/central-proxy.md
+++ b/docs/central-proxy.md
@@ -26,7 +26,7 @@ node scripts/cors-proxy-server.mjs --https
 | Variable | Default | Purpose |
 |---|---|---|
 | `HOST` | `localhost` (https) / `127.0.0.1` (http) | Bind address. Use your server's interface address (or `0.0.0.0` behind a firewall). |
-| `PORT` | `3003` | Listen port. |
+| `PORT` | `3003` | Listen port. If unset and 3003 is busy, the local helper may choose a random free port; central deployments should set `PORT` explicitly for a stable URL. |
 | `HTTPS=1` / `--https` | off | Serve TLS directly. Recommended unless you terminate TLS at a reverse proxy. |
 | `TLS_KEY_PATH` / `TLS_CERT_PATH` | `./key.pem` / `./cert.pem` | Paths to your org-issued TLS key/cert (e.g. `*.example.com`). |
 | `ALLOWED_CLIENT_CIDRS` | *(unset — loopback only)* | Comma-separated IPv4 CIDRs (or bare IPs) allowed as clients, e.g. `10.96.0.0/13,192.168.1.5`. Loopback is always allowed. Invalid entries (including `/0`) are fatal at startup — fail closed. IPv6 client ranges are not supported. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -158,7 +158,7 @@ curl -fsSL https://piforexcel.com/proxy | sh
 
 2. In Pi, open `/settings` → **Proxy**:
    - enable **Proxy**
-   - set URL to `https://localhost:3003`
+   - set URL to the URL printed by the proxy (normally `https://localhost:3003`; if 3003 is busy, it will choose a random free port and print that URL)
 
 3. Retry OAuth login
 
@@ -178,7 +178,8 @@ curl -k -i -s \
 Notes:
 - Keep the proxy URL on **HTTPS** (`https://...`), not HTTP.
 - API-key providers generally work without proxy.
-- If port `3003` is busy, run with another port and use that same URL in settings:
+- If port `3003` is busy, `npx pi-for-excel-proxy` automatically chooses a random free port. Copy the printed `https://localhost:<port>` URL into `/settings` → **Proxy**.
+- To force a specific port, set `PORT` and use that same URL in settings:
 
 ```bash
 PORT=3005 npx pi-for-excel-proxy

--- a/pkg/proxy/README.md
+++ b/pkg/proxy/README.md
@@ -12,13 +12,13 @@ This command:
 
 1. Ensures `mkcert` exists (installs via Homebrew on macOS if missing)
 2. Creates certificates in `~/.pi-for-excel/certs/` when needed
-3. Starts the proxy at `https://localhost:3003`
+3. Starts the proxy at `https://localhost:3003`, or picks a random free port if 3003 is busy
 
 Then in Pi for Excel:
 
 1. Open `/settings`
 2. Enable **Proxy**
-3. Set URL to `https://localhost:3003`
+3. Set URL to the URL printed by the proxy (normally `https://localhost:3003`)
 4. Run `/login`
 
 ## Publishing (maintainers)
@@ -29,6 +29,7 @@ Before packing/publishing, `prepack` copies runtime files from repo root:
 
 - `scripts/cors-proxy-server.mjs`
 - `scripts/proxy-target-policy.mjs`
+- `scripts/proxy-client-policy.mjs`
 
 Publish from this directory:
 

--- a/pkg/proxy/package.json
+++ b/pkg/proxy/package.json
@@ -1,10 +1,10 @@
 {
   "name": "pi-for-excel-proxy",
-  "version": "0.2.3-pre",
+  "version": "0.2.4-pre",
   "description": "One-command local HTTPS proxy helper for Pi for Excel OAuth logins.",
   "type": "module",
   "bin": {
-    "pi-for-excel-proxy": "./cli.mjs"
+    "pi-for-excel-proxy": "cli.mjs"
   },
   "files": [
     "cli.mjs",

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -6,14 +6,15 @@
  * Why this exists:
  * - Some provider OAuth/token endpoints (and some LLM APIs) block browser requests via CORS.
  * - In dev we rely on Vite's proxy. In production, you can run this locally and point
- *   Pi for Excel's proxy setting at it (default: https://localhost:3003).
+ *   Pi for Excel's proxy setting at it (default: https://localhost:3003; if
+ *   3003 is busy and PORT is not set, the helper chooses a random free port).
  *
  * Usage:
  *   npm run proxy:https   # HTTPS (recommended for Office webviews)
  *   npm run proxy         # HTTP  (may be blocked as mixed content)
  *
  * Proxy format:
- *   https://localhost:3003/?url=<target-url>
+ *   https://<listen-host>:<listen-port>/?url=<target-url>
  *
  * Example:
  *   curl 'https://localhost:3003/?url=https%3A%2F%2Fexample.com'
@@ -46,8 +47,21 @@ if (useHttps && useHttp) {
   process.exit(1);
 }
 
+const DEFAULT_PORT = 3003;
 const HOST = process.env.HOST || (useHttps ? "localhost" : "127.0.0.1");
-const PORT = Number.parseInt(process.env.PORT || "3003", 10);
+const hasExplicitPort = typeof process.env.PORT === "string" && process.env.PORT.trim().length > 0;
+
+function parsePort(rawPort) {
+  const port = Number.parseInt(rawPort, 10);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    console.error(`[pi-for-excel] Invalid PORT: ${rawPort}`);
+    console.error("[pi-for-excel] Expected an integer from 0 to 65535.");
+    process.exit(1);
+  }
+  return port;
+}
+
+const PORT = hasExplicitPort ? parsePort(process.env.PORT) : DEFAULT_PORT;
 
 const rootDir = path.resolve(process.cwd());
 // Central deployments (docs/central-proxy.md) can point at org-issued certs.
@@ -483,10 +497,22 @@ const server = (() => {
   );
 })();
 
-server.listen(PORT, HOST, () => {
+function getListeningPort(fallbackPort) {
+  const address = server.address();
+  if (address && typeof address !== "string") {
+    return address.port;
+  }
+  return fallbackPort;
+}
+
+function logStartup(listeningPort) {
   const scheme = useHttps ? "https" : "http";
-  console.log(`[pi-for-excel] CORS proxy listening on ${scheme}://${HOST}:${PORT}`);
-  console.log(`[pi-for-excel] Format: ${scheme}://${HOST}:${PORT}/?url=<target-url>`);
+  const proxyUrl = `${scheme}://${HOST}:${listeningPort}`;
+  console.log(`[pi-for-excel] CORS proxy listening on ${proxyUrl}`);
+  console.log(`[pi-for-excel] Format: ${proxyUrl}/?url=<target-url>`);
+  if (listeningPort !== DEFAULT_PORT) {
+    console.log(`[pi-for-excel] Update Pi for Excel /settings → Proxy URL to ${proxyUrl}`);
+  }
   console.log(`[pi-for-excel] Allowed origins: ${Array.from(allowedOrigins).join(", ")}`);
 
   if (allowedClientCidrs.length > 0) {
@@ -518,4 +544,42 @@ server.listen(PORT, HOST, () => {
   if (strictTargetResolution) {
     console.log("[pi-for-excel] Strict DNS resolution enabled (STRICT_TARGET_RESOLUTION=1)");
   }
-});
+}
+
+function listen(port) {
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    server.off("error", onError);
+    server.off("listening", onListening);
+  };
+
+  const onError = (err) => {
+    cleanup();
+
+    if (err?.code === "EADDRINUSE" && !hasExplicitPort && port === DEFAULT_PORT) {
+      console.warn(`[pi-for-excel] Port ${DEFAULT_PORT} is already in use; choosing a random available port instead.`);
+      listen(0);
+      return;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[pi-for-excel] Failed to listen on ${HOST}:${port}: ${message}`);
+    if (hasExplicitPort) {
+      console.error("[pi-for-excel] Choose a different port with PORT=0 (random) or PORT=<port>.");
+    }
+    process.exit(1);
+  };
+
+  const onListening = () => {
+    cleanup();
+    logStartup(getListeningPort(port));
+  };
+
+  server.once("error", onError);
+  server.once("listening", onListening);
+  server.listen(port, HOST);
+}
+
+listen(PORT);

--- a/scripts/sync-proxy-package.mjs
+++ b/scripts/sync-proxy-package.mjs
@@ -10,6 +10,7 @@ const repoRoot = path.resolve(scriptDir, "..");
 const sourceFiles = [
   "scripts/cors-proxy-server.mjs",
   "scripts/proxy-target-policy.mjs",
+  "scripts/proxy-client-policy.mjs",
 ];
 
 const packageScriptsDir = path.join(repoRoot, "pkg", "proxy", "scripts");

--- a/tests/cors-proxy-server.security.test.mjs
+++ b/tests/cors-proxy-server.security.test.mjs
@@ -29,6 +29,23 @@ async function getFreePort() {
   });
 }
 
+async function stopChild(child) {
+  if (!child.killed) {
+    child.kill("SIGTERM");
+  }
+
+  const exited = Promise.race([
+    once(child, "exit"),
+    delay(2000).then(() => {
+      if (!child.killed) {
+        child.kill("SIGKILL");
+      }
+    }),
+  ]);
+
+  await exited.catch(() => {});
+}
+
 async function startProxy(extraEnv = {}) {
   const port = await getFreePort();
 
@@ -78,26 +95,71 @@ async function startProxy(extraEnv = {}) {
     }),
   ]);
 
-  const stop = async () => {
-    if (!child.killed) {
-      child.kill("SIGTERM");
-    }
-
-    const exited = Promise.race([
-      once(child, "exit"),
-      delay(2000).then(() => {
-        if (!child.killed) {
-          child.kill("SIGKILL");
-        }
-      }),
-    ]);
-
-    await exited.catch(() => {});
-  };
-
   return {
     port,
-    stop,
+    stop: () => stopChild(child),
+    getLogs: () => ({ stdout, stderr }),
+  };
+}
+
+async function startProxyOnDefaultPort(extraEnv = {}) {
+  const env = { ...process.env };
+  delete env.PORT;
+  Object.assign(env, {
+    HOST: "127.0.0.1",
+    ALLOWED_ORIGINS: ORIGIN,
+    ...extraEnv,
+  });
+
+  const child = spawn(process.execPath, [PROXY_SCRIPT_PATH], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+
+  const ready = new Promise((resolve, reject) => {
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      const hasListeningLog = stdout.includes("CORS proxy listening on");
+      const hasTargetPolicyLog =
+        stdout.includes("Allowed target hosts")
+        || stdout.includes("target host allowlisting disabled");
+
+      if (hasListeningLog && hasTargetPolicyLog) {
+        resolve(undefined);
+      }
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    child.once("exit", (code, signal) => {
+      reject(new Error(`proxy exited before ready (code=${String(code)} signal=${String(signal)})\n${stdout}\n${stderr}`));
+    });
+  });
+
+  await Promise.race([
+    ready,
+    delay(5000).then(() => {
+      throw new Error(`proxy start timeout\n${stdout}\n${stderr}`);
+    }),
+  ]);
+
+  const match = stdout.match(/CORS proxy listening on http:\/\/127\.0\.0\.1:(\d+)/);
+  if (!match) {
+    await stopChild(child);
+    throw new Error(`Could not parse proxy port from logs\n${stdout}\n${stderr}`);
+  }
+
+  return {
+    port: Number.parseInt(match[1], 10),
+    stop: () => stopChild(child),
     getLogs: () => ({ stdout, stderr }),
   };
 }
@@ -351,6 +413,33 @@ test("proxy /healthz responds without an Origin header and never proxies", async
   );
   assert.equal(withUrl.status, 200);
   assert.equal(await withUrl.text(), "ok");
+});
+
+test("proxy auto-selects a random port when default 3003 is busy and PORT is not set", async (t) => {
+  const first = await startProxyOnDefaultPort();
+  t.after(async () => {
+    await first.stop();
+  });
+
+  const second = await startProxyOnDefaultPort();
+  t.after(async () => {
+    await second.stop();
+  });
+
+  assert.notEqual(second.port, 3003);
+
+  const health = await fetch(`http://127.0.0.1:${second.port}/healthz`);
+  assert.equal(health.status, 200);
+  assert.equal(await health.text(), "ok");
+
+  const { stdout, stderr } = second.getLogs();
+  const listeningLogCount = stdout.match(/CORS proxy listening on/g)?.length ?? 0;
+  const settingsHintCount = stdout.match(/Update Pi for Excel \/settings → Proxy URL/g)?.length ?? 0;
+  assert.equal(listeningLogCount, 1);
+  assert.equal(settingsHintCount, 1);
+  assert.match(stderr, /Port 3003 is already in use; choosing a random available port instead\./);
+  assert.match(stdout, new RegExp(`CORS proxy listening on http://127\\.0\\.0\\.1:${second.port}`));
+  assert.match(stdout, /Update Pi for Excel \/settings → Proxy URL to http:\/\/127\.0\.0\.1:\d+/);
 });
 
 test("proxy boots with ALLOWED_CLIENT_CIDRS, warns, and still serves loopback", async (t) => {


### PR DESCRIPTION
## Summary\n- fall back to a random free proxy port when 3003 is already occupied and PORT is unset\n- avoid duplicate startup logs on retry\n- update proxy package/docs and include client-policy file in package sync\n\nPublished npm package: pi-for-excel-proxy@0.2.4-pre\n\n## Verification\n- node --test tests/cors-proxy-server.security.test.mjs\n- npm run check\n- npm run build\n- fresh npx smoke with 3003 occupied