### PR TITLE
docs: make WPS Windows skill feature-specific

### DIFF
--- a/.agents/skills/wps-windows-smoke/README.md
+++ b/.agents/skills/wps-windows-smoke/README.md
@@ -1,14 +1,16 @@
-# WPS Windows Smoke
+# WPS Windows Test Harness
 
-Agent Skill for real China-domestic WPS Spreadsheets smoke testing of pi-for-excel on a local Windows 11 ARM QEMU VM.
+Agent Skill for feature-specific validation of pi-for-excel inside real China-domestic WPS Spreadsheets on a local Windows 11 ARM QEMU VM.
 
-Use the skill when WPS JSAPI, WPS packaging, WPS taskpane loading, auth, or real workbook behavior needs validation beyond browser/Office.js tests.
+Use the skill when WPS JSAPI, WPS packaging, WPS taskpane loading, auth, workbook behavior, unsupported-tool handling, or an issue reproduction needs validation beyond browser/Office.js tests.
+
+This skill does **not** define one canonical workbook scenario. Agents should choose a minimal test fixture/action for the feature under review and record evidence tied to that feature.
 
 ## Installation
 
 This is a repo-local Agent Skill. No package install is required beyond the repo's normal dependencies.
 
-External runtime prerequisites for the smoke workflow:
+External runtime prerequisites for the workflow:
 
 - macOS Apple Silicon host with QEMU, EDK2 AArch64 firmware, and `swtpm`
 - local Windows 11 ARM VM under `~/VMs/wps-win11`
@@ -20,6 +22,6 @@ External runtime prerequisites for the smoke workflow:
 ## Helpers
 
 - `scripts/wps-win11-vm.sh` — start/stop the VM, wait for WinRM, run guest PowerShell, attach ISOs, install VirtIO NetKVM.
-- `scripts/prepare-wps-plugin.mjs` — build a WPS smoke plugin from `wps/`, patch URLs for the QEMU guest, generate `publish.html`, and optionally serve it.
+- `scripts/prepare-wps-plugin.mjs` — build a WPS test add-in from `wps/`, patch URLs for the QEMU guest, generate `publish.html`, and optionally serve it.
 
-Read `SKILL.md` for the actual operating notes, gotchas, and first successful smoke evidence.
+Read `SKILL.md` for the operating notes, gotchas, feature-specific test-plan template, and historical first-route evidence.

--- a/.agents/skills/wps-windows-smoke/SKILL.md
+++ b/.agents/skills/wps-windows-smoke/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: wps-windows-smoke
-description: Provision or reuse a local Windows 11 ARM VM for China-domestic WPS Spreadsheets smoke testing of pi-for-excel WPS support. Use when validating WPS JSAPI, WPS add-in packaging, China WPS install/login, or real WPS taskpane/workbook behavior.
+description: Provision or reuse a local Windows 11 ARM VM as a reusable test harness for validating pi-for-excel inside real China-domestic WPS Spreadsheets. Use when an agent needs to test a specific WPS feature, WPS JSAPI behavior, add-in packaging, China WPS install/login, auth, taskpane boot, workbook operations, or an issue reproduction in real WPS rather than in Excel/Office.js or a browser fallback.
 ---
 
-# WPS Windows Smoke
+# WPS Windows Test Harness
 
-Use this skill for **real WPS Spreadsheets validation** of pi-for-excel. Browser tests and Office.js tests are not enough: WPS does not run Office manifests or Office.js add-ins.
+Use this skill for **feature-specific real WPS Spreadsheets validation** of pi-for-excel. Browser tests and Office.js tests are not enough: WPS does not run Office manifests or Office.js add-ins.
+
+This skill is an environment + workflow harness, **not one fixed smoke test**. Before testing, name the feature or regression under test and choose the smallest WPS workbook action that proves it. Do not use a generic “create and format a table” prompt unless the feature being tested is specifically table-like writing/formatting behavior.
 
 ## What agents get wrong
 
@@ -21,6 +23,7 @@ Use this skill for **real WPS Spreadsheets validation** of pi-for-excel. Browser
 - Real WPS requests add-in-root `/index.html`; it must load `main.js`. Do not assume `wpsjs publish` or WPS generates this entrypoint.
 - WPS's publish-page validator expects `ribbon.xml` to start with `<customUI`; an XML declaration prefix can make the row show `无效` even when WPS can fetch the file.
 - WPS 12.1.0.26200 embeds a WebView with `crypto.getRandomValues` but no `crypto.randomUUID`; keep the app bootstrap compatibility patch installed.
+- Do **not** turn historical evidence into the canonical test. The first successful run used a table prompt, but future runs should test the feature actually under review.
 
 ## Local VM conventions
 
@@ -69,9 +72,9 @@ Invoke-WebRequest -UseBasicParsing http://10.0.2.2:3141/src/taskpane.html | Sele
 PS
 ```
 
-### WPS smoke plugin packaging
+### WPS test add-in packaging
 
-`prepare-wps-plugin.mjs` builds a smoke add-in root with `index.html`, `ribbon.xml`, `main.js`, `manifest.xml`, and `jsplugins.xml`; patches the taskpane URL to the QEMU host gateway; keeps the WPS callback alias; and can generate `publish.html` via `wpsjs publish`.
+`prepare-wps-plugin.mjs` builds a WPS test add-in root with `index.html`, `ribbon.xml`, `main.js`, `manifest.xml`, and `jsplugins.xml`; patches the taskpane URL to the QEMU host gateway; keeps the WPS callback alias; and can generate `publish.html` via `wpsjs publish`. The default output directory is still named `wps-smoke-plugin` for compatibility with existing scripts and evidence paths; it is not tied to one specific test scenario.
 
 ```bash
 npm run dev > /tmp/pi-for-excel-wps-vite.log 2>&1 &
@@ -100,7 +103,20 @@ $ProgressPreference = 'SilentlyContinue'
 PS
 ```
 
-## Smoke workflow
+## Feature-specific test planning
+
+Before launching the full path, write down a compact test plan:
+
+- **Feature/regression under test:** e.g. taskpane boot, provider auth, `execute_wps_js`, `read_range`, an unsupported-tool failure path, a newly implemented WPS tool, or a reported customer issue.
+- **Build under test:** branch/commit, dev URL, WPS version, and whether using personal publish mode or enterprise `jsplugins.xml` mode.
+- **Fixture:** blank workbook, seeded range, saved workbook path, or exact reproduction file. Keep raw workbook paths and credentials out of logs.
+- **Action:** the exact Pi prompt, tool call, JSAPI snippet, or install/update action that exercises the target feature.
+- **Expected result:** what must visibly or programmatically happen in WPS for the test to pass.
+- **Evidence:** screenshots, WinRM command output, taskpane logs, WPS version, publish/install evidence, workbook before/after state, and any failure output.
+
+Use [`docs/wps-support.md`](../../../docs/wps-support.md) as the current support matrix. If the feature is explicitly unsupported on WPS, a typed `unsupported_host_tool` failure is the correct pass condition.
+
+## General workflow
 
 1. Start VM and confirm WinRM + guest internet:
    ```bash
@@ -109,26 +125,36 @@ PS
    .agents/skills/wps-windows-smoke/scripts/wps-win11-vm.sh wait-winrm 180
    .agents/skills/wps-windows-smoke/scripts/wps-win11-vm.sh health
    ```
-2. Start pi-for-excel dev server on macOS (`npm run dev`); Vite binds `::`/3141 by default.
-3. Generate and serve the WPS smoke plugin with `prepare-wps-plugin.mjs --publish --serve`.
-4. In Windows, open `http://10.0.2.2:3889/publish.html` in Edge and install the WPS add-in. Use this personal publish flow before trying `jsplugins.xml`. If Edge asks to open WPS Office, allow it; if direct service deployment is needed, POST the page's base64 payload to `http://127.0.0.1:58890/deployaddons/runParams` and approve the WPS trust prompt.
-5. Launch direct Spreadsheets (`et.exe`) rather than the WPS home shell if the home/login webview crashes.
-6. Confirm the **Pi** ribbon tab appears. In WPS 12.1.0.26200 the tab appeared at the far right after the WPS AI tab; click the `Pi` label/overflow if needed. Click **Open Pi**.
-7. In the taskpane, verify WPS host behavior:
+2. Write the feature-specific test plan above. Avoid broad “prove everything” prompts.
+3. Start pi-for-excel dev server on macOS (`npm run dev`); Vite binds `::`/3141 by default.
+4. Generate and serve the WPS test add-in with `prepare-wps-plugin.mjs --publish --serve`.
+5. In Windows, open `http://10.0.2.2:3889/publish.html` in Edge and install the WPS add-in. Use this personal publish flow before trying `jsplugins.xml`. If Edge asks to open WPS Office, allow it; if direct service deployment is needed, POST the page's base64 payload to `http://127.0.0.1:58890/deployaddons/runParams` and approve the WPS trust prompt.
+6. Launch direct Spreadsheets (`et.exe`) rather than the WPS home shell if the home/login webview crashes.
+7. Confirm the baseline environment is valid:
    - taskpane loads from `http://10.0.2.2:3141/src/taskpane.html`
    - host kind resolves to WPS, not Office/browser
-   - `execute_wps_js` works
-   - `get_workbook_overview`, `read_range`, and `write_cells` work against the real workbook
-   - unsupported Office-coupled tools fail fast with `unsupported_host_tool`
-8. For the full end-to-end smoke, prompt Pi to create and format a worksheet table. First successful evidence used local `/__pi-auth` OpenAI Codex credentials, created the table in `A1:D5`, then formatted it with a blue header, borders, and bold total row.
+   - the Pi ribbon tab and **Open Pi** button are visible
+   - the target add-in build/commit is the one under test
+8. Execute only the feature-specific action from the plan. Examples:
+   - **Packaging/install:** reinstall via `publish.html`, inspect WPS publish/install state, verify the Pi ribbon appears after WPS restart.
+   - **Taskpane boot:** open **Open Pi**, capture taskpane load/console state, verify no boot-time compatibility error.
+   - **Host detection:** ask Pi or inspect logs to verify WPS host selection and workbook context, without mutating the workbook.
+   - **`execute_wps_js`:** run a minimal JSAPI snippet that reads workbook/sheet metadata or performs the specific mutation under test, then verify the returned JSON.
+   - **Workbook tool support:** seed only the range needed, call the relevant tool/prompt, and verify workbook state with WPS UI or `execute_wps_js` readback.
+   - **Unsupported tools:** deliberately invoke the unsupported WPS path and confirm a typed `unsupported_host_tool` error, not an Office.js fallback.
+   - **Auth/model flow:** verify provider setup and a small prompt response without exposing tokens or local credential paths.
+   - **Regression reproduction:** reproduce the exact issue steps first, then rerun after the fix with the same fixture.
+9. Capture evidence tied to the target feature. Prefer a screenshot plus a text log/command output. Include residual risks or gaps instead of calling unrelated behavior “covered.”
 
-## Evidence from first successful route
+## Historical evidence from first successful route
+
+These artifacts prove the harness can install and run pi-for-excel in real WPS. They are **historical examples only**, not the required test scenario for future work.
 
 - `~/VMs/wps-win11/publish-page-cmd-launch.png` — Edge publish page opened the WPS Office protocol handler.
 - `~/VMs/wps-win11/after-trust-install.png` plus WPS publishlist output — add-in installed through the WPS relay service.
 - `~/VMs/wps-click-addin-chevron.png` — Pi tab visible with `Open Pi`.
 - `~/VMs/wps-taskpane-after-randomuuid-patch.png` — taskpane initialized in real WPS after the WebView compatibility patch.
-- `~/VMs/wps-after-format-prompt-settle.png` — authenticated agent write and formatting succeeded in the workbook.
+- `~/VMs/wps-after-format-prompt-settle.png` — the first authenticated agent write/formatting scenario succeeded in the workbook.
 
 ## WPS install/account notes
 
@@ -144,4 +170,4 @@ kill "$(cat /tmp/pi-wps-smoke-plugin-3889.pid)" 2>/dev/null || true
 pkill -f 'vite --port 3141' 2>/dev/null || true
 ```
 
-Keep screenshots/logs under `~/VMs/wps-win11/` or `/tmp`; do not commit VM credentials, ISOs, qcow2 disks, or WPS installers.
+Keep screenshots/logs under `~/VMs/wps-win11/` or `/tmp`; do not commit VM credentials, ISOs, qcow2 disks, WPS installers, or screenshots that expose tokens/private workbook data.

--- a/docs/wps-support.md
+++ b/docs/wps-support.md
@@ -49,7 +49,7 @@ workbook context.
 | Host/distribution | Support stance | Add-in route | Notes |
 |---|---|---|---|
 | Microsoft Excel | Supported | Office Add-in manifest + Office.js | Existing production path. |
-| China WPS personal (`wps.cn`) | Phase 2 backend implemented; real-client smoke pending | `wpsjs publish` flow | Recommended WPS route. Installs write `publish.xml` under `%appdata%/kingsoft/wps/jsaddons` on Windows or `~/.local/share/Kingsoft/wps/jsaddons` on Linux. |
+| China WPS personal (`wps.cn`) | Phase 2 backend implemented; personal publish-mode smoke completed on WPS 12.1.0.26200 | `wpsjs publish` flow | Recommended WPS route. Installs write `publish.xml` under `%appdata%/kingsoft/wps/jsaddons` on Windows or `~/.local/share/Kingsoft/wps/jsaddons` on Linux. |
 | WPS 365 enterprise | Phase 2 backend implemented; enterprise deployment smoke pending | Publish mode or managed `jsplugins.xml` via `oem.ini` | `jsplugins.xml` mode is for enterprise/OEM repack scenarios. |
 | International WPS (`wps.com`) | Unsupported for now | N/A | Public docs and JSAPI/plugin routes differ; do not claim support until verified. |
 | Browser/dev server | Supported for UI testing only | Vite dev server | No workbook API; mirrors existing no-Office fallback. |
@@ -151,8 +151,8 @@ Evidence artifacts from the first smoke run live outside the repo under
 - `wps-click-addin-chevron.png` — Pi tab visible with `Open Pi` button.
 - `wps-taskpane-after-randomuuid-patch.png` — taskpane initialized in WPS after
   the `crypto.randomUUID` compatibility patch.
-- `wps-after-format-prompt-settle.png` — agent-created and formatted worksheet
-  table in WPS.
+- `wps-after-format-prompt-settle.png` — first authenticated agent write/formatting
+  scenario in WPS.
 
 ## Open verification gaps
 


### PR DESCRIPTION
## What\n- Reframe the WPS Windows skill as a reusable feature-specific test harness, not one canonical table-creation smoke.\n- Add a compact test-plan template and examples for packaging, taskpane boot, host detection, WPS JSAPI, workbook tools, unsupported-tool paths, auth, and regressions.\n- Keep the first successful table/write-format run as historical evidence only.\n- Update WPS support docs to reflect completed personal publish-mode smoke evidence.\n\n## Validation\n- npm run check\n- node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/skills-frontmatter.test.ts tests/docs-skills-drift.test.ts