### PR TITLE
docs: require visual proof for WPS harness tests

### DIFF
--- a/.agents/skills/wps-windows-smoke/README.md
+++ b/.agents/skills/wps-windows-smoke/README.md
@@ -6,6 +6,8 @@ Use the skill when WPS JSAPI, WPS packaging, WPS taskpane loading, auth, workboo
 
 This skill does **not** define one canonical workbook scenario. Agents should choose a minimal test fixture/action for the feature under review and record evidence tied to that feature.
 
+Real WPS verification should include visual proof: at least one screenshot, or a short video / screenshot sequence for timing-sensitive flows. Text logs alone are not enough.
+
 ## Installation
 
 This is a repo-local Agent Skill. No package install is required beyond the repo's normal dependencies.
@@ -24,4 +26,4 @@ External runtime prerequisites for the workflow:
 - `scripts/wps-win11-vm.sh` — start/stop the VM, wait for WinRM, run guest PowerShell, attach ISOs, install VirtIO NetKVM.
 - `scripts/prepare-wps-plugin.mjs` — build a WPS test add-in from `wps/`, patch URLs for the QEMU guest, generate `publish.html`, and optionally serve it.
 
-Read `SKILL.md` for the operating notes, gotchas, feature-specific test-plan template, and historical first-route evidence.
+Read `SKILL.md` for the operating notes, gotchas, feature-specific test-plan template, screenshot/video proof requirements, and historical first-route evidence.

--- a/.agents/skills/wps-windows-smoke/SKILL.md
+++ b/.agents/skills/wps-windows-smoke/SKILL.md
@@ -112,9 +112,30 @@ Before launching the full path, write down a compact test plan:
 - **Fixture:** blank workbook, seeded range, saved workbook path, or exact reproduction file. Keep raw workbook paths and credentials out of logs.
 - **Action:** the exact Pi prompt, tool call, JSAPI snippet, or install/update action that exercises the target feature.
 - **Expected result:** what must visibly or programmatically happen in WPS for the test to pass.
-- **Evidence:** screenshots, WinRM command output, taskpane logs, WPS version, publish/install evidence, workbook before/after state, and any failure output.
+- **Evidence:** screenshots/video, WinRM command output, taskpane logs, WPS version, publish/install evidence, workbook before/after state, and any failure output.
 
 Use [`docs/wps-support.md`](../../../docs/wps-support.md) as the current support matrix. If the feature is explicitly unsupported on WPS, a typed `unsupported_host_tool` failure is the correct pass condition.
+
+## Visual proof requirements
+
+Real-client WPS verification must produce at least one visual artifact from the Windows VM. Text logs alone are not enough.
+
+- Capture **before/after screenshots** for workbook mutations, taskpane boot, ribbon/install state, and regressions with visible UI symptoms.
+- Prefer a final screenshot where the relevant UI is unobstructed (close popups/taskpanes if they hide the proof).
+- For flows where timing matters (install prompts, crash/restart loops, modal handoffs), capture a short video or a sequence of screenshots.
+- Store proof artifacts under `~/VMs/wps-win11/` or `/tmp` with descriptive names, and report the paths in the result.
+- Do not commit screenshots/videos that expose tokens, private workbook data, local credentials, or customer data.
+
+Screenshot helper:
+
+```bash
+VM=~/VMs/wps-win11
+VNCDOTOOL="$VM/.venv/bin/vncdotool"
+[ -x "$VNCDOTOOL" ] || VNCDOTOOL="$(command -v vncdotool)"
+"$VNCDOTOOL" -s 127.0.0.1::5907 capture "$VM/<feature>-after.png"
+```
+
+If the capture is black, the Windows display is probably locked/asleep. Wake/unlock the console before treating the capture as evidence; do not rely on a black screenshot.
 
 ## General workflow
 
@@ -144,7 +165,7 @@ Use [`docs/wps-support.md`](../../../docs/wps-support.md) as the current support
    - **Unsupported tools:** deliberately invoke the unsupported WPS path and confirm a typed `unsupported_host_tool` error, not an Office.js fallback.
    - **Auth/model flow:** verify provider setup and a small prompt response without exposing tokens or local credential paths.
    - **Regression reproduction:** reproduce the exact issue steps first, then rerun after the fix with the same fixture.
-9. Capture evidence tied to the target feature. Prefer a screenshot plus a text log/command output. Include residual risks or gaps instead of calling unrelated behavior “covered.”
+9. Capture evidence tied to the target feature. Include at least one screenshot or video plus a text log/command output. Include residual risks or gaps instead of calling unrelated behavior “covered.”
 
 ## Historical evidence from first successful route
 

--- a/docs/wps-support.md
+++ b/docs/wps-support.md
@@ -30,9 +30,9 @@ Office.js path.
 | `read_range` | Supported | `compact`, `csv`, and `detailed` modes via WPS `Range.Value2`, `Formula`, and `NumberFormat`. If formula/format metadata is unavailable, the result includes an in-band WPS metadata note. |
 | `write_cells` | Supported | Values/formulas, overwrite protection, and read-back verification. **No WPS automatic backup is created**; the result and details report recovery as `not_available`. |
 | `instructions`, `conventions`, `skills` | Supported | Local/settings-backed tools; same behavior as Phase 1. Workbook-scoped instructions require the WPS workbook identity to be available. |
-| `execute_wps_js` | Supported on WPS only | Non-core escape hatch for direct synchronous WPS JSAPI code with `Application` in scope. Uses the same approval gate and JSON serialization policy as `execute_office_js`. |
+| `execute_wps_js` | Supported on WPS only | Non-core escape hatch for direct synchronous WPS JSAPI code with `Application` in scope. Uses the same approval gate and JSON serialization policy as `execute_office_js`. Raw WPS JSAPI chart creation has been verified through this host surface, but the typed `charts` tool is still unsupported on WPS. |
 | `workbook_history` | Fail-fast | WPS workbook backups/snapshots are not implemented. |
-| Other workbook tools (`fill_formula`, `search_workbook`, `modify_structure`, `format_cells`, `conditional_format`, `trace_dependencies`, `explain_formula`, `view_settings`, `comments`) | Fail-fast | Not implemented on WPS in Phase 2. |
+| Other workbook tools (`fill_formula`, `search_workbook`, `modify_structure`, `format_cells`, `conditional_format`, `charts`, `trace_dependencies`, `explain_formula`, `view_settings`, `comments`) | Fail-fast | Not implemented on WPS in Phase 2. |
 | `execute_office_js`, `python_transform_range` | Fail-fast on WPS | These are Office.js/Excel-coupled and remain unavailable on WPS. |
 | Host-independent non-core tools (`python_run`, `tmux`, `libreoffice_convert`, `files`, `extensions_manager`, integrations) | Unchanged | Registered as before; their own gates/connection requirements still apply. |
 
@@ -153,6 +153,11 @@ Evidence artifacts from the first smoke run live outside the repo under
   the `crypto.randomUUID` compatibility patch.
 - `wps-after-format-prompt-settle.png` — first authenticated agent write/formatting
   scenario in WPS.
+- `wps-chart-probe-workbook-chart-only.png` plus
+  `wps-chart-probe-result.json` — raw WPS JSAPI chart creation probe: wrote
+  `A1:B5`, created one embedded chart with `ChartObjects().Add(...)` and
+  `ChartWizard(...)`, and visually confirmed the rendered chart. This does **not**
+  mean the typed Pi `charts` tool is supported on WPS yet.
 
 ## Open verification gaps
 


### PR DESCRIPTION
## What
- Make screenshot/video proof a hard expectation for WPS real-client harness tests.
- Add a VNC screenshot helper and guidance for black/locked captures.
- Record today's WPS chart probe as raw JSAPI evidence while keeping the typed Pi `charts` tool marked unsupported on WPS.

## Validation
- npm run check
- node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/skills-frontmatter.test.ts tests/docs-skills-drift.test.ts tests/registry-host-selection.test.ts
