### PR TITLE
docs: distinguish WPS product proof from API probes

### DIFF
--- a/.agents/skills/wps-windows-smoke/README.md
+++ b/.agents/skills/wps-windows-smoke/README.md
@@ -6,6 +6,8 @@ Use the skill when WPS JSAPI, WPS packaging, WPS taskpane loading, auth, workboo
 
 This skill does **not** define one canonical workbook scenario. Agents should choose a minimal test fixture/action for the feature under review and record evidence tied to that feature.
 
+Separate **product-level Pi for Excel proof** from **low-level WPS JSAPI probes**. Product-level proof must use the real Pi taskpane/sidebar, auth/model setup, agent loop, tools/approvals, workbook updates, and final user-visible result. Custom probe taskpanes are useful for isolating WPS APIs, but they are not proof that Pi for Excel works for that feature.
+
 Real WPS verification should include visual proof: at least one screenshot, or a short video / screenshot sequence for timing-sensitive flows. Text logs alone are not enough.
 
 ## Installation

--- a/.agents/skills/wps-windows-smoke/SKILL.md
+++ b/.agents/skills/wps-windows-smoke/SKILL.md
@@ -9,6 +9,11 @@ Use this skill for **feature-specific real WPS Spreadsheets validation** of pi-f
 
 This skill is an environment + workflow harness, **not one fixed smoke test**. Before testing, name the feature or regression under test and choose the smallest WPS workbook action that proves it. Do not use a generic “create and format a table” prompt unless the feature being tested is specifically table-like writing/formatting behavior.
 
+Be explicit about the test level:
+
+- **Product-level Pi for Excel proof** must load the real Pi taskpane (`/src/taskpane.html`) and exercise the actual sidebar/chat UI, auth/model setup, agent loop, tool calls, approvals, workbook updates, and final user-visible result.
+- **Low-level WPS JSAPI probes** may use a custom temporary taskpane/page to isolate WPS host APIs, but they are only host-capability evidence. They do **not** prove that the Pi sidebar, agent, auth, or typed Pi tools work for that feature.
+
 ## What agents get wrong
 
 - Use **China-domestic WPS** (`wps.cn` / `platform.wps.cn`) first. International `wps.com` builds are not the target and may not expose the documented JSAPI/add-in channel.
@@ -108,6 +113,7 @@ PS
 Before launching the full path, write down a compact test plan:
 
 - **Feature/regression under test:** e.g. taskpane boot, provider auth, `execute_wps_js`, `read_range`, an unsupported-tool failure path, a newly implemented WPS tool, or a reported customer issue.
+- **Test level:** product-level Pi sidebar/agent proof, or low-level WPS JSAPI host-capability probe. Do not mix these up in the conclusion.
 - **Build under test:** branch/commit, dev URL, WPS version, and whether using personal publish mode or enterprise `jsplugins.xml` mode.
 - **Fixture:** blank workbook, seeded range, saved workbook path, or exact reproduction file. Keep raw workbook paths and credentials out of logs.
 - **Action:** the exact Pi prompt, tool call, JSAPI snippet, or install/update action that exercises the target feature.
@@ -152,16 +158,17 @@ If the capture is black, the Windows display is probably locked/asleep. Wake/unl
 5. In Windows, open `http://10.0.2.2:3889/publish.html` in Edge and install the WPS add-in. Use this personal publish flow before trying `jsplugins.xml`. If Edge asks to open WPS Office, allow it; if direct service deployment is needed, POST the page's base64 payload to `http://127.0.0.1:58890/deployaddons/runParams` and approve the WPS trust prompt.
 6. Launch direct Spreadsheets (`et.exe`) rather than the WPS home shell if the home/login webview crashes.
 7. Confirm the baseline environment is valid:
-   - taskpane loads from `http://10.0.2.2:3141/src/taskpane.html`
-   - host kind resolves to WPS, not Office/browser
+   - for product-level tests, the taskpane loads the real Pi app from `http://10.0.2.2:3141/src/taskpane.html`
+   - for low-level probes, the taskpane URL is clearly recorded as a custom probe URL and the result is not described as Pi sidebar/agent proof
+   - host kind resolves to WPS, not Office/browser, when the real Pi app is under test
    - the Pi ribbon tab and **Open Pi** button are visible
    - the target add-in build/commit is the one under test
 8. Execute only the feature-specific action from the plan. Examples:
    - **Packaging/install:** reinstall via `publish.html`, inspect WPS publish/install state, verify the Pi ribbon appears after WPS restart.
    - **Taskpane boot:** open **Open Pi**, capture taskpane load/console state, verify no boot-time compatibility error.
    - **Host detection:** ask Pi or inspect logs to verify WPS host selection and workbook context, without mutating the workbook.
-   - **`execute_wps_js`:** run a minimal JSAPI snippet that reads workbook/sheet metadata or performs the specific mutation under test, then verify the returned JSON.
-   - **Workbook tool support:** seed only the range needed, call the relevant tool/prompt, and verify workbook state with WPS UI or `execute_wps_js` readback.
+   - **`execute_wps_js`:** in the real Pi sidebar, run a minimal JSAPI snippet that reads workbook/sheet metadata or performs the specific mutation under test, then verify the returned JSON.
+   - **Workbook tool support:** in the real Pi sidebar, seed only the range needed, call the relevant typed tool/prompt, and verify workbook state with WPS UI or `execute_wps_js` readback.
    - **Unsupported tools:** deliberately invoke the unsupported WPS path and confirm a typed `unsupported_host_tool` error, not an Office.js fallback.
    - **Auth/model flow:** verify provider setup and a small prompt response without exposing tokens or local credential paths.
    - **Regression reproduction:** reproduce the exact issue steps first, then rerun after the fix with the same fixture.

--- a/docs/wps-support.md
+++ b/docs/wps-support.md
@@ -30,7 +30,7 @@ Office.js path.
 | `read_range` | Supported | `compact`, `csv`, and `detailed` modes via WPS `Range.Value2`, `Formula`, and `NumberFormat`. If formula/format metadata is unavailable, the result includes an in-band WPS metadata note. |
 | `write_cells` | Supported | Values/formulas, overwrite protection, and read-back verification. **No WPS automatic backup is created**; the result and details report recovery as `not_available`. |
 | `instructions`, `conventions`, `skills` | Supported | Local/settings-backed tools; same behavior as Phase 1. Workbook-scoped instructions require the WPS workbook identity to be available. |
-| `execute_wps_js` | Supported on WPS only | Non-core escape hatch for direct synchronous WPS JSAPI code with `Application` in scope. Uses the same approval gate and JSON serialization policy as `execute_office_js`. Raw WPS JSAPI chart creation has been verified through this host surface, but the typed `charts` tool is still unsupported on WPS. |
+| `execute_wps_js` | Supported on WPS only | Non-core escape hatch for direct synchronous WPS JSAPI code with `Application` in scope. Uses the same approval gate and JSON serialization policy as `execute_office_js`. |
 | `workbook_history` | Fail-fast | WPS workbook backups/snapshots are not implemented. |
 | Other workbook tools (`fill_formula`, `search_workbook`, `modify_structure`, `format_cells`, `conditional_format`, `charts`, `trace_dependencies`, `explain_formula`, `view_settings`, `comments`) | Fail-fast | Not implemented on WPS in Phase 2. |
 | `execute_office_js`, `python_transform_range` | Fail-fast on WPS | These are Office.js/Excel-coupled and remain unavailable on WPS. |
@@ -154,10 +154,12 @@ Evidence artifacts from the first smoke run live outside the repo under
 - `wps-after-format-prompt-settle.png` — first authenticated agent write/formatting
   scenario in WPS.
 - `wps-chart-probe-workbook-chart-only.png` plus
-  `wps-chart-probe-result.json` — raw WPS JSAPI chart creation probe: wrote
-  `A1:B5`, created one embedded chart with `ChartObjects().Add(...)` and
-  `ChartWizard(...)`, and visually confirmed the rendered chart. This does **not**
-  mean the typed Pi `charts` tool is supported on WPS yet.
+  `wps-chart-probe-result.json` — low-level custom-taskpane WPS JSAPI chart
+  creation probe: wrote `A1:B5`, created one embedded chart with
+  `ChartObjects().Add(...)` and `ChartWizard(...)`, and visually confirmed the
+  rendered chart. This proves the WPS host API can create a chart; it does **not**
+  prove the real Pi sidebar/chat, `execute_wps_js`, or typed Pi `charts` tool can
+  create charts on WPS.
 
 ## Open verification gaps
 


### PR DESCRIPTION
## What
- Clarify that product-level WPS proof must use the real Pi sidebar/chat, auth/model setup, agent loop, tool calls/approvals, workbook updates, and visible result.
- Distinguish low-level custom-taskpane WPS JSAPI probes from product proof.
- Correct the chart evidence note: the chart probe proved WPS host API capability only; it did not prove `execute_wps_js` or typed `charts` support through the real Pi sidebar.

## Validation
- npm run check
- node --test --experimental-strip-types --import ./scripts/register-test-ts-loader.mjs tests/skills-frontmatter.test.ts tests/docs-skills-drift.test.ts tests/registry-host-selection.test.ts
