### PR TITLE
Fix WPS short-pane chat composer layout

### DIFF
--- a/src/ui/theme/components/empty-state.css
+++ b/src/ui/theme/components/empty-state.css
@@ -86,6 +86,44 @@
   background: var(--green-alpha-6);
 }
 
+@media (max-height: 520px) {
+  .pi-empty {
+    padding: 8px 16px 10px;
+  }
+
+  .pi-empty__content {
+    min-height: 0;
+    justify-content: flex-start;
+  }
+
+  .pi-empty__logo {
+    display: none;
+  }
+
+  .pi-empty__tagline {
+    font-size: var(--text-sm);
+    line-height: 1.35;
+  }
+
+  .pi-empty__hints {
+    margin-top: 10px;
+    gap: 4px;
+  }
+
+  .pi-empty__hint {
+    gap: 1px;
+    padding: 6px 10px;
+  }
+
+  .pi-empty__hint-label {
+    font-size: var(--text-sm);
+  }
+
+  .pi-empty__hint-preview {
+    display: none;
+  }
+}
+
 /* Loading + startup errors */
 .pi-loading {
   display: flex;

--- a/src/ui/theme/components/input.css
+++ b/src/ui/theme/components/input.css
@@ -2,6 +2,12 @@
    4. PI-INPUT — textarea card + send button
    ═══════════════════════════════════════════════════════ */
 
+pi-input {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
 .pi-input-card {
   position: relative;
   border-radius: var(--pill-radius);
@@ -126,6 +132,30 @@
 .pi-input-btn--abort:hover {
   background: oklch(0.50 0.22 25);
   transform: scale(1.05);
+}
+
+@media (max-height: 520px) {
+  .pi-input-textarea {
+    min-height: 34px;
+    padding: 8px 46px 8px 36px;
+    line-height: 1.35;
+    max-height: 28vh;
+  }
+
+  .pi-input-btn {
+    bottom: 5px;
+    width: 24px;
+    height: 24px;
+  }
+
+  .pi-input-btn--attach {
+    left: 6px;
+  }
+
+  .pi-input-btn--send,
+  .pi-input-btn--abort {
+    right: 6px;
+  }
 }
 
 

--- a/src/ui/theme/components/tabs.css
+++ b/src/ui/theme/components/tabs.css
@@ -2,6 +2,17 @@
    3. PI-SIDEBAR — tabs + messages area + input area
    ═══════════════════════════════════════════════════════ */
 
+pi-sidebar {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .pi-session-tabs {
   display: flex;
   align-items: center;
@@ -411,6 +422,22 @@
   height: 10px;
   background: linear-gradient(to top, var(--alpha-4), transparent);
   pointer-events: none;
+}
+
+@media (max-height: 520px) {
+  .pi-session-tabs {
+    padding-top: 4px;
+    padding-bottom: 3px;
+  }
+
+  .pi-messages__inner {
+    padding-top: 6px;
+    padding-bottom: 14px;
+  }
+
+  :is(.pi-input-area, .pi-widget-slot) {
+    padding: 4px 8px;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- Make the `pi-sidebar` custom element explicitly fill the taskpane as a flex column.
- Make the `pi-input` custom element block/full-width so its textarea card and send affordance do not shrink/clip in narrow WPS panes.
- Compact the empty-state hints and input footer for short taskpane heights so the real composer remains usable.

## WPS proof
Validated in China-domestic WPS Spreadsheets `12.1.0.26200` on the Windows 11 ARM harness against the real Pi taskpane (`/src/taskpane.html`) using dev `/__pi-auth` restore for this tool-surface run.

Observed bug before this patch: in the 800×600 WPS/VNC pane, the post-auth chat composer was cramped enough that VNC input was easy to put into/near hint text and the send affordance was not reliably visible. This blocked supported-tool proof through the real sidebar.

After the patch / reload path:
- Real composer accepted prompt text.
- Enter dispatched the prompt.
- Real Pi agent/tool loop wrote `OK` into `A1`.
- Follow-up prompt visibly requested reading A1 and writing `READOK`; final workbook showed `A1=OK`, `B1=READOK`.
- Follow-up WPS JSAPI prompt visibly requested WPS JSAPI read/write; final workbook showed `C1=JSOK`.

Evidence saved locally under `~/VMs/wps-win11/`:
- `wps-tools-write-ok-prompt-visible.png`
- `wps-tools-write-ok-after-send.png`
- `wps-tools-read-then-write-prompt.png`
- `wps-tools-read-then-write-after-send.png`
- `wps-tools-jsapi-prompt.png`
- `wps-tools-jsapi-after-send-20s.png`

Local visual verification also rendered `src/taskpane.html` at `260×443` and confirmed:
- `pi-sidebar` display is `flex`, `260×443`.
- `pi-input` is full width (`244px`) and the send button is inside the card.

## Validation
- `npm run check`
- `npm run build`
