### PR TITLE
evals: fix bridge cmd payload default

### DIFF
--- a/evals/bin/bridge.sh
+++ b/evals/bin/bridge.sh
@@ -73,7 +73,9 @@ print("msgs=%s busy=%s" % (ar.get("messageCount"), ar.get("isBusy")))' 2>/dev/nu
     done
     ;;
   cmd)
-    post "$3" "$2" "${4:-{}}" "${5:-30000}"
+    PAYLOAD="${4-}"
+    [ -n "$PAYLOAD" ] || PAYLOAD='{}'
+    post "$3" "$2" "$PAYLOAD" "${5:-30000}"
     echo
     ;;
   *)


### PR DESCRIPTION
Small follow-up to #636 from the live eval loop.

## Problem

`evals/bin/bridge.sh cmd` used:

```bash
post "$3" "$2" "${4:-{}}" "${5:-30000}"
```

Bash parses `${4:-{}}` as the parameter expansion plus a trailing literal `}`, so payloads become invalid JSON:

- default `{}` becomes `{}}`
- explicit JSON payloads get an extra trailing `}`

This only affects the generic `cmd` path; `status`/`watch` call `post` directly and remained usable.

## Fix

Assign the default into a local `PAYLOAD` variable first, then pass it through.

## Verification

Against the live background bridge/client:

```text
bridge.sh cmd <client> status '{}' 10000  -> ok=true, workbook=gpu-farm-doctor-01b-run5.xlsx
bridge.sh cmd <client> status             -> ok=true, messageCount=57
```

Also mirrored the same fix into the private corpus helper.