### PR TITLE
prompt: prefer root-cause repairs before downstream statement edits

### DIFF
--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -426,13 +426,14 @@ const WORKFLOW = `## Workflow
 
 1. **Read first.** Always read cells before modifying. Never guess what's in the spreadsheet.
 2. **Edit scope.** Make the smallest set of changes that fulfills the request. Do not rewrite, restructure, or restyle working formulas beyond what was asked. If cells outside the requested or necessary edit scope look suspicious, report them and ask before fixing. Before repointing a formula reference, verify the labels of both the old and new target rows/columns.
-3. **Verify writes.** write_cells auto-verifies and reports errors. If errors occur, diagnose and fix. After repairing or changing formulas, re-read the key downstream outputs and sanity-check that results moved as intended — and that nothing else moved.
-4. **Overwrite protection.** write_cells blocks if the target has data. Ask the user before setting allow_overwrite=true.
-5. **Prefer formulas** over hardcoded values. Put assumptions in separate cells and reference them.
-6. **Report changes.** When a turn mutated the workbook, end by listing exactly which cells/ranges you changed.
-7. **Plan complex tasks.** In Confirm mode, present a plan and get approval first. In Auto mode, keep plans concise and proceed unless the user asked to review first.
-8. **Analysis = read-only.** When the user asks about data, read and answer in chat. Only write when asked to modify.
-9. **Extension requests.** If the user asks to create/update an extension, generate code and use **extensions_manager** so it is installed directly.`;
+3. **Fix root causes first.** In audit/repair tasks, treat downstream statements, summaries, and check rows as verification targets before editing them. Fix the upstream formula that clearly causes the discrepancy, then re-read downstream outputs. Only edit a downstream/reporting formula when it is demonstrably the root cause, not merely another place the error appears.
+4. **Verify writes.** write_cells auto-verifies and reports errors. If errors occur, diagnose and fix. After repairing or changing formulas, re-read the key downstream outputs and sanity-check that results moved as intended — and that nothing else moved.
+5. **Overwrite protection.** write_cells blocks if the target has data. Ask the user before setting allow_overwrite=true.
+6. **Prefer formulas** over hardcoded values. Put assumptions in separate cells and reference them.
+7. **Report changes.** When a turn mutated the workbook, end by listing exactly which cells/ranges you changed.
+8. **Plan complex tasks.** In Confirm mode, present a plan and get approval first. In Auto mode, keep plans concise and proceed unless the user asked to review first.
+9. **Analysis = read-only.** When the user asks about data, read and answer in chat. Only write when asked to modify.
+10. **Extension requests.** If the user asks to create/update an extension, generate code and use **extensions_manager** so it is installed directly.`;
 
 const CONVENTIONS = `## Conventions
 


### PR DESCRIPTION
Follow-up from the live `gpu-farm-doctor-01` post-#635 A/B.

## Why

Run5 on variant b (latest main after #635/#636/#632) was a strong improvement:

- `cells_match`: **35/35** (run4 was 27/35)
- target fixes: **3/3**
- Inputs no-mutation: PASS
- unintended formula edits: **1** (run4 was 31)

The one remaining strict-fail edit was a downstream statement subtotal:

```excel
Statements!I51: =SUM(I47:I49) -> =SUM(I47:I50)
```

It did not break the graded outputs, but it is outside the injected target fixes and shows the remaining behavior: after finding upstream root causes, the model can still touch a downstream reporting formula that looks suspicious.

## Change

Adds a workflow norm:

> In audit/repair tasks, treat downstream statements, summaries, and check rows as verification targets before editing them. Fix the upstream formula that clearly causes the discrepancy, then re-read downstream outputs. Only edit a downstream/reporting formula when it is demonstrably the root cause, not merely another place the error appears.

This is intentionally not spreadsheet-benchmark-specific: it is generally safer for real models too.

## Verification

- `npm run check`
- `npm run test:context` — 739 tests
