### PR TITLE
Revert root-cause prompt norm after live eval regression

### DIFF
--- a/src/prompt/system-prompt.ts
+++ b/src/prompt/system-prompt.ts
@@ -426,14 +426,13 @@ const WORKFLOW = `## Workflow
 
 1. **Read first.** Always read cells before modifying. Never guess what's in the spreadsheet.
 2. **Edit scope.** Make the smallest set of changes that fulfills the request. Do not rewrite, restructure, or restyle working formulas beyond what was asked. If cells outside the requested or necessary edit scope look suspicious, report them and ask before fixing. Before repointing a formula reference, verify the labels of both the old and new target rows/columns.
-3. **Fix root causes first.** In audit/repair tasks, treat downstream statements, summaries, and check rows as verification targets before editing them. Fix the upstream formula that clearly causes the discrepancy, then re-read downstream outputs. Only edit a downstream/reporting formula when it is demonstrably the root cause, not merely another place the error appears.
-4. **Verify writes.** write_cells auto-verifies and reports errors. If errors occur, diagnose and fix. After repairing or changing formulas, re-read the key downstream outputs and sanity-check that results moved as intended — and that nothing else moved.
-5. **Overwrite protection.** write_cells blocks if the target has data. Ask the user before setting allow_overwrite=true.
-6. **Prefer formulas** over hardcoded values. Put assumptions in separate cells and reference them.
-7. **Report changes.** When a turn mutated the workbook, end by listing exactly which cells/ranges you changed.
-8. **Plan complex tasks.** In Confirm mode, present a plan and get approval first. In Auto mode, keep plans concise and proceed unless the user asked to review first.
-9. **Analysis = read-only.** When the user asks about data, read and answer in chat. Only write when asked to modify.
-10. **Extension requests.** If the user asks to create/update an extension, generate code and use **extensions_manager** so it is installed directly.`;
+3. **Verify writes.** write_cells auto-verifies and reports errors. If errors occur, diagnose and fix. After repairing or changing formulas, re-read the key downstream outputs and sanity-check that results moved as intended — and that nothing else moved.
+4. **Overwrite protection.** write_cells blocks if the target has data. Ask the user before setting allow_overwrite=true.
+5. **Prefer formulas** over hardcoded values. Put assumptions in separate cells and reference them.
+6. **Report changes.** When a turn mutated the workbook, end by listing exactly which cells/ranges you changed.
+7. **Plan complex tasks.** In Confirm mode, present a plan and get approval first. In Auto mode, keep plans concise and proceed unless the user asked to review first.
+8. **Analysis = read-only.** When the user asks about data, read and answer in chat. Only write when asked to modify.
+9. **Extension requests.** If the user asks to create/update an extension, generate code and use **extensions_manager** so it is installed directly.`;
 
 const CONVENTIONS = `## Conventions
 


### PR DESCRIPTION
Reverts #638 based on immediate live-eval evidence.

## Why revert

#638 was intended to reduce the one remaining unintended downstream edit from run5. It instead regressed the doctor lane on the same hidden variant (`gpu-farm-doctor-01` variant b):

| Run | Prompt state | Accuracy | Target fixes | Inputs | Unintended edits | Strict |
|---|---|---:|---:|---:|---:|---:|
| run5 | #635 | **35/35** | 3/3 | PASS | **1** | FAIL |
| run6 | #635 + #638 | 27/35 | 3/3 | PASS | 26 | FAIL |

The #638 wording seems to have nudged the model back into broad upstream-looking formula repointing (`Calculations!I167:M171`, rows `118:122` -> `82:86`), which recreated the eight accuracy failures from run4.

## Action

Revert the #638 prompt norm and keep #635 as the best observed prompt state so far.

## Verification

- `npm run check`
- `npm run test:context` — 739 tests

Private eval artifacts:

- `_evals/runs/2026-07-08-run6-gpu-farm-doctor-01b-root-cause/report.md`
- local corpus commit `b0341fb`
