### PR TITLE
Reuse healthy default local proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The dev manifest points to `https://localhost:3141`. The production manifest (`m
 | `npm run test:models` | Unit tests — model ordering |
 | `npm run test:context` | Unit tests — tools, context, sessions, extensions, integrations |
 | `npm run test:security` | Security policy tests — proxy, CORS, sandbox, OAuth |
-| `npm run proxy:https` | CORS proxy for OAuth flows (default `https://localhost:3003`; auto-picks a random free port if the default is busy) |
+| `npm run proxy:https` | CORS proxy for OAuth flows (default `https://localhost:3003`; random port only if 3003 is busy and no healthy default proxy is already running) |
 | `npm run validate` | Validate the Office add-in manifest |
 
 ### CORS proxy
@@ -145,7 +145,7 @@ The dev manifest points to `https://localhost:3141`. The production manifest (`m
 Some OAuth token endpoints are blocked by CORS inside Office webviews. If OAuth login fails:
 
 1. User setup command: `npx pi-for-excel-proxy` (or `curl -fsSL https://piforexcel.com/proxy | sh` if Node is missing)
-2. Dev/source setup command: `npm run proxy:https` (defaults to `https://localhost:3003`; if 3003 is busy, copy the random port printed in the terminal)
+2. Dev/source setup command: `npm run proxy:https` (defaults to `https://localhost:3003`; if 3003 is busy for another service, copy the random port printed in the terminal)
 3. In Pi → `/settings` → **Proxy** → enable and set the printed URL
 4. Retry login
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -161,7 +161,7 @@ curl -fsSL https://piforexcel.com/proxy | sh
 
 2. In Pi, open `/settings` → **Proxy**:
    - enable **Proxy**
-   - set URL to the URL printed by the proxy (normally `https://localhost:3003`; if 3003 is busy, it will choose a random free port and print that URL)
+   - set URL to the URL printed by the proxy (normally `https://localhost:3003`; if 3003 is busy for another service, it will choose a random free port and print that URL)
 
 3. Retry OAuth login
 
@@ -182,7 +182,9 @@ Notes:
 - Keep the proxy URL on **HTTPS** (`https://...`), not HTTP.
 - API-key providers generally work without proxy.
 - The local proxy also starts loopback-only callback listeners for browser OAuth flows so ChatGPT (`http://localhost:1455/auth/callback`), Anthropic (`http://localhost:53692/callback`), Google Code Assist (`http://localhost:8085/oauth2callback`), and Google Antigravity (`http://localhost:51121/oauth-callback`) can capture browser callbacks automatically. If a port is busy, the affected login still works via the manual URL paste fallback.
-- If port `3003` is busy, `npx pi-for-excel-proxy` automatically chooses a random free port. Copy the printed `https://localhost:<port>` URL into `/settings` → **Proxy**.
+- `3141` is the add-in/dev-server port; the local proxy normally uses `3003`.
+- If a healthy proxy is already running on `3003`, `npx pi-for-excel-proxy` reports that and exits instead of starting a duplicate.
+- If port `3003` is busy for some other reason, `npx pi-for-excel-proxy` automatically chooses a random free port. Copy the printed `https://localhost:<port>` URL into `/settings` → **Proxy**.
 - To force a specific port, set `PORT` and use that same URL in settings:
 
 ```bash

--- a/pkg/proxy/README.md
+++ b/pkg/proxy/README.md
@@ -12,8 +12,9 @@ This command:
 
 1. Ensures `mkcert` exists (installs via Homebrew on macOS if missing)
 2. Creates certificates in `~/.pi-for-excel/certs/` when needed
-3. Starts the proxy at `https://localhost:3003`, or picks a random free port if 3003 is busy
-4. Starts loopback-only callback listeners for ChatGPT, Anthropic, and Google OAuth so supported logins can complete without copy/paste when possible
+3. Starts the proxy at `https://localhost:3003`, or reuses an already-running healthy proxy on that URL
+4. Picks a random free port only when 3003 is busy and no compatible default proxy is already running
+5. Starts loopback-only callback listeners for ChatGPT, Anthropic, and Google OAuth so supported logins can complete without copy/paste when possible
 
 Then in Pi for Excel:
 

--- a/pkg/proxy/cli.mjs
+++ b/pkg/proxy/cli.mjs
@@ -2,6 +2,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import https from "node:https";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -15,6 +16,8 @@ const appDir = path.join(homeDir, ".pi-for-excel");
 const certDir = path.join(appDir, "certs");
 const keyPath = path.join(certDir, "key.pem");
 const certPath = path.join(certDir, "cert.pem");
+const DEFAULT_PROXY_PORT = "3003";
+const DEFAULT_PROXY_URL = `https://localhost:${DEFAULT_PROXY_PORT}`;
 
 function commandExists(command) {
   const whichCommand = process.platform === "win32" ? "where" : "which";
@@ -164,6 +167,77 @@ function resolveProxyConfig() {
   };
 }
 
+function hasExplicitPort() {
+  return typeof process.env.PORT === "string" && process.env.PORT.trim().length > 0;
+}
+
+function probeHttpsHealth(urlString) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (healthy) => {
+      if (settled) return;
+      settled = true;
+      resolve(healthy);
+    };
+
+    const req = https.request(
+      urlString,
+      {
+        method: "GET",
+        rejectUnauthorized: false,
+        timeout: 800,
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+          if (body.length > 32) {
+            req.destroy();
+            finish(false);
+          }
+        });
+        res.on("end", () => {
+          finish(res.statusCode === 200 && body.trim() === "ok");
+        });
+      },
+    );
+
+    req.on("timeout", () => {
+      req.destroy();
+      finish(false);
+    });
+    req.on("error", () => finish(false));
+    req.end();
+  });
+}
+
+async function exitIfDefaultProxyAlreadyRunning(proxyConfig) {
+  if (!proxyConfig.usesHttps || hasExplicitPort()) {
+    return;
+  }
+
+  const [localhostHealthy, ipv4Healthy] = await Promise.all([
+    probeHttpsHealth(`${DEFAULT_PROXY_URL}/healthz`),
+    probeHttpsHealth(`https://127.0.0.1:${DEFAULT_PROXY_PORT}/healthz`),
+  ]);
+
+  if (localhostHealthy && ipv4Healthy) {
+    console.log(`[pi-for-excel-proxy] Proxy already running at ${DEFAULT_PROXY_URL}`);
+    console.log("[pi-for-excel-proxy] Nothing else to start — keep the existing proxy terminal open.");
+    process.exit(0);
+  }
+
+  if (localhostHealthy || ipv4Healthy) {
+    console.error("[pi-for-excel-proxy] Port 3003 has a partial/stale proxy listener.");
+    console.error(`[pi-for-excel-proxy] ${DEFAULT_PROXY_URL}/healthz: ${localhostHealthy ? "ok" : "failed"}`);
+    console.error(`[pi-for-excel-proxy] https://127.0.0.1:${DEFAULT_PROXY_PORT}/healthz: ${ipv4Healthy ? "ok" : "failed"}`);
+    console.error("[pi-for-excel-proxy] Stop old pi-for-excel proxy processes, then run npx pi-for-excel-proxy again.");
+    console.error("[pi-for-excel-proxy] Or set PORT=<free-port> and copy that URL into Pi for Excel /settings → Proxy.");
+    process.exit(1);
+  }
+}
+
 function startProxy(proxyArgs) {
   fs.mkdirSync(certDir, { recursive: true });
   console.log(`[pi-for-excel-proxy] Using certificate directory: ${certDir}`);
@@ -212,6 +286,7 @@ if (!fs.existsSync(proxyScriptPath)) {
 
 const proxyConfig = resolveProxyConfig();
 if (proxyConfig.usesHttps) {
+  await exitIfDefaultProxyAlreadyRunning(proxyConfig);
   ensureCertificates();
 }
 startProxy(proxyConfig.proxyArgs);

--- a/pkg/proxy/cli.mjs
+++ b/pkg/proxy/cli.mjs
@@ -18,6 +18,8 @@ const keyPath = path.join(certDir, "key.pem");
 const certPath = path.join(certDir, "cert.pem");
 const DEFAULT_PROXY_PORT = "3003";
 const DEFAULT_PROXY_URL = `https://localhost:${DEFAULT_PROXY_PORT}`;
+const PROXY_HEALTH_HEADER = "x-pi-for-excel-proxy";
+const PROXY_HEALTH_VALUE = "1";
 
 function commandExists(command) {
   const whichCommand = process.platform === "win32" ? "where" : "which";
@@ -59,7 +61,7 @@ function supportsMkcertCli(command) {
   return result.status === 0 && !result.signal;
 }
 
-function resolveMkcertCommand() {
+function getMkcertCommandCandidates() {
   const candidates = [];
 
   if (process.platform === "darwin") {
@@ -75,10 +77,23 @@ function resolveMkcertCommand() {
     candidates.push("mkcert");
   }
 
-  for (const candidate of candidates) {
+  return candidates;
+}
+
+function findMkcertCommand() {
+  for (const candidate of getMkcertCommandCandidates()) {
     if (supportsMkcertCli(candidate)) {
       return candidate;
     }
+  }
+
+  return null;
+}
+
+function resolveMkcertCommand() {
+  const existingCommand = findMkcertCommand();
+  if (existingCommand) {
+    return existingCommand;
   }
 
   if (process.platform === "darwin") {
@@ -171,20 +186,52 @@ function hasExplicitPort() {
   return typeof process.env.PORT === "string" && process.env.PORT.trim().length > 0;
 }
 
-function probeHttpsHealth(urlString) {
+function hasExplicitHost() {
+  return typeof process.env.HOST === "string" && process.env.HOST.trim().length > 0;
+}
+
+function readMkcertRootCa() {
+  const mkcertCommand = findMkcertCommand();
+  if (!mkcertCommand) {
+    return null;
+  }
+
+  const result = spawnSync(mkcertCommand, ["-CAROOT"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.error || result.status !== 0 || result.signal) {
+    return null;
+  }
+
+  const caRoot = result.stdout.trim();
+  if (!caRoot) {
+    return null;
+  }
+
+  const rootCaPath = path.join(caRoot, "rootCA.pem");
+  try {
+    return fs.readFileSync(rootCaPath);
+  } catch {
+    return null;
+  }
+}
+
+function probeHttpsHealth(urlString, trustedCa) {
   return new Promise((resolve) => {
     let settled = false;
-    const finish = (healthy) => {
+    const finish = (result) => {
       if (settled) return;
       settled = true;
-      resolve(healthy);
+      resolve(result);
     };
 
     const req = https.request(
       urlString,
       {
         method: "GET",
-        rejectUnauthorized: false,
+        ca: trustedCa,
+        servername: "localhost",
         timeout: 800,
       },
       (res) => {
@@ -194,44 +241,53 @@ function probeHttpsHealth(urlString) {
           body += chunk;
           if (body.length > 32) {
             req.destroy();
-            finish(false);
+            finish({ healthy: false, compatible: false });
           }
         });
         res.on("end", () => {
-          finish(res.statusCode === 200 && body.trim() === "ok");
+          const healthy = res.statusCode === 200 && body.trim() === "ok";
+          finish({
+            healthy,
+            compatible: healthy && res.headers[PROXY_HEALTH_HEADER] === PROXY_HEALTH_VALUE,
+          });
         });
       },
     );
 
     req.on("timeout", () => {
       req.destroy();
-      finish(false);
+      finish({ healthy: false, compatible: false });
     });
-    req.on("error", () => finish(false));
+    req.on("error", () => finish({ healthy: false, compatible: false }));
     req.end();
   });
 }
 
 async function exitIfDefaultProxyAlreadyRunning(proxyConfig) {
-  if (!proxyConfig.usesHttps || hasExplicitPort()) {
+  if (!proxyConfig.usesHttps || hasExplicitPort() || hasExplicitHost()) {
     return;
   }
 
-  const [localhostHealthy, ipv4Healthy] = await Promise.all([
-    probeHttpsHealth(`${DEFAULT_PROXY_URL}/healthz`),
-    probeHttpsHealth(`https://127.0.0.1:${DEFAULT_PROXY_PORT}/healthz`),
+  const trustedCa = readMkcertRootCa();
+  if (!trustedCa) {
+    return;
+  }
+
+  const [localhostProbe, ipv4Probe] = await Promise.all([
+    probeHttpsHealth(`${DEFAULT_PROXY_URL}/healthz`, trustedCa),
+    probeHttpsHealth(`https://127.0.0.1:${DEFAULT_PROXY_PORT}/healthz`, trustedCa),
   ]);
 
-  if (localhostHealthy && ipv4Healthy) {
+  if (localhostProbe.compatible && ipv4Probe.compatible) {
     console.log(`[pi-for-excel-proxy] Proxy already running at ${DEFAULT_PROXY_URL}`);
     console.log("[pi-for-excel-proxy] Nothing else to start — keep the existing proxy terminal open.");
     process.exit(0);
   }
 
-  if (localhostHealthy || ipv4Healthy) {
-    console.error("[pi-for-excel-proxy] Port 3003 has a partial/stale proxy listener.");
-    console.error(`[pi-for-excel-proxy] ${DEFAULT_PROXY_URL}/healthz: ${localhostHealthy ? "ok" : "failed"}`);
-    console.error(`[pi-for-excel-proxy] https://127.0.0.1:${DEFAULT_PROXY_PORT}/healthz: ${ipv4Healthy ? "ok" : "failed"}`);
+  if (localhostProbe.compatible || ipv4Probe.compatible) {
+    console.error("[pi-for-excel-proxy] Port 3003 has a partial/stale pi-for-excel proxy listener.");
+    console.error(`[pi-for-excel-proxy] ${DEFAULT_PROXY_URL}/healthz: ${localhostProbe.compatible ? "compatible" : "failed"}`);
+    console.error(`[pi-for-excel-proxy] https://127.0.0.1:${DEFAULT_PROXY_PORT}/healthz: ${ipv4Probe.compatible ? "compatible" : "failed"}`);
     console.error("[pi-for-excel-proxy] Stop old pi-for-excel proxy processes, then run npx pi-for-excel-proxy again.");
     console.error("[pi-for-excel-proxy] Or set PORT=<free-port> and copy that URL into Pi for Excel /settings → Proxy.");
     process.exit(1);

--- a/pkg/proxy/cli.mjs
+++ b/pkg/proxy/cli.mjs
@@ -61,7 +61,7 @@ function supportsMkcertCli(command) {
   return result.status === 0 && !result.signal;
 }
 
-function getMkcertCommandCandidates() {
+function findMkcertCommand() {
   const candidates = [];
 
   if (process.platform === "darwin") {
@@ -77,11 +77,7 @@ function getMkcertCommandCandidates() {
     candidates.push("mkcert");
   }
 
-  return candidates;
-}
-
-function findMkcertCommand() {
-  for (const candidate of getMkcertCommandCandidates()) {
+  for (const candidate of candidates) {
     if (supportsMkcertCli(candidate)) {
       return candidate;
     }
@@ -182,41 +178,6 @@ function resolveProxyConfig() {
   };
 }
 
-function hasExplicitPort() {
-  return typeof process.env.PORT === "string" && process.env.PORT.trim().length > 0;
-}
-
-function hasExplicitHost() {
-  return typeof process.env.HOST === "string" && process.env.HOST.trim().length > 0;
-}
-
-function readMkcertRootCa() {
-  const mkcertCommand = findMkcertCommand();
-  if (!mkcertCommand) {
-    return null;
-  }
-
-  const result = spawnSync(mkcertCommand, ["-CAROOT"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  if (result.error || result.status !== 0 || result.signal) {
-    return null;
-  }
-
-  const caRoot = result.stdout.trim();
-  if (!caRoot) {
-    return null;
-  }
-
-  const rootCaPath = path.join(caRoot, "rootCA.pem");
-  try {
-    return fs.readFileSync(rootCaPath);
-  } catch {
-    return null;
-  }
-}
-
 function probeHttpsHealth(urlString, trustedCa) {
   return new Promise((resolve) => {
     let settled = false;
@@ -264,12 +225,34 @@ function probeHttpsHealth(urlString, trustedCa) {
 }
 
 async function exitIfDefaultProxyAlreadyRunning(proxyConfig) {
-  if (!proxyConfig.usesHttps || hasExplicitPort() || hasExplicitHost()) {
+  const portWasRequested = typeof process.env.PORT === "string" && process.env.PORT.trim().length > 0;
+  const hostWasRequested = typeof process.env.HOST === "string" && process.env.HOST.trim().length > 0;
+  if (!proxyConfig.usesHttps || portWasRequested || hostWasRequested) {
     return;
   }
 
-  const trustedCa = readMkcertRootCa();
-  if (!trustedCa) {
+  const mkcertCommand = findMkcertCommand();
+  if (!mkcertCommand) {
+    return;
+  }
+
+  const caRootResult = spawnSync(mkcertCommand, ["-CAROOT"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (caRootResult.error || caRootResult.status !== 0 || caRootResult.signal) {
+    return;
+  }
+
+  const caRoot = caRootResult.stdout.trim();
+  if (!caRoot) {
+    return;
+  }
+
+  let trustedCa;
+  try {
+    trustedCa = fs.readFileSync(path.join(caRoot, "rootCA.pem"));
+  } catch {
     return;
   }
 

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -559,6 +559,7 @@ const handler = async (req, res) => {
     }
     res.statusCode = 200;
     res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.setHeader("X-Pi-For-Excel-Proxy", "1");
     res.end("ok");
     return;
   }

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -751,21 +751,10 @@ function createProxyServer() {
   );
 }
 
-function getListeningPort(server, fallbackPort) {
-  const address = server.address();
-  if (address && typeof address !== "string") {
-    return address.port;
-  }
-  return fallbackPort;
-}
-
-function formatHostForUrl(host) {
-  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
-}
-
 function logStartup(listeningPort, listeningHosts) {
   const scheme = useHttps ? "https" : "http";
-  const proxyUrl = `${scheme}://${formatHostForUrl(HOST)}:${listeningPort}`;
+  const formattedHost = HOST.includes(":") && !HOST.startsWith("[") ? `[${HOST}]` : HOST;
+  const proxyUrl = `${scheme}://${formattedHost}:${listeningPort}`;
   console.log(`[pi-for-excel] CORS proxy listening on ${proxyUrl}`);
   if (listeningHosts.length > 1) {
     console.log(`[pi-for-excel] Listening on loopback addresses: ${listeningHosts.join(", ")}`);
@@ -860,16 +849,6 @@ function listenOAuthCallbackServers() {
   }
 }
 
-function isAddressInUse(error) {
-  return typeof error?.code === "string" && error.code === "EADDRINUSE";
-}
-
-function isOptionalLoopbackUnavailable(error) {
-  if (hasExplicitHost) return false;
-  const code = typeof error?.code === "string" ? error.code : "";
-  return code === "EAFNOSUPPORT" || code === "EADDRNOTAVAIL";
-}
-
 function closeServer(server) {
   return new Promise((resolve) => {
     try {
@@ -878,10 +857,6 @@ function closeServer(server) {
       resolve();
     }
   });
-}
-
-async function closeServerEntries(entries) {
-  await Promise.all(entries.map((entry) => closeServer(entry.server)));
 }
 
 function listenServer(server, port, host) {
@@ -912,52 +887,50 @@ function listenServer(server, port, host) {
   });
 }
 
-async function listenOnHosts(port) {
+async function listen(port) {
   const entries = [];
   const skippedHosts = [];
   let selectedPort = port;
 
-  for (const host of LISTEN_HOSTS) {
-    const server = createProxyServer();
-    try {
-      await listenServer(server, selectedPort, host);
-    } catch (error) {
-      await closeServer(server);
-      if (isOptionalLoopbackUnavailable(error)) {
-        skippedHosts.push(host);
-        continue;
-      }
-      await closeServerEntries(entries);
-      throw error;
-    }
-
-    const actualPort = getListeningPort(server, selectedPort);
-    if (selectedPort === 0) {
-      selectedPort = actualPort;
-    }
-    entries.push({ server, host, port: actualPort });
-  }
-
-  if (entries.length === 0) {
-    throw new Error(
-      skippedHosts.length > 0
-        ? `No loopback listen addresses were available (${skippedHosts.join(", ")})`
-        : "No listen addresses were configured",
-    );
-  }
-
-  return { entries, listeningPort: selectedPort, skippedHosts };
-}
-
-async function listen(port) {
   try {
-    const { entries, listeningPort, skippedHosts } = await listenOnHosts(port);
+    for (const host of LISTEN_HOSTS) {
+      const server = createProxyServer();
+      try {
+        await listenServer(server, selectedPort, host);
+      } catch (error) {
+        await closeServer(server);
+        const code = typeof error?.code === "string" ? error.code : "";
+        if (!hasExplicitHost && (code === "EAFNOSUPPORT" || code === "EADDRNOTAVAIL")) {
+          skippedHosts.push(host);
+          continue;
+        }
+        await Promise.all(entries.map((entry) => closeServer(entry.server)));
+        throw error;
+      }
+
+      const address = server.address();
+      const actualPort = address && typeof address !== "string" ? address.port : selectedPort;
+      if (selectedPort === 0) {
+        selectedPort = actualPort;
+      }
+      entries.push({ server, host, port: actualPort });
+    }
+
+    if (entries.length === 0) {
+      throw new Error(
+        skippedHosts.length > 0
+          ? `No loopback listen addresses were available (${skippedHosts.join(", ")})`
+          : "No listen addresses were configured",
+      );
+    }
+
     if (skippedHosts.length > 0) {
       console.warn(`[pi-for-excel] Skipped unavailable loopback addresses: ${skippedHosts.join(", ")}`);
     }
-    logStartup(listeningPort, entries.map((entry) => entry.host));
+    logStartup(selectedPort, entries.map((entry) => entry.host));
   } catch (error) {
-    if (isAddressInUse(error) && !hasExplicitPort && port === DEFAULT_PORT) {
+    const code = typeof error?.code === "string" ? error.code : "";
+    if (code === "EADDRINUSE" && !hasExplicitPort && port === DEFAULT_PORT) {
       console.warn(`[pi-for-excel] Port ${DEFAULT_PORT} is already in use; choosing a random available port instead.`);
       await listen(0);
       return;

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -48,7 +48,13 @@ if (useHttps && useHttp) {
 }
 
 const DEFAULT_PORT = 3003;
-const HOST = process.env.HOST || (useHttps ? "localhost" : "127.0.0.1");
+const hasExplicitHost = typeof process.env.HOST === "string" && process.env.HOST.trim().length > 0;
+const HOST = hasExplicitHost ? process.env.HOST.trim() : (useHttps ? "localhost" : "127.0.0.1");
+const LISTEN_HOSTS = hasExplicitHost
+  ? [HOST]
+  : useHttps
+    ? ["127.0.0.1", "::1"]
+    : [HOST];
 const hasExplicitPort = typeof process.env.PORT === "string" && process.env.PORT.trim().length > 0;
 
 function parsePort(rawPort) {
@@ -541,9 +547,16 @@ const handler = async (req, res) => {
   }
 
   // Health endpoint for load balancers / monitoring. Sits after the client
-  // address check but before origin enforcement (health checks send no
-  // Origin header). Never proxies anything.
+  // address check but before origin enforcement (health checks often send no
+  // Origin header). Browser-based status probes still need CORS headers when
+  // they come from an allowed add-in origin. Never proxies anything.
   if ((req.url || "").split("?")[0] === "/healthz") {
+    setCorsHeaders(req, res);
+    if (req.method === "OPTIONS") {
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
     res.statusCode = 200;
     res.setHeader("Content-Type", "text/plain; charset=utf-8");
     res.end("ok");
@@ -714,7 +727,7 @@ const handler = async (req, res) => {
   }
 };
 
-const server = (() => {
+function createProxyServer() {
   if (!useHttps) {
     return http.createServer(handler);
   }
@@ -735,9 +748,9 @@ const server = (() => {
     },
     handler,
   );
-})();
+}
 
-function getListeningPort(fallbackPort) {
+function getListeningPort(server, fallbackPort) {
   const address = server.address();
   if (address && typeof address !== "string") {
     return address.port;
@@ -745,10 +758,17 @@ function getListeningPort(fallbackPort) {
   return fallbackPort;
 }
 
-function logStartup(listeningPort) {
+function formatHostForUrl(host) {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+function logStartup(listeningPort, listeningHosts) {
   const scheme = useHttps ? "https" : "http";
-  const proxyUrl = `${scheme}://${HOST}:${listeningPort}`;
+  const proxyUrl = `${scheme}://${formatHostForUrl(HOST)}:${listeningPort}`;
   console.log(`[pi-for-excel] CORS proxy listening on ${proxyUrl}`);
+  if (listeningHosts.length > 1) {
+    console.log(`[pi-for-excel] Listening on loopback addresses: ${listeningHosts.join(", ")}`);
+  }
   console.log(`[pi-for-excel] Format: ${proxyUrl}/?url=<target-url>`);
   if (listeningPort !== DEFAULT_PORT) {
     console.log(`[pi-for-excel] Update Pi for Excel /settings → Proxy URL to ${proxyUrl}`);
@@ -839,41 +859,117 @@ function listenOAuthCallbackServers() {
   }
 }
 
-function listen(port) {
-  let cleanedUp = false;
-  const cleanup = () => {
-    if (cleanedUp) return;
-    cleanedUp = true;
-    server.off("error", onError);
-    server.off("listening", onListening);
-  };
+function isAddressInUse(error) {
+  return typeof error?.code === "string" && error.code === "EADDRINUSE";
+}
 
-  const onError = (err) => {
-    cleanup();
+function isOptionalLoopbackUnavailable(error) {
+  if (hasExplicitHost) return false;
+  const code = typeof error?.code === "string" ? error.code : "";
+  return code === "EAFNOSUPPORT" || code === "EADDRNOTAVAIL";
+}
 
-    if (err?.code === "EADDRINUSE" && !hasExplicitPort && port === DEFAULT_PORT) {
+function closeServer(server) {
+  return new Promise((resolve) => {
+    try {
+      server.close(() => resolve());
+    } catch {
+      resolve();
+    }
+  });
+}
+
+async function closeServerEntries(entries) {
+  await Promise.all(entries.map((entry) => closeServer(entry.server)));
+}
+
+function listenServer(server, port, host) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      server.off("error", onError);
+      server.off("listening", onListening);
+    };
+
+    const onError = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const onListening = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+}
+
+async function listenOnHosts(port) {
+  const entries = [];
+  const skippedHosts = [];
+  let selectedPort = port;
+
+  for (const host of LISTEN_HOSTS) {
+    const server = createProxyServer();
+    try {
+      await listenServer(server, selectedPort, host);
+    } catch (error) {
+      await closeServer(server);
+      if (isOptionalLoopbackUnavailable(error)) {
+        skippedHosts.push(host);
+        continue;
+      }
+      await closeServerEntries(entries);
+      throw error;
+    }
+
+    const actualPort = getListeningPort(server, selectedPort);
+    if (selectedPort === 0) {
+      selectedPort = actualPort;
+    }
+    entries.push({ server, host, port: actualPort });
+  }
+
+  if (entries.length === 0) {
+    throw new Error(
+      skippedHosts.length > 0
+        ? `No loopback listen addresses were available (${skippedHosts.join(", ")})`
+        : "No listen addresses were configured",
+    );
+  }
+
+  return { entries, listeningPort: selectedPort, skippedHosts };
+}
+
+async function listen(port) {
+  try {
+    const { entries, listeningPort, skippedHosts } = await listenOnHosts(port);
+    if (skippedHosts.length > 0) {
+      console.warn(`[pi-for-excel] Skipped unavailable loopback addresses: ${skippedHosts.join(", ")}`);
+    }
+    logStartup(listeningPort, entries.map((entry) => entry.host));
+  } catch (error) {
+    if (isAddressInUse(error) && !hasExplicitPort && port === DEFAULT_PORT) {
       console.warn(`[pi-for-excel] Port ${DEFAULT_PORT} is already in use; choosing a random available port instead.`);
-      listen(0);
+      await listen(0);
       return;
     }
 
-    const message = err instanceof Error ? err.message : String(err);
+    const message = error instanceof Error ? error.message : String(error);
     console.error(`[pi-for-excel] Failed to listen on ${HOST}:${port}: ${message}`);
     if (hasExplicitPort) {
       console.error("[pi-for-excel] Choose a different port with PORT=0 (random) or PORT=<port>.");
     }
     process.exit(1);
-  };
-
-  const onListening = () => {
-    cleanup();
-    logStartup(getListeningPort(port));
-  };
-
-  server.once("error", onError);
-  server.once("listening", onListening);
-  server.listen(port, HOST);
+  }
 }
 
-listen(PORT);
+await listen(PORT);
 listenOAuthCallbackServers();

--- a/src/taskpane/proxy-status.ts
+++ b/src/taskpane/proxy-status.ts
@@ -5,7 +5,7 @@
  * dispatches a custom event so UI surfaces can react.
  */
 
-import { DEFAULT_PROXY_URL } from "../auth/proxy-validation.js";
+import { DEFAULT_PROXY_URL, normalizeProxyUrl } from "../auth/proxy-validation.js";
 
 const CHECK_INTERVAL_MS = 30_000;
 const CHECK_TIMEOUT_MS = 1_500;
@@ -24,14 +24,12 @@ async function probeProxy(proxyUrl: string): Promise<boolean> {
   const timeout = setTimeout(() => controller.abort(), CHECK_TIMEOUT_MS);
 
   try {
-    // Probe without a ?url= parameter — the proxy returns 400 ("Missing target"),
-    // which proves it's running. This avoids hitting the target allowlist.
-    const url = `${proxyUrl.replace(/\/+$/, "")}/`;
-    const resp = await fetch(url, { method: "HEAD", signal: controller.signal });
-    // Any response (200, 400, 404) proves the proxy is reachable.
-    // Only network errors (fetch throws) indicate it's not running.
-    void resp;
-    return true;
+    // Health never proxies upstream data and includes CORS headers for allowed
+    // add-in origins, so status detection does not depend on target allowlists
+    // or a browser accepting an error response body from `/`.
+    const url = `${normalizeProxyUrl(proxyUrl)}/healthz`;
+    const resp = await fetch(url, { cache: "no-store", signal: controller.signal });
+    return resp.ok;
   } catch {
     return false;
   } finally {

--- a/tests/cors-proxy-server.security.test.mjs
+++ b/tests/cors-proxy-server.security.test.mjs
@@ -516,6 +516,7 @@ test("proxy /healthz responds without an Origin header and never proxies", async
 
   const health = await fetch(`http://127.0.0.1:${proxy.port}/healthz`);
   assert.equal(health.status, 200);
+  assert.equal(health.headers.get("x-pi-for-excel-proxy"), "1");
   assert.equal(await health.text(), "ok");
 
   const browserHealth = await fetch(`http://127.0.0.1:${proxy.port}/healthz`, {
@@ -523,6 +524,7 @@ test("proxy /healthz responds without an Origin header and never proxies", async
   });
   assert.equal(browserHealth.status, 200);
   assert.equal(browserHealth.headers.get("access-control-allow-origin"), ORIGIN);
+  assert.equal(browserHealth.headers.get("x-pi-for-excel-proxy"), "1");
   assert.equal(await browserHealth.text(), "ok");
 
   // Query strings (including ?url=) must not turn /healthz into a proxy path.

--- a/tests/cors-proxy-server.security.test.mjs
+++ b/tests/cors-proxy-server.security.test.mjs
@@ -518,6 +518,13 @@ test("proxy /healthz responds without an Origin header and never proxies", async
   assert.equal(health.status, 200);
   assert.equal(await health.text(), "ok");
 
+  const browserHealth = await fetch(`http://127.0.0.1:${proxy.port}/healthz`, {
+    headers: { Origin: ORIGIN },
+  });
+  assert.equal(browserHealth.status, 200);
+  assert.equal(browserHealth.headers.get("access-control-allow-origin"), ORIGIN);
+  assert.equal(await browserHealth.text(), "ok");
+
   // Query strings (including ?url=) must not turn /healthz into a proxy path.
   const withUrl = await fetch(
     `http://127.0.0.1:${proxy.port}/healthz?url=${encodeURIComponent("https://api.openai.com/")}`,


### PR DESCRIPTION
Proxy startup/reachability improvements plus compatibility hardening.\n\nSummary:\n- probe /healthz from the taskpane proxy status checker\n- add CORS headers to /healthz for allowed add-in origins\n- have the packaged proxy helper exit cleanly if a healthy compatible default proxy already runs on 3003\n- bind HTTPS proxy to both IPv4 and IPv6 loopback addresses by default\n- add an identifying X-Pi-For-Excel-Proxy health marker so unrelated local services returning 'ok' are not mistaken for the proxy\n- skip default-proxy reuse preflight when HOST or PORT is explicitly set\n- inline one-off startup helpers to avoid premature abstraction\n- update docs around default proxy reuse vs random fallback ports\n\nValidation:\n- npm run test:security -- --runInBand\n- git diff --check\n- node --check pkg/proxy/cli.mjs\n- node --check scripts/cors-proxy-server.mjs\n- pre-commit npm run check