### PR TITLE
Add real Excel adversarial extension provider coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This folder contains **current** docs that should match shipped behavior.
 - [Dev server behind portless (opt-in)](./portless.md)
 - [Release notes (`v0.10.0-pre`)](./release-notes/v0.10.0-pre.md)
 - [Release smoke test checklist](./release-smoke-test-checklist.md)
+- [Adversarial extension-provider smoke](./adversarial-extension-provider-smoke.md)
 - [Release smoke run logs](./release-smoke-runs/README.md)
 
 ## Runtime features

--- a/docs/adversarial-extension-provider-smoke.md
+++ b/docs/adversarial-extension-provider-smoke.md
@@ -1,0 +1,66 @@
+# Adversarial extension-provider smoke
+
+This smoke verifies the complete model-provider path exposed to pasted extensions. It does not use a built-in provider.
+
+The scenario runs inside a real Excel taskpane. It installs inline code through `ExtensionRuntimeManager.installFromCode()`, which routes the extension into the sandbox iframe runtime. It then uses the same host connection store, dynamic model runtime, selector and chat stream as the taskpane UI.
+
+## Coverage
+
+The runner starts two instrumented HTTPS OpenAI-compatible gateways and verifies:
+
+- default permission denial, followed by explicit `connections.readwrite` and `models.register` grants
+- real sandbox iframe activation from pasted extension code
+- owner-qualified connection and provider IDs
+- host-owned credential injection for discovery and inference
+- denial of `connections.getSecrets()` inside the sandbox
+- dynamic `/models` discovery and exact streamed completions
+- cached operation when `/models` returns an outage
+- rejection of oversized catalogues without replacing the last safe cache
+- endpoint upgrades with the same extension/provider ID, including cache rebinding from gateway A to gateway B
+- no new credential or request reaches gateway A after the staged cutover
+- safe provider fallback after the extension unloads during an in-flight completion
+- cancellation of delayed discovery during unload, so a late response cannot resurrect deleted catalogue data
+- rejection when a provider endpoint host is outside the owning connection's exact allowlist
+
+The gateways compare credentials internally but never print them. The taskpane bridge compares exact assistant text and returns only the match result and lengths.
+
+## Run it
+
+The worktree needs trusted local `cert.pem` and `key.pem` files. Start the normal dev taskpane and tokened background bridge:
+
+```bash
+export PI_BACKGROUND_VERIFY_TOKEN="$(openssl rand -hex 24)"
+export PI_BACKGROUND_VERIFY_HOST=localhost
+
+npm run background:verify:bridge
+```
+
+In another terminal, start Vite with the same token:
+
+```bash
+VITE_PI_BACKGROUND_VERIFY_URL=https://localhost:3157 \
+VITE_PI_BACKGROUND_VERIFY_TOKEN="$PI_BACKGROUND_VERIFY_TOKEN" \
+npm run dev
+```
+
+Start the local proxy with an explicit localhost-only target policy. These loopback overrides are for this local smoke only; do not use them on a shared proxy:
+
+```bash
+ALLOWED_TARGET_HOSTS=localhost \
+ALLOW_LOOPBACK_TARGETS=1 \
+NODE_EXTRA_CA_CERTS="$HOME/Library/Application Support/mkcert/rootCA.pem" \
+npm run proxy:https
+```
+
+Sideload/open the add-in in Excel, wait for the background bridge client, then run:
+
+```bash
+PI_BACKGROUND_VERIFY_TOKEN="$PI_BACKGROUND_VERIFY_TOKEN" \
+PI_BACKGROUND_VERIFY_HOST=localhost \
+NODE_EXTRA_CA_CERTS="$HOME/Library/Application Support/mkcert/rootCA.pem" \
+npm run smoke:extension-provider
+```
+
+The mock gateways use ports `3161` and `3162`. The runner removes its extensions and resets the permission-gate experiment in a `finally` block.
+
+A successful run prints one bounded JSON summary with `"ok": true` and no credential values.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -148,6 +148,8 @@ The host owner-qualifies provider ids (`acme` becomes `ext.<extension-id>.acme`)
 
 Credentials remain host-owned. The extension declares which connection secret contains the API key, but discovery and model requests read it inside the host. The provider's `baseUrl` and `modelsUrl` hosts must both appear in the connection's exact `httpAuth.allowedHosts` list. Extensions cannot supply custom stream handlers. Cached discovery results are rebound to the provider's current API and base URL before use, so an endpoint change cannot reuse stale transport headers or route a new credential to the previous host.
 
+Dynamic catalogue responses are limited to 2 MiB, 2,000 entries and 256 characters per model ID. Rejected or unavailable refreshes retain the last safe catalogue and configured baseline. Unloading a provider aborts its in-flight discovery before cache deletion so a delayed response cannot restore stale data.
+
 ```ts
 export function activate(api) {
   api.connections.register({

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -15,8 +15,9 @@ This doc describes how to update:
 - **Built-in model IDs:** `node_modules/@earendil-works/pi-ai/dist/models.generated.js`, exposed through `builtinProviders()`.
 - **Runtime lookup and streaming:** the taskpane-owned `BrowserModelRuntime`, backed by Pi AI's `createModels()` collection.
 - **Dynamic catalogue cache:** IndexedDB store `model-catalogs`, accessed through `ModelCatalogsStore`; restored entries are rebound to the provider's current API/base URL before use.
+- **Discovery bounds:** responses are limited to 2 MiB, 2,000 entries and 256 characters per model ID. An invalid/oversized refresh leaves the last safe cache and configured baseline intact.
 - **Custom gateways:** baseline models remain in `CustomProvidersStore`; `/models` discovery overlays them without deleting the configured fallback model.
-- **Extension providers:** `api.models.registerProvider()` declarations are runtime-owned and unload with their extension.
+- **Extension providers:** `api.models.registerProvider()` declarations are runtime-owned and unload with their extension. Unregistering aborts in-flight discovery before deleting its cache so late responses cannot resurrect stale entries.
 
 Do not use Pi coding-agent's Node/file `ModelRuntime` directly in the Office WebView. Pi for Excel uses the same Pi AI provider primitives with browser storage, OAuth and proxy policy. Cross-check the installed Pi package and changelog when the generated registry changes. Never infer aliases or metadata from marketing names.
 

--- a/docs/release-notes/v0.10.0-pre.md
+++ b/docs/release-notes/v0.10.0-pre.md
@@ -5,7 +5,7 @@ _Pre-release. Changes since `v0.9.5-pre`._
 ## Snapshot since the previous tag
 
 - Previous release tag: `v0.9.5-pre` (`876162a`, 2026-06-13)
-- This release includes **56 first-parent commits** after the release PR is squash-merged to `main`
+- This release includes **58 first-parent commits** after the release PR is squash-merged to `main`
 - This is a **minor pre-release bump** because the accumulated release includes broad UI, localization, platform, tool, auth, and model-capability work
 
 ## Highlights
@@ -20,6 +20,7 @@ _Pre-release. Changes since `v0.9.5-pre`._
   - Replaced Pi AI's temporary global `/compat` registry with an injected `createModels()` runtime shared by model selection, session restore, extension side-completions and streaming.
   - Added IndexedDB-backed dynamic catalogues. Custom OpenAI-compatible gateways restore cached models at startup and refresh `/models` in the background while retaining their configured baseline model.
   - Added declarative `api.models.registerProvider()` support for extensions. Provider credentials stay in host-owned connections; extension providers unload cleanly and cannot supply arbitrary stream handlers.
+  - Added a real-Excel adversarial sandbox-provider smoke. It caught and fixed an invalid generated sandbox bootstrap, unbounded discovery catalogues, stale endpoint metadata on same-ID reselection, post-turn reconciliation after in-flight unload, and delayed discovery writes after unregister.
 
 - **First-party taskpane UI and Simplified Chinese**
   - Replaced the remaining shared `pi-web-ui`/mini-lit/Tailwind surfaces with first-party message, model-selector, provider, storage, and settings UI.
@@ -76,6 +77,7 @@ A real Excel for Mac pass on a new blank workbook completed all three canonical 
 - Real macOS Excel taskpane on a new blank workbook: exact Sol, Terra, and Luna rows selected and activated with canonical display names, 372k context, and 128k maximum output
 - Real macOS Excel completion: Sol, Terra, and Luna each returned its fixed sentinel with `stopReason=stop`; Luna used the proxy's native-compatible Codex WebSocket bridge
 - Real Office.js scratch write/read/formula check completed and restored the blank fixture; Excel stayed in the background throughout
+- Real Excel sandbox extension-provider adversarial smoke passed permission gates, host-owned credential injection, exact inference, offline cache fallback, endpoint rebinding, in-flight unload, delayed discovery cancellation, catalogue bounds and host-allowlist rejection
 
 ## Version rationale
 

--- a/docs/release-smoke-runs/2026-07-16-macos-extension-provider.md
+++ b/docs/release-smoke-runs/2026-07-16-macos-extension-provider.md
@@ -1,0 +1,56 @@
+# macOS adversarial extension-provider smoke — 2026-07-16
+
+## Build and environment
+
+- Commit: `d7bba2f` (`test/adversarial-extension-provider`)
+- Host: Microsoft Excel for Mac, real Office.js taskpane
+- Taskpane: `https://localhost:3141/src/taskpane.html`
+- Background verification bridge: token-authenticated loopback HTTPS on `3157`
+- CORS proxy: loopback HTTPS on `3003`, explicitly restricted to target host `localhost`
+- Instrumented model gateways: HTTPS ports `3161` and `3162`
+- Runtime: pasted inline extension in `sandbox-iframe` mode
+
+## Result
+
+Overall: **Pass**
+
+Command:
+
+```bash
+npm run smoke:extension-provider
+```
+
+The runner completed with `"ok": true`. It installed pasted code through the real extension manager, granted capabilities through the persisted permission path, configured a host-owned connection, selected the discovered extension model in the real model selector and completed four exact streamed responses:
+
+- `EXTENSION_PROVIDER_A_OK`
+- `EXTENSION_PROVIDER_CACHE_OK`
+- `EXTENSION_PROVIDER_B_OK`
+- `EXTENSION_PROVIDER_DELAYED_OK`
+
+## Focused checklist evidence
+
+| Checklist | Result | Evidence |
+|---|---|---|
+| C-5 self-extension flow | Pass | Inline code activated in the sandbox iframe; owner-qualified provider appeared in the real selector and completed inference. |
+| H-1 error paths | Pass | Permission denials, discovery outage, oversized catalogue, endpoint upgrade, in-flight unload and delayed discovery race all reached deterministic recovery states. |
+| H-3 proxy/security boundaries | Pass | Both discovery and inference received host-injected test credentials; sandbox secret reads were denied; the old gateway never received the replacement credential; a non-allowlisted endpoint host was rejected. |
+| H-4 storage/cache tolerance | Pass | Last safe catalogue survived an outage and oversized refresh; cached model metadata rebound to gateway B; an aborted late response did not resurrect deleted cache data. |
+
+## Defects found by the adversarial run
+
+The initial run exposed five real failures that narrower mocked tests had not covered:
+
+1. Generated sandbox bootstrap JavaScript contained an unescaped newline and did not execute in Excel.
+2. Dynamic discovery accepted unbounded response and model-list sizes.
+3. Selecting the same provider/model ID after an endpoint upgrade retained stale session transport metadata.
+4. Unloading a provider during an in-flight turn left that removed provider selected after the turn.
+5. A delayed discovery response could write its catalogue after provider unregister/cache deletion.
+
+The tested commit fixes each failure and adds focused regression coverage.
+
+## Cleanup
+
+- Probe and hostile-test extensions uninstalled.
+- Permission-gate experiment reset.
+- Active runtime reconciled to `openai-codex/gpt-5.6-sol`.
+- No test credential values were printed by the runner.

--- a/docs/release-smoke-runs/README.md
+++ b/docs/release-smoke-runs/README.md
@@ -21,6 +21,7 @@ Keep each run append-only; create a new file for each run instead of rewriting o
 
 ## Recent focused runs
 
+- [`2026-07-16-macos-extension-provider.md`](./2026-07-16-macos-extension-provider.md) — real Excel sandbox provider registration, credentials, cache, races and teardown.
 - [`2026-07-10-macos-gpt-5-6.md`](./2026-07-10-macos-gpt-5-6.md) — GPT-5.6 discovery, thinking UI, and real Excel taskpane verification.
 
 ## Templates

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "python:bridge:https": "node scripts/python-bridge-server.mjs --https",
     "background:verify:bridge": "node scripts/background-verify-bridge-server.mjs serve",
     "background:verify:command": "node scripts/background-verify-bridge-server.mjs command",
+    "smoke:extension-provider": "node scripts/adversarial-extension-provider-smoke.mjs",
     "serve:dist": "node scripts/serve-dist-https.mjs",
     "manifest:prod": "node scripts/generate-manifest.mjs",
     "manifest:dev": "node scripts/generate-dev-manifest.mjs",

--- a/scripts/adversarial-extension-provider-smoke.mjs
+++ b/scripts/adversarial-extension-provider-smoke.mjs
@@ -1,0 +1,824 @@
+#!/usr/bin/env node
+
+/**
+ * Real-host adversarial smoke for sandbox extension model providers.
+ *
+ * Prerequisites:
+ * - Excel has the dev add-in loaded from https://localhost:3141.
+ * - The tokened background verification bridge is connected on port 3157.
+ * - The local CORS proxy is running on https://localhost:3003 with localhost
+ *   explicitly allowlisted as a target.
+ *
+ * The script starts two instrumented HTTPS model gateways, installs pasted
+ * extension code into the real sandbox iframe runtime, and drives the same
+ * manager/connection/model-selector/chat paths used by the taskpane UI.
+ */
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { setTimeout as delay } from "node:timers/promises";
+
+const BRIDGE_HOST = process.env.PI_BACKGROUND_VERIFY_HOST || "localhost";
+const BRIDGE_PORT = Number.parseInt(process.env.PI_BACKGROUND_VERIFY_PORT || "3157", 10);
+const TOKEN = (process.env.PI_BACKGROUND_VERIFY_TOKEN || "").trim();
+const CERT_PATH = path.resolve(process.env.TLS_CERT_PATH || "cert.pem");
+const KEY_PATH = path.resolve(process.env.TLS_KEY_PATH || "key.pem");
+const GATEWAY_A_PORT = 3161;
+const GATEWAY_B_PORT = 3162;
+const PROBE_NAME = "Adversarial extension provider probe";
+const HOST_SECRET_A = "pi-extension-test-alpha";
+const HOST_SECRET_B = "pi-extension-test-bravo";
+const HOST_SECRET_C = "pi-extension-test-charlie";
+const MODEL_A = "adversarial-model-a";
+const BASELINE_A = "adversarial-baseline-a";
+const BASELINE_B = "adversarial-baseline-b";
+const SENTINEL_A = "EXTENSION_PROVIDER_A_OK";
+const SENTINEL_CACHE = "EXTENSION_PROVIDER_CACHE_OK";
+const SENTINEL_B = "EXTENSION_PROVIDER_B_OK";
+const SENTINEL_DELAYED = "EXTENSION_PROVIDER_DELAYED_OK";
+const DISCOVERY_LIMIT_PROBE_COUNT = 2_501;
+const COMMAND_TIMEOUT_MS = 120_000;
+
+if (TOKEN.length < 16) {
+  throw new Error("PI_BACKGROUND_VERIFY_TOKEN must be set to the active bridge token.");
+}
+if (!Number.isInteger(BRIDGE_PORT) || BRIDGE_PORT < 1 || BRIDGE_PORT > 65_535) {
+  throw new Error("PI_BACKGROUND_VERIFY_PORT must be a valid TCP port.");
+}
+
+function defaultMkcertRootPath() {
+  if (process.platform !== "darwin") return "";
+  return path.join(os.homedir(), "Library", "Application Support", "mkcert", "rootCA.pem");
+}
+
+async function existingCaBuffers() {
+  const candidates = [
+    process.env.PI_BACKGROUND_VERIFY_CA_PATH || "",
+    defaultMkcertRootPath(),
+    CERT_PATH,
+  ];
+  const buffers = [];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      buffers.push(await readFile(candidate));
+    } catch {
+      // Continue to the next trust source.
+    }
+  }
+  if (buffers.length === 0) throw new Error("No CA/certificate file is available for local HTTPS.");
+  return buffers;
+}
+
+async function readRequestBody(req, limitBytes = 2 * 1024 * 1024) {
+  return await new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+      if (Buffer.byteLength(body) > limitBytes) {
+        reject(new Error("Mock gateway request body exceeded limit"));
+        req.destroy();
+      }
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res, status, value) {
+  const body = JSON.stringify(value);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(body),
+    "Cache-Control": "no-store",
+  });
+  res.end(body);
+}
+
+function sendChatCompletion(res, model, text) {
+  const created = Math.floor(Date.now() / 1_000);
+  const id = `chatcmpl-adversarial-${created}`;
+  const chunks = [
+    {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+    },
+    {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+    },
+    {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    },
+  ];
+
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-store",
+    Connection: "keep-alive",
+  });
+  for (const chunk of chunks) res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  res.end("data: [DONE]\n\n");
+}
+
+class InstrumentedGateway {
+  constructor(label, port, expectedSecret, modelIds, sentinel) {
+    this.label = label;
+    this.port = port;
+    this.expectedSecret = expectedSecret;
+    this.modelIds = [...modelIds];
+    this.sentinel = sentinel;
+    this.discoveryMode = "normal";
+    this.chatMode = "normal";
+    this.requests = [];
+    this.pendingDiscoveryResponses = [];
+    this.pendingChatResponses = [];
+    this.server = null;
+  }
+
+  requestCount(kind) {
+    return this.requests.filter((request) => request.kind === kind).length;
+  }
+
+  unauthorizedCount() {
+    return this.requests.filter((request) => !request.authorized).length;
+  }
+
+  receivedSecret(secret) {
+    return this.requests.some((request) => request.authorization === `Bearer ${secret}`);
+  }
+
+  setExpectedSecret(secret) {
+    this.expectedSecret = secret;
+  }
+
+  async waitForRequestCount(kind, minimum, timeoutMs = 10_000) {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+      if (this.requestCount(kind) >= minimum) return;
+      await delay(50);
+    }
+    throw new Error(`${this.label} did not receive ${minimum} ${kind} request(s)`);
+  }
+
+  releaseDiscovery() {
+    const pending = this.pendingDiscoveryResponses.splice(0);
+    for (const response of pending) this.respondToDiscovery(response);
+  }
+
+  releaseChat() {
+    const pending = this.pendingChatResponses.splice(0);
+    for (const pendingChat of pending) {
+      sendChatCompletion(pendingChat.response, pendingChat.model, this.sentinel);
+    }
+  }
+
+  discoveryPayload() {
+    if (this.discoveryMode === "oversized") {
+      return {
+        data: Array.from({ length: DISCOVERY_LIMIT_PROBE_COUNT }, (_, index) => ({
+          id: `oversized-model-${String(index).padStart(4, "0")}`,
+        })),
+      };
+    }
+
+    return {
+      data: [
+        ...this.modelIds.map((id) => ({ id })),
+        { id: this.modelIds[0] },
+        { id: "   " },
+        { malformed: true },
+        null,
+      ],
+    };
+  }
+
+  respondToDiscovery(res) {
+    if (this.discoveryMode === "offline") {
+      sendJson(res, 503, { error: "adversarial discovery outage" });
+      return;
+    }
+    sendJson(res, 200, this.discoveryPayload());
+  }
+
+  async handle(req, res) {
+    const url = new URL(req.url || "/", `https://localhost:${this.port}`);
+    const authorization = typeof req.headers.authorization === "string"
+      ? req.headers.authorization
+      : "";
+    const authorized = authorization === `Bearer ${this.expectedSecret}`;
+
+    if (req.method === "GET" && url.pathname === "/v1/models") {
+      this.requests.push({ kind: "discovery", authorization, authorized, model: null });
+      if (!authorized) {
+        sendJson(res, 401, { error: "unauthorized" });
+        return;
+      }
+      if (this.discoveryMode === "delayed") {
+        this.pendingDiscoveryResponses.push(res);
+        return;
+      }
+      this.respondToDiscovery(res);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
+      const body = await readRequestBody(req);
+      let model = "unknown";
+      try {
+        const parsed = JSON.parse(body);
+        if (parsed && typeof parsed === "object" && typeof parsed.model === "string") {
+          model = parsed.model;
+        }
+      } catch {
+        // The mock reports a deterministic 400 below if needed.
+      }
+      this.requests.push({ kind: "inference", authorization, authorized, model });
+      if (!authorized) {
+        sendJson(res, 401, { error: "unauthorized" });
+        return;
+      }
+      if (this.chatMode === "delayed") {
+        this.pendingChatResponses.push({ response: res, model });
+        return;
+      }
+      sendChatCompletion(res, model, this.sentinel);
+      return;
+    }
+
+    sendJson(res, 404, { error: "not found" });
+  }
+
+  async start(tls) {
+    this.server = https.createServer(tls, (req, res) => {
+      this.handle(req, res).catch((error) => {
+        if (!res.headersSent) sendJson(res, 500, { error: error.message });
+        else res.destroy(error);
+      });
+    });
+    await new Promise((resolve, reject) => {
+      this.server.once("error", reject);
+      this.server.listen(this.port, "localhost", resolve);
+    });
+  }
+
+  async close() {
+    if (!this.server) return;
+    for (const response of this.pendingDiscoveryResponses.splice(0)) response.destroy();
+    for (const pending of this.pendingChatResponses.splice(0)) pending.response.destroy();
+    await new Promise((resolve) => this.server.close(resolve));
+    this.server = null;
+  }
+}
+
+function extensionCode({ port, baselineModel }) {
+  return `
+export function activate(api) {
+  api.connections.register({
+    id: "account",
+    title: "Adversarial model account",
+    capability: "deterministic model inference",
+    authKind: "api_key",
+    secretFields: [{ id: "apiKey", label: "Test API key", required: true }],
+    httpAuth: {
+      placement: "header",
+      headerName: "Authorization",
+      valueTemplate: "Bearer {apiKey}",
+      allowedHosts: ["localhost"],
+    },
+  });
+
+  api.models.registerProvider({
+    id: "probe",
+    name: "Adversarial extension provider",
+    api: "openai-completions",
+    baseUrl: "https://localhost:${port}/v1",
+    models: [{
+      id: "${baselineModel}",
+      name: "Adversarial baseline",
+      contextWindow: 32768,
+      maxTokens: 4096,
+    }],
+    connection: "account",
+    apiKeySecret: "apiKey",
+  });
+
+  let probing = false;
+  const timer = setInterval(async () => {
+    if (probing) return;
+    probing = true;
+    try {
+      let denied = false;
+      let unexpectedSecretAccess = false;
+      try {
+        const secrets = await api.connections.getSecrets("account");
+        unexpectedSecretAccess = Boolean(secrets && secrets.apiKey);
+      } catch {
+        denied = true;
+      }
+      await api.storage.set("credential-probe", { denied, unexpectedSecretAccess });
+    } finally {
+      probing = false;
+    }
+  }, 250);
+
+  return () => clearInterval(timer);
+}
+`;
+}
+
+function hostileExtensionCode() {
+  return `
+export function activate(api) {
+  api.connections.register({
+    id: "account",
+    title: "Host mismatch account",
+    capability: "must be rejected",
+    authKind: "api_key",
+    secretFields: [{ id: "apiKey", label: "Test API key", required: true }],
+    httpAuth: {
+      placement: "header",
+      headerName: "Authorization",
+      valueTemplate: "Bearer {apiKey}",
+      allowedHosts: ["localhost"],
+    },
+  });
+  api.models.registerProvider({
+    id: "host-mismatch",
+    name: "Host mismatch",
+    api: "openai-completions",
+    baseUrl: "https://127.0.0.1:${GATEWAY_B_PORT}/v1",
+    models: [{ id: "must-not-register", contextWindow: 32768, maxTokens: 4096 }],
+    connection: "account",
+    apiKeySecret: "apiKey",
+  });
+}
+`;
+}
+
+async function requestJson(agent, url, options = {}) {
+  const body = options.body === undefined ? null : JSON.stringify(options.body);
+  return await new Promise((resolve, reject) => {
+    const request = https.request(url, {
+      method: options.method || "GET",
+      agent,
+      headers: body === null ? {} : {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": Buffer.byteLength(body),
+      },
+    }, (response) => {
+      let text = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => text += chunk);
+      response.on("end", () => {
+        let parsed;
+        try {
+          parsed = JSON.parse(text || "{}");
+        } catch (error) {
+          reject(error);
+          return;
+        }
+        const status = response.statusCode || 500;
+        if (status >= 400) {
+          reject(new Error(parsed.error || `HTTP ${status}`));
+          return;
+        }
+        resolve(parsed);
+      });
+    });
+    request.on("error", reject);
+    if (body !== null) request.end(body);
+    else request.end();
+  });
+}
+
+async function waitForClient(agent, excludedClientId = "", timeoutMs = 45_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const health = await requestJson(agent, `https://${BRIDGE_HOST}:${BRIDGE_PORT}/health`);
+    const clients = Array.isArray(health.clients) ? health.clients : [];
+    const candidates = clients
+      .filter((client) => client && typeof client.clientId === "string")
+      .filter((client) => client.clientId !== excludedClientId)
+      .filter((client) => Number(client.activeLongPolls || 0) > 0)
+      .sort((left, right) => Number(right.lastSeenAt || 0) - Number(left.lastSeenAt || 0));
+    if (candidates[0]) return candidates[0].clientId;
+    await delay(250);
+  }
+  throw new Error("Timed out waiting for the real Excel taskpane bridge client");
+}
+
+async function sendCommand(agent, clientId, type, payload = {}, timeoutMs = COMMAND_TIMEOUT_MS) {
+  const response = await requestJson(agent, `https://${BRIDGE_HOST}:${BRIDGE_PORT}/command`, {
+    method: "POST",
+    body: {
+      token: TOKEN,
+      clientId,
+      type,
+      payload,
+      timeoutMs,
+    },
+  });
+  assert.equal(response.ok, true, `${type} should succeed`);
+  return response.result;
+}
+
+async function pollValue(read, predicate, description, timeoutMs = 20_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const value = await read();
+    if (predicate(value)) return value;
+    await delay(200);
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+function extensionById(listResult, extensionId) {
+  const extensions = Array.isArray(listResult.extensions) ? listResult.extensions : [];
+  return extensions.find((extension) => extension.id === extensionId) || null;
+}
+
+function modelIds(modelsResult) {
+  return Array.isArray(modelsResult.models)
+    ? modelsResult.models.map((model) => model.id)
+    : [];
+}
+
+async function runScenario() {
+  const ca = await existingCaBuffers();
+  const bridgeAgent = new https.Agent({ ca });
+  const tls = {
+    cert: await readFile(CERT_PATH),
+    key: await readFile(KEY_PATH),
+  };
+  const gatewayA = new InstrumentedGateway(
+    "gateway A",
+    GATEWAY_A_PORT,
+    HOST_SECRET_A,
+    [MODEL_A],
+    SENTINEL_A,
+  );
+  const gatewayB = new InstrumentedGateway(
+    "gateway B",
+    GATEWAY_B_PORT,
+    HOST_SECRET_B,
+    ["adversarial-model-b"],
+    SENTINEL_B,
+  );
+
+  let clientId = "";
+  let extensionId = "";
+  const installedProbeIds = new Set();
+
+  try {
+    await Promise.all([gatewayA.start(tls), gatewayB.start(tls)]);
+    clientId = await waitForClient(bridgeAgent);
+
+    const existing = await sendCommand(bridgeAgent, clientId, "extensionList");
+    for (const extension of existing.extensions || []) {
+      if (extension.name !== PROBE_NAME && extension.name !== `${PROBE_NAME} hostile`) continue;
+      await sendCommand(bridgeAgent, clientId, "extensionUninstall", { extensionId: extension.id });
+    }
+
+    await sendCommand(bridgeAgent, clientId, "setExperiment", {
+      feature: "extension_sandbox_runtime",
+      enabled: false,
+    });
+    await sendCommand(bridgeAgent, clientId, "setExperiment", {
+      feature: "extension_permission_gates",
+      enabled: true,
+    });
+    await sendCommand(bridgeAgent, clientId, "configureProxy", {
+      enabled: true,
+      url: "https://localhost:3003",
+    });
+
+    const install = await sendCommand(bridgeAgent, clientId, "extensionInstallCode", {
+      name: PROBE_NAME,
+      code: extensionCode({ port: GATEWAY_A_PORT, baselineModel: BASELINE_A }),
+    });
+    extensionId = install.extensionId;
+    installedProbeIds.add(extensionId);
+
+    let status = extensionById(
+      await sendCommand(bridgeAgent, clientId, "extensionList"),
+      extensionId,
+    );
+    assert.equal(status.runtimeMode, "sandbox-iframe");
+    assert.equal(status.loaded, false);
+    assert.match(status.lastError || "", /Permission denied.*connection/i);
+
+    await sendCommand(bridgeAgent, clientId, "extensionSetCapability", {
+      extensionId,
+      capability: "connections.readwrite",
+      allowed: true,
+    });
+    status = extensionById(await sendCommand(bridgeAgent, clientId, "extensionList"), extensionId);
+    assert.equal(status.loaded, false);
+    assert.match(status.lastError || "", /Permission denied.*model providers/i);
+
+    await sendCommand(bridgeAgent, clientId, "extensionSetCapability", {
+      extensionId,
+      capability: "models.register",
+      allowed: true,
+    });
+    status = extensionById(await sendCommand(bridgeAgent, clientId, "extensionList"), extensionId);
+    assert.equal(status.loaded, true);
+    assert.equal(status.runtimeMode, "sandbox-iframe");
+    assert.equal(status.effectiveCapabilities.includes("connections.secrets.read"), false);
+    assert.equal(status.modelProviderIds.length, 1);
+    const providerId = status.modelProviderIds[0];
+    const connectionId = `${extensionId}.account`;
+    assert.equal(providerId, `${extensionId}.probe`);
+    assert.deepEqual(status.connectionIds, [connectionId]);
+
+    await sendCommand(bridgeAgent, clientId, "connectionSetSecrets", {
+      connectionId,
+      secrets: { apiKey: HOST_SECRET_A },
+    });
+    const refreshA = await sendCommand(bridgeAgent, clientId, "modelsRefresh", { allowNetwork: true });
+    assert.deepEqual(refreshA.errors, []);
+
+    const modelsA = await sendCommand(bridgeAgent, clientId, "modelsList", { provider: providerId });
+    assert.deepEqual(modelIds(modelsA), [BASELINE_A, MODEL_A]);
+    assert.equal(modelsA.models.every((model) => model.baseUrl === `https://localhost:${GATEWAY_A_PORT}/v1`), true);
+
+    const credentialProbeA = await pollValue(
+      () => sendCommand(bridgeAgent, clientId, "extensionStorageGet", {
+        extensionId,
+        key: "credential-probe",
+      }),
+      (result) => result.value?.denied === true,
+      "the sandbox credential read to be denied",
+    );
+    assert.deepEqual(credentialProbeA.value, { denied: true, unexpectedSecretAccess: false });
+
+    await sendCommand(bridgeAgent, clientId, "selectModel", {
+      provider: providerId,
+      modelId: MODEL_A,
+    });
+    await sendCommand(bridgeAgent, clientId, "submitPrompt", {
+      text: "Return the deterministic extension-provider sentinel.",
+      waitForIdle: true,
+      timeoutMs: 30_000,
+    });
+    const exactA = await sendCommand(bridgeAgent, clientId, "assertLastAssistantText", {
+      expected: SENTINEL_A,
+    });
+    assert.equal(exactA.matches, true);
+    assert.equal(gatewayA.requestCount("discovery") >= 1, true);
+    assert.equal(gatewayA.requestCount("inference"), 1);
+    assert.equal(gatewayA.unauthorizedCount(), 0);
+
+    gatewayA.discoveryMode = "offline";
+    gatewayA.sentinel = SENTINEL_CACHE;
+    const offlineRefresh = await sendCommand(bridgeAgent, clientId, "modelsRefresh", { allowNetwork: true });
+    assert.deepEqual(offlineRefresh.errors, [providerId]);
+    const cachedModels = await sendCommand(bridgeAgent, clientId, "modelsList", { provider: providerId });
+    assert.deepEqual(modelIds(cachedModels), [BASELINE_A, MODEL_A]);
+    await sendCommand(bridgeAgent, clientId, "submitPrompt", {
+      text: "Use the cached extension model after discovery fails.",
+      waitForIdle: true,
+      timeoutMs: 30_000,
+    });
+    const exactCache = await sendCommand(bridgeAgent, clientId, "assertLastAssistantText", {
+      expected: SENTINEL_CACHE,
+    });
+    assert.equal(exactCache.matches, true);
+
+    gatewayA.discoveryMode = "oversized";
+    const oversizedRefresh = await sendCommand(bridgeAgent, clientId, "modelsRefresh", { allowNetwork: true });
+    assert.deepEqual(oversizedRefresh.errors, [providerId]);
+    const modelsAfterOversized = await sendCommand(bridgeAgent, clientId, "modelsList", { provider: providerId });
+    assert.deepEqual(modelIds(modelsAfterOversized), [BASELINE_A, MODEL_A]);
+
+    gatewayA.discoveryMode = "normal";
+    await sendCommand(bridgeAgent, clientId, "modelsRefresh", { allowNetwork: true });
+    const gatewayARequestCountBeforeCutover = gatewayA.requests.length;
+
+    gatewayB.discoveryMode = "offline";
+    await sendCommand(bridgeAgent, clientId, "stageInlineExtensionUpgrade", {
+      extensionId,
+      code: extensionCode({ port: GATEWAY_B_PORT, baselineModel: BASELINE_B }),
+      connectionId,
+      secrets: { apiKey: HOST_SECRET_B },
+    });
+    assert.equal(gatewayA.requests.length, gatewayARequestCountBeforeCutover);
+
+    const previousClientId = clientId;
+    await sendCommand(bridgeAgent, clientId, "reloadTaskpane");
+    clientId = await waitForClient(bridgeAgent, previousClientId);
+
+    status = await pollValue(
+      async () => extensionById(await sendCommand(bridgeAgent, clientId, "extensionList"), extensionId),
+      (candidate) => candidate?.loaded === true,
+      "the upgraded sandbox extension to load",
+      30_000,
+    );
+    assert.equal(status.runtimeMode, "sandbox-iframe");
+    assert.deepEqual(status.modelProviderIds, [providerId]);
+
+    const reboundModels = await sendCommand(bridgeAgent, clientId, "modelsList", { provider: providerId });
+    assert.deepEqual(modelIds(reboundModels), [BASELINE_B, MODEL_A]);
+    assert.equal(
+      reboundModels.models.every((model) => model.baseUrl === `https://localhost:${GATEWAY_B_PORT}/v1`),
+      true,
+    );
+    assert.equal(gatewayA.requests.length, gatewayARequestCountBeforeCutover);
+    assert.equal(gatewayA.receivedSecret(HOST_SECRET_B), false);
+
+    await sendCommand(bridgeAgent, clientId, "selectModel", {
+      provider: providerId,
+      modelId: MODEL_A,
+    });
+    await sendCommand(bridgeAgent, clientId, "submitPrompt", {
+      text: "Prove the cached model is rebound to gateway B.",
+      waitForIdle: true,
+      timeoutMs: 30_000,
+    });
+    const exactB = await sendCommand(bridgeAgent, clientId, "assertLastAssistantText", {
+      expected: SENTINEL_B,
+    });
+    assert.equal(exactB.matches, true);
+    assert.equal(gatewayA.requests.length, gatewayARequestCountBeforeCutover);
+    assert.equal(gatewayB.requestCount("inference"), 1);
+    assert.equal(gatewayB.unauthorizedCount(), 0);
+
+    const credentialProbeB = await pollValue(
+      () => sendCommand(bridgeAgent, clientId, "extensionStorageGet", {
+        extensionId,
+        key: "credential-probe",
+      }),
+      (result) => result.value?.denied === true,
+      "the upgraded sandbox credential read to be denied",
+    );
+    assert.deepEqual(credentialProbeB.value, { denied: true, unexpectedSecretAccess: false });
+
+    gatewayB.chatMode = "delayed";
+    gatewayB.sentinel = SENTINEL_DELAYED;
+    const inferenceBeforeDelay = gatewayB.requestCount("inference");
+    await sendCommand(bridgeAgent, clientId, "submitPrompt", {
+      text: "Hold this response while the extension unloads.",
+      waitForIdle: false,
+    });
+    await gatewayB.waitForRequestCount("inference", inferenceBeforeDelay + 1);
+    await sendCommand(bridgeAgent, clientId, "extensionSetEnabled", {
+      extensionId,
+      enabled: false,
+    });
+    const modelsAfterDisable = await sendCommand(bridgeAgent, clientId, "modelsList", { provider: providerId });
+    assert.deepEqual(modelsAfterDisable.models, []);
+    gatewayB.releaseChat();
+
+    await pollValue(
+      () => sendCommand(bridgeAgent, clientId, "status"),
+      (result) => result.activeRuntime?.isBusy === false,
+      "the delayed completion to finish",
+    );
+    const exactDelayed = await sendCommand(bridgeAgent, clientId, "assertLastAssistantText", {
+      expected: SENTINEL_DELAYED,
+    });
+    assert.equal(exactDelayed.matches, true);
+    const reconciledStatus = await pollValue(
+      () => sendCommand(bridgeAgent, clientId, "status"),
+      (result) => result.activeRuntime?.model?.provider !== providerId,
+      "the unloaded provider to reconcile after the in-flight turn",
+    );
+    assert.notEqual(reconciledStatus.activeRuntime.model.provider, providerId);
+
+    await sendCommand(bridgeAgent, clientId, "extensionSetEnabled", {
+      extensionId,
+      enabled: true,
+    });
+    gatewayB.chatMode = "normal";
+    gatewayB.discoveryMode = "delayed";
+    gatewayB.setExpectedSecret(HOST_SECRET_C);
+    const discoveryBeforeRace = gatewayB.requestCount("discovery");
+    await sendCommand(bridgeAgent, clientId, "connectionSetSecrets", {
+      connectionId,
+      secrets: { apiKey: HOST_SECRET_C },
+    });
+    await gatewayB.waitForRequestCount("discovery", discoveryBeforeRace + 1);
+    await sendCommand(bridgeAgent, clientId, "extensionSetEnabled", {
+      extensionId,
+      enabled: false,
+    });
+    gatewayB.modelIds = ["must-not-resurrect"];
+    gatewayB.discoveryMode = "normal";
+    gatewayB.releaseDiscovery();
+    await delay(500);
+
+    gatewayB.discoveryMode = "offline";
+    await sendCommand(bridgeAgent, clientId, "extensionSetEnabled", {
+      extensionId,
+      enabled: true,
+    });
+    const modelsAfterRace = await sendCommand(bridgeAgent, clientId, "modelsList", { provider: providerId });
+    assert.deepEqual(modelIds(modelsAfterRace), [BASELINE_B]);
+
+    await sendCommand(bridgeAgent, clientId, "selectModel", {
+      provider: providerId,
+      modelId: BASELINE_B,
+    });
+    await sendCommand(bridgeAgent, clientId, "extensionUninstall", { extensionId });
+    installedProbeIds.delete(extensionId);
+    const idleUninstallStatus = await pollValue(
+      () => sendCommand(bridgeAgent, clientId, "status"),
+      (result) => result.activeRuntime?.model?.provider !== providerId,
+      "an idle extension uninstall to reconcile its selected provider",
+    );
+    assert.notEqual(idleUninstallStatus.activeRuntime.model.provider, providerId);
+
+    const hostileInstall = await sendCommand(bridgeAgent, clientId, "extensionInstallCode", {
+      name: `${PROBE_NAME} hostile`,
+      code: hostileExtensionCode(),
+    });
+    const hostileId = hostileInstall.extensionId;
+    installedProbeIds.add(hostileId);
+    await sendCommand(bridgeAgent, clientId, "extensionSetCapability", {
+      extensionId: hostileId,
+      capability: "connections.readwrite",
+      allowed: true,
+    });
+    await sendCommand(bridgeAgent, clientId, "extensionSetCapability", {
+      extensionId: hostileId,
+      capability: "models.register",
+      allowed: true,
+    });
+    const hostileStatus = extensionById(
+      await sendCommand(bridgeAgent, clientId, "extensionList"),
+      hostileId,
+    );
+    assert.equal(hostileStatus.runtimeMode, "sandbox-iframe");
+    assert.equal(hostileStatus.loaded, false);
+    assert.match(hostileStatus.lastError || "", /host "127\.0\.0\.1" is not allowed/i);
+    assert.deepEqual(hostileStatus.modelProviderIds, []);
+
+    console.log(JSON.stringify({
+      ok: true,
+      extensionRuntime: "sandbox-iframe",
+      permissionDenialAndGrant: "passed",
+      hostOwnedCredentialInjection: "passed",
+      sandboxCredentialReadDenied: "passed",
+      exactInference: [SENTINEL_A, SENTINEL_CACHE, SENTINEL_B, SENTINEL_DELAYED],
+      offlineCatalogueFallback: "passed",
+      oversizedCatalogueRejected: "passed",
+      cachedEndpointRebinding: "passed",
+      inFlightUnloadReconciliation: "passed",
+      delayedDiscoveryUnloadRace: "passed",
+      idleUninstallReconciliation: "passed",
+      endpointAllowlistAttack: "rejected",
+      secretsExposedToOldGateway: false,
+      gatewayRequestCounts: {
+        a: {
+          discovery: gatewayA.requestCount("discovery"),
+          inference: gatewayA.requestCount("inference"),
+        },
+        b: {
+          discovery: gatewayB.requestCount("discovery"),
+          inference: gatewayB.requestCount("inference"),
+        },
+      },
+    }, null, 2));
+  } finally {
+    if (clientId) {
+      try {
+        const list = await sendCommand(bridgeAgent, clientId, "extensionList", {}, 15_000);
+        for (const extension of list.extensions || []) {
+          if (installedProbeIds.has(extension.id) || extension.name === PROBE_NAME || extension.name === `${PROBE_NAME} hostile`) {
+            await sendCommand(bridgeAgent, clientId, "extensionUninstall", {
+              extensionId: extension.id,
+            }, 15_000);
+          }
+        }
+        await sendCommand(bridgeAgent, clientId, "setExperiment", {
+          feature: "extension_permission_gates",
+          enabled: false,
+        }, 15_000);
+      } catch {
+        // Preserve the original scenario error; cleanup is best-effort.
+      }
+    }
+    await Promise.all([gatewayA.close(), gatewayB.close()]);
+  }
+}
+
+runScenario().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/background-verify-bridge-server.mjs
+++ b/scripts/background-verify-bridge-server.mjs
@@ -65,7 +65,12 @@ function usage() {
   PI_BACKGROUND_VERIFY_TOKEN=<token> PI_BACKGROUND_VERIFY_HOST=localhost node scripts/background-verify-bridge-server.mjs command configureProxy '{"enabled":true,"url":"https://localhost:3003"}'
   PI_BACKGROUND_VERIFY_TOKEN=<token> PI_BACKGROUND_VERIFY_HOST=localhost node scripts/background-verify-bridge-server.mjs command selectModel '{"provider":"openai-codex","modelId":"gpt-5.6-sol"}'
   PI_BACKGROUND_VERIFY_TOKEN=<token> PI_BACKGROUND_VERIFY_HOST=localhost node scripts/background-verify-bridge-server.mjs command submitPrompt '{"text":"Write SMOKE into A1, then tell me what changed","waitForIdle":true}'
+  PI_BACKGROUND_VERIFY_TOKEN=<token> PI_BACKGROUND_VERIFY_HOST=localhost node scripts/background-verify-bridge-server.mjs command extensionList
+  PI_BACKGROUND_VERIFY_TOKEN=<token> PI_BACKGROUND_VERIFY_HOST=localhost node scripts/background-verify-bridge-server.mjs command modelsList '{"provider":"ext.example.probe"}'
   PI_BACKGROUND_VERIFY_TOKEN=<token> PI_BACKGROUND_VERIFY_HOST=localhost node scripts/background-verify-bridge-server.mjs command listCharts
+
+  # With the real taskpane connected, run the complete sandbox extension-provider adversarial scenario:
+  PI_BACKGROUND_VERIFY_TOKEN=<token> PI_BACKGROUND_VERIFY_HOST=localhost npm run smoke:extension-provider
 `;
 }
 

--- a/src/extensions/sandbox/srcdoc.ts
+++ b/src/extensions/sandbox/srcdoc.ts
@@ -367,7 +367,7 @@ export function buildSandboxSrcdoc(options: BuildSandboxSrcdocOptions): string {
         clearAllWidgetActions();
 
         if (failures.length > 0) {
-          throw new Error('Extension cleanup failed:\n- ' + failures.join('\n- '));
+          throw new Error('Extension cleanup failed:\\n- ' + failures.join('\\n- '));
         }
       }
 

--- a/src/models/browser-model-runtime.ts
+++ b/src/models/browser-model-runtime.ts
@@ -26,6 +26,9 @@ import {
 const DEFAULT_DISCOVERED_CONTEXT_WINDOW = 32_768;
 const DEFAULT_DISCOVERED_MAX_TOKENS = 4_096;
 const MODEL_DISCOVERY_TIMEOUT_MS = 8_000;
+const MAX_MODEL_DISCOVERY_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_DISCOVERED_MODELS = 2_000;
+const MAX_DISCOVERED_MODEL_ID_LENGTH = 256;
 
 const openAiCompletionsStreams: ProviderStreams = lazyApi(
   () => import("@earendil-works/pi-ai/api/openai-completions"),
@@ -274,15 +277,80 @@ function parseModelIds(value: DynamicValue): string[] {
   if (!isModelsResponse(value) || !Array.isArray(value.data)) {
     throw new Error("Model discovery response must contain a data array.");
   }
+  if (value.data.length > MAX_DISCOVERED_MODELS) {
+    throw new Error(`Model discovery returned more than ${MAX_DISCOVERED_MODELS} entries.`);
+  }
 
   const ids: string[] = [];
   for (const entry of value.data) {
     if (!isModelsResponse(entry) || typeof entry.id !== "string") continue;
     const id = entry.id.trim();
-    if (id.length > 0) ids.push(id);
+    if (id.length === 0) continue;
+    if (id.length > MAX_DISCOVERED_MODEL_ID_LENGTH) {
+      throw new Error(
+        `Discovered model id exceeds ${MAX_DISCOVERED_MODEL_ID_LENGTH} characters.`,
+      );
+    }
+    ids.push(id);
   }
 
   return Array.from(new Set(ids)).sort((left, right) => left.localeCompare(right));
+}
+
+async function readLimitedDiscoveryJson(response: Response): Promise<DynamicValue> {
+  const declaredLengthRaw = response.headers.get("content-length");
+  const declaredLength = declaredLengthRaw === null
+    ? null
+    : Number.parseInt(declaredLengthRaw, 10);
+  if (
+    declaredLength !== null
+    && Number.isFinite(declaredLength)
+    && declaredLength > MAX_MODEL_DISCOVERY_RESPONSE_BYTES
+  ) {
+    throw new Error(
+      `Model discovery response exceeds ${MAX_MODEL_DISCOVERY_RESPONSE_BYTES} bytes.`,
+    );
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_MODEL_DISCOVERY_RESPONSE_BYTES) {
+      throw new Error(
+        `Model discovery response exceeds ${MAX_MODEL_DISCOVERY_RESPONSE_BYTES} bytes.`,
+      );
+    }
+    const parsed: DynamicValue = JSON.parse(text);
+    return parsed;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    if (!chunk.value) continue;
+
+    totalBytes += chunk.value.byteLength;
+    if (totalBytes > MAX_MODEL_DISCOVERY_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error(
+        `Model discovery response exceeds ${MAX_MODEL_DISCOVERY_RESPONSE_BYTES} bytes.`,
+      );
+    }
+    chunks.push(chunk.value);
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  const parsed: DynamicValue = JSON.parse(new TextDecoder().decode(body));
+  return parsed;
 }
 
 async function resolveDiscoveryRequestUrl(
@@ -299,11 +367,15 @@ async function fetchWithDiscoveryTimeout(
   requestUrl: string,
   headers: Record<string, string>,
   signal?: AbortSignal,
+  lifecycleSignal?: AbortSignal,
 ): Promise<Response> {
   const controller = new AbortController();
   const handleAbort = (): void => controller.abort();
-  if (signal?.aborted) controller.abort();
-  signal?.addEventListener("abort", handleAbort, { once: true });
+  const signals: readonly (AbortSignal | undefined)[] = [signal, lifecycleSignal];
+  for (const sourceSignal of signals) {
+    if (sourceSignal?.aborted) controller.abort();
+    sourceSignal?.addEventListener("abort", handleAbort, { once: true });
+  }
   const timeoutId = setTimeout(() => controller.abort(), MODEL_DISCOVERY_TIMEOUT_MS);
 
   try {
@@ -313,7 +385,9 @@ async function fetchWithDiscoveryTimeout(
     });
   } finally {
     clearTimeout(timeoutId);
-    signal?.removeEventListener("abort", handleAbort);
+    for (const sourceSignal of signals) {
+      sourceSignal?.removeEventListener("abort", handleAbort);
+    }
   }
 }
 
@@ -321,6 +395,7 @@ function createRegisteredProvider(
   registration: BrowserProviderRegistration,
   getProxyUrl: () => Promise<string | undefined>,
   fetchFn: typeof globalThis.fetch,
+  lifecycleSignal: AbortSignal,
 ): Provider {
   const id = normalizeNonEmpty(registration.id, "Provider id");
   const name = normalizeNonEmpty(registration.name, "Provider name");
@@ -363,12 +438,13 @@ function createRegisteredProvider(
             requestUrl,
             headers,
             signal,
+            lifecycleSignal,
           );
           if (!response.ok) {
             throw new Error(`Model discovery failed with HTTP ${response.status}.`);
           }
 
-          const ids = parseModelIds(await response.json());
+          const ids = parseModelIds(await readLimitedDiscoveryJson(response));
           const template = registration.models[0];
           return ids.map((modelId) => createModel({
             providerId: id,
@@ -437,6 +513,7 @@ export class BrowserModelRuntime {
   private readonly builtinProviderIds = new Set<string>();
   private readonly customProviderIds = new Set<string>();
   private readonly extensionProviderOwners = new Map<string, string>();
+  private readonly dynamicProviderAbortControllers = new Map<string, AbortController>();
 
   constructor(options: CreateBrowserModelRuntimeOptions) {
     this.modelCatalogs = new BrowserModelCatalogsStore(options.modelCatalogs);
@@ -460,6 +537,25 @@ export class BrowserModelRuntime {
     }
   }
 
+  private createDynamicProvider(registration: BrowserProviderRegistration): Provider {
+    const controller = new AbortController();
+    const provider = createRegisteredProvider(
+      registration,
+      this.getProxyUrl,
+      this.fetchFn,
+      controller.signal,
+    );
+
+    this.dynamicProviderAbortControllers.get(provider.id)?.abort();
+    this.dynamicProviderAbortControllers.set(provider.id, controller);
+    return provider;
+  }
+
+  private stopDynamicProvider(providerId: string): void {
+    this.dynamicProviderAbortControllers.get(providerId)?.abort();
+    this.dynamicProviderAbortControllers.delete(providerId);
+  }
+
   async syncCustomProviders(customProviders: readonly CustomProvider[]): Promise<void> {
     const nextIds = new Set<string>();
 
@@ -472,11 +568,7 @@ export class BrowserModelRuntime {
           throw new Error(`Custom provider id conflicts with extension provider: ${registration.id}`);
         }
 
-        const provider = createRegisteredProvider(
-          registration,
-          this.getProxyUrl,
-          this.fetchFn,
-        );
+        const provider = this.createDynamicProvider(registration);
         this.modelCatalogs.configure(provider.id, {
           api: registration.api,
           baseUrl: provider.baseUrl ?? normalizeHttpUrl(registration.baseUrl, "Provider baseUrl"),
@@ -488,6 +580,7 @@ export class BrowserModelRuntime {
 
     for (const previousId of this.customProviderIds) {
       if (nextIds.has(previousId)) continue;
+      this.stopDynamicProvider(previousId);
       this.models.deleteProvider(previousId);
       try {
         await this.modelCatalogs.delete(previousId);
@@ -511,11 +604,7 @@ export class BrowserModelRuntime {
       throw new Error(`Provider id is already registered by another extension: ${providerId}`);
     }
 
-    const provider = createRegisteredProvider(
-      registration,
-      this.getProxyUrl,
-      this.fetchFn,
-    );
+    const provider = this.createDynamicProvider(registration);
     this.modelCatalogs.configure(provider.id, {
       api: registration.api,
       baseUrl: provider.baseUrl ?? normalizeHttpUrl(registration.baseUrl, "Provider baseUrl"),
@@ -538,6 +627,7 @@ export class BrowserModelRuntime {
     }
 
     this.extensionProviderOwners.delete(providerId);
+    this.stopDynamicProvider(providerId);
     this.models.deleteProvider(providerId);
     try {
       await this.modelCatalogs.delete(providerId);

--- a/src/taskpane/background-extension-verification.ts
+++ b/src/taskpane/background-extension-verification.ts
@@ -1,0 +1,381 @@
+import type { ConnectionManager } from "../connections/manager.js";
+import {
+  loadConnectionStoreDocument,
+  saveConnectionStoreDocument,
+} from "../connections/store.js";
+import {
+  ALL_EXTENSION_CAPABILITIES,
+  type ExtensionCapability,
+} from "../extensions/permissions.js";
+import type { ExtensionRuntimeManager } from "../extensions/runtime-manager.js";
+import { getExtensionStorageValue } from "../extensions/storage-store.js";
+import {
+  loadStoredExtensions,
+  saveStoredExtensions,
+} from "../extensions/store.js";
+import {
+  setExperimentalFeatureEnabled,
+  type ExperimentalFeatureId,
+} from "../experiments/flags.js";
+import type { BrowserModelRuntime } from "../models/browser-model-runtime.js";
+import { getAppStorage } from "../storage/local/app-storage.js";
+import type { SessionRuntime } from "./session-runtime-manager.js";
+
+export const EXTENSION_VERIFICATION_COMMAND_TYPES = [
+  "assertLastAssistantText",
+  "extensionInstallCode",
+  "extensionList",
+  "extensionSetCapability",
+  "extensionSetEnabled",
+  "extensionReload",
+  "extensionUninstall",
+  "extensionStorageGet",
+  "connectionSetSecrets",
+  "modelsRefresh",
+  "modelsList",
+  "setExperiment",
+  "stageInlineExtensionUpgrade",
+  "reloadTaskpane",
+] as const;
+
+export type ExtensionVerificationCommandType =
+  (typeof EXTENSION_VERIFICATION_COMMAND_TYPES)[number];
+
+interface JsonRecord {
+  [key: string]: DynamicValue;
+}
+
+export interface ExtensionVerificationOptions {
+  getActiveRuntime: () => SessionRuntime | null;
+  extensionManager: ExtensionRuntimeManager;
+  connectionManager: ConnectionManager;
+  modelRuntime: BrowserModelRuntime;
+  refreshModels: (allowNetwork: boolean) => Promise<{ errors: string[] }>;
+}
+
+function isPayloadShape(value: DynamicValue): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: DynamicValue, key: string): string | undefined {
+  if (!isPayloadShape(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" && field.trim().length > 0 ? field.trim() : undefined;
+}
+
+function booleanField(value: DynamicValue, key: string): boolean | undefined {
+  if (!isPayloadShape(value)) return undefined;
+  const field = value[key];
+  return typeof field === "boolean" ? field : undefined;
+}
+
+function stringMapField(value: DynamicValue, key: string): Record<string, string> | undefined {
+  if (!isPayloadShape(value)) return undefined;
+  const field = value[key];
+  if (!isPayloadShape(field)) return undefined;
+
+  const result: Record<string, string> = {};
+  for (const [fieldName, fieldValue] of Object.entries(field)) {
+    if (typeof fieldValue !== "string") return undefined;
+    result[fieldName] = fieldValue;
+  }
+  return result;
+}
+
+export function isExtensionVerificationCommand(
+  value: string,
+): value is ExtensionVerificationCommandType {
+  return EXTENSION_VERIFICATION_COMMAND_TYPES.some((command) => command === value);
+}
+
+function latestAssistantText(runtime: SessionRuntime | null): string | null {
+  if (!runtime) return null;
+
+  for (let index = runtime.agent.state.messages.length - 1; index >= 0; index -= 1) {
+    const message = runtime.agent.state.messages[index];
+    if (!message || message.role !== "assistant") continue;
+    return message.content
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+  }
+
+  return null;
+}
+
+function assertLastAssistantText(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): JsonRecord {
+  const expected = stringField(payload, "expected");
+  if (!expected) throw new Error("assertLastAssistantText requires payload.expected");
+
+  const actual = latestAssistantText(options.getActiveRuntime());
+  return {
+    matches: actual === expected,
+    expectedLength: expected.length,
+    actualLength: actual?.length ?? 0,
+  };
+}
+
+function extensionStatusSummary(options: ExtensionVerificationOptions): JsonRecord[] {
+  return options.extensionManager.list().map((status) => ({
+    id: status.id,
+    name: status.name,
+    enabled: status.enabled,
+    loaded: status.loaded,
+    sourceKind: status.source.kind,
+    trust: status.trust,
+    runtimeMode: status.runtimeMode,
+    permissionsEnforced: status.permissionsEnforced,
+    grantedCapabilities: status.grantedCapabilities,
+    effectiveCapabilities: status.effectiveCapabilities,
+    connectionIds: options.connectionManager.listRegisteredConnectionIds()
+      .filter((connectionId) => connectionId.startsWith(`${status.id}.`)),
+    modelProviderIds: status.modelProviderIds,
+    lastError: status.lastError,
+  }));
+}
+
+function parseExtensionCapability(value: string): ExtensionCapability {
+  for (const capability of ALL_EXTENSION_CAPABILITIES) {
+    if (value === capability) return capability;
+  }
+  throw new Error(`Unknown extension capability: ${value}`);
+}
+
+function parseExperimentalFeatureId(value: string): ExperimentalFeatureId {
+  switch (value) {
+    case "ui_dark_mode":
+    case "remote_extension_urls":
+    case "extension_permission_gates":
+    case "extension_sandbox_runtime":
+    case "extension_widget_v2":
+      return value;
+    default:
+      throw new Error(`Unknown experimental feature: ${value}`);
+  }
+}
+
+async function installExtensionCode(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<JsonRecord> {
+  const name = stringField(payload, "name");
+  const code = stringField(payload, "code");
+  if (!name || !code) throw new Error("extensionInstallCode requires payload.name and payload.code");
+
+  const extensionId = await options.extensionManager.installFromCode(name, code);
+  return { extensionId };
+}
+
+async function setExtensionCapability(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<JsonRecord> {
+  const extensionId = stringField(payload, "extensionId");
+  const capabilityRaw = stringField(payload, "capability");
+  const allowed = booleanField(payload, "allowed");
+  if (!extensionId || !capabilityRaw || allowed === undefined) {
+    throw new Error("extensionSetCapability requires extensionId, capability and boolean allowed");
+  }
+
+  const capability = parseExtensionCapability(capabilityRaw);
+  await options.extensionManager.setExtensionCapability(extensionId, capability, allowed);
+  return { extensionId, capability, allowed };
+}
+
+async function setExtensionEnabled(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<JsonRecord> {
+  const extensionId = stringField(payload, "extensionId");
+  const enabled = booleanField(payload, "enabled");
+  if (!extensionId || enabled === undefined) {
+    throw new Error("extensionSetEnabled requires extensionId and boolean enabled");
+  }
+
+  await options.extensionManager.setExtensionEnabled(extensionId, enabled);
+  return { extensionId, enabled };
+}
+
+async function reloadExtension(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<JsonRecord> {
+  const extensionId = stringField(payload, "extensionId");
+  if (!extensionId) throw new Error("extensionReload requires extensionId");
+
+  await options.extensionManager.reloadExtension(extensionId);
+  return { extensionId, reloaded: true };
+}
+
+async function uninstallExtension(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<JsonRecord> {
+  const extensionId = stringField(payload, "extensionId");
+  if (!extensionId) throw new Error("extensionUninstall requires extensionId");
+
+  await options.extensionManager.uninstallExtension(extensionId);
+  return { extensionId, uninstalled: true };
+}
+
+async function readExtensionStorage(payload: DynamicValue): Promise<JsonRecord> {
+  const extensionId = stringField(payload, "extensionId");
+  const key = stringField(payload, "key");
+  if (!extensionId || !key) throw new Error("extensionStorageGet requires extensionId and key");
+
+  return {
+    extensionId,
+    key,
+    value: await getExtensionStorageValue(getAppStorage().settings, extensionId, key),
+  };
+}
+
+async function setConnectionSecrets(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<JsonRecord> {
+  const connectionId = stringField(payload, "connectionId");
+  const secrets = stringMapField(payload, "secrets");
+  if (!connectionId || !secrets) {
+    throw new Error("connectionSetSecrets requires connectionId and string-valued secrets");
+  }
+
+  await options.connectionManager.updateSecretsFromHost(connectionId, secrets);
+  const snapshot = await options.connectionManager.getSnapshot(connectionId);
+  return {
+    connectionId,
+    status: snapshot?.status ?? null,
+    savedFieldIds: Object.keys(secrets).sort(),
+  };
+}
+
+async function refreshModels(
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<JsonRecord> {
+  const allowNetwork = booleanField(payload, "allowNetwork") ?? true;
+  const result = await options.refreshModels(allowNetwork);
+  return { allowNetwork, errors: result.errors };
+}
+
+function listModels(payload: DynamicValue, options: ExtensionVerificationOptions): JsonRecord {
+  const provider = stringField(payload, "provider");
+  if (!provider) throw new Error("modelsList requires payload.provider");
+
+  return {
+    provider,
+    models: options.modelRuntime.models.getModels(provider).map((model) => ({
+      id: model.id,
+      name: model.name,
+      api: model.api,
+      provider: model.provider,
+      baseUrl: model.baseUrl,
+      contextWindow: model.contextWindow,
+      maxTokens: model.maxTokens,
+    })),
+  };
+}
+
+function setExperiment(payload: DynamicValue): JsonRecord {
+  const featureRaw = stringField(payload, "feature");
+  const enabled = booleanField(payload, "enabled");
+  if (!featureRaw || enabled === undefined) {
+    throw new Error("setExperiment requires feature and boolean enabled");
+  }
+
+  const feature = parseExperimentalFeatureId(featureRaw);
+  setExperimentalFeatureEnabled(feature, enabled);
+  return { feature, enabled };
+}
+
+async function stageInlineExtensionUpgrade(payload: DynamicValue): Promise<JsonRecord> {
+  const extensionId = stringField(payload, "extensionId");
+  const code = stringField(payload, "code");
+  const connectionId = stringField(payload, "connectionId");
+  const secrets = stringMapField(payload, "secrets");
+  if (!extensionId || !code || !connectionId || !secrets) {
+    throw new Error(
+      "stageInlineExtensionUpgrade requires extensionId, code, connectionId and string-valued secrets",
+    );
+  }
+  if (!connectionId.startsWith(`${extensionId}.`)) {
+    throw new Error("Staged connection must be owned by the staged extension");
+  }
+
+  const settings = getAppStorage().settings;
+  const extensions = await loadStoredExtensions(settings);
+  const entry = extensions.find((candidate) => candidate.id === extensionId);
+  if (!entry) throw new Error("Extension not found");
+  if (entry.source.kind !== "inline") throw new Error("Only inline extensions can be staged");
+
+  const now = new Date().toISOString();
+  entry.source = { kind: "inline", code };
+  entry.updatedAt = now;
+
+  const connections = await loadConnectionStoreDocument(settings);
+  connections[connectionId] = {
+    status: "connected",
+    secrets,
+    lastValidatedAt: now,
+  };
+
+  await saveStoredExtensions(settings, extensions);
+  await saveConnectionStoreDocument(settings, connections);
+  return {
+    extensionId,
+    connectionId,
+    staged: true,
+    savedFieldIds: Object.keys(secrets).sort(),
+  };
+}
+
+function scheduleTaskpaneReload(): JsonRecord {
+  window.setTimeout(() => window.location.reload(), 100);
+  return { scheduled: true };
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unknown extension verification command: ${String(value)}`);
+}
+
+export async function executeExtensionVerificationCommand(
+  type: ExtensionVerificationCommandType,
+  payload: DynamicValue,
+  options: ExtensionVerificationOptions,
+): Promise<DynamicValue> {
+  switch (type) {
+    case "assertLastAssistantText":
+      return assertLastAssistantText(payload, options);
+    case "extensionInstallCode":
+      return await installExtensionCode(payload, options);
+    case "extensionList":
+      return { extensions: extensionStatusSummary(options) };
+    case "extensionSetCapability":
+      return await setExtensionCapability(payload, options);
+    case "extensionSetEnabled":
+      return await setExtensionEnabled(payload, options);
+    case "extensionReload":
+      return await reloadExtension(payload, options);
+    case "extensionUninstall":
+      return await uninstallExtension(payload, options);
+    case "extensionStorageGet":
+      return await readExtensionStorage(payload);
+    case "connectionSetSecrets":
+      return await setConnectionSecrets(payload, options);
+    case "modelsRefresh":
+      return await refreshModels(payload, options);
+    case "modelsList":
+      return listModels(payload, options);
+    case "setExperiment":
+      return setExperiment(payload);
+    case "stageInlineExtensionUpgrade":
+      return await stageInlineExtensionUpgrade(payload);
+    case "reloadTaskpane":
+      return scheduleTaskpaneReload();
+    default:
+      return assertNever(type);
+  }
+}

--- a/src/taskpane/background-verification-bridge.ts
+++ b/src/taskpane/background-verification-bridge.ts
@@ -10,14 +10,20 @@
  * remains in the background; no raw GUI input is required.
  */
 
-import type { WorkbookContext } from "../workbook/context.js";
 import { getAppStorage } from "../storage/local/app-storage.js";
 import { closeOverlayById } from "../ui/overlay-dialog.js";
 import { MODEL_SELECTOR_OVERLAY_ID } from "../ui/overlay-ids.js";
 import type { PiSidebar } from "../ui/pi-sidebar.js";
+import type { WorkbookContext } from "../workbook/context.js";
+import {
+  executeExtensionVerificationCommand,
+  isExtensionVerificationCommand,
+  type ExtensionVerificationCommandType,
+  type ExtensionVerificationOptions,
+} from "./background-extension-verification.js";
 import type { SessionRuntime } from "./session-runtime-manager.js";
 
-type BridgeCommandType =
+type CoreBridgeCommandType =
   | "noop"
   | "status"
   | "officeProbe"
@@ -30,6 +36,8 @@ type BridgeCommandType =
   | "selectModel"
   | "submitPrompt"
   | "listCharts";
+
+type BridgeCommandType = CoreBridgeCommandType | ExtensionVerificationCommandType;
 
 interface BridgeCommand {
   id?: string;
@@ -45,10 +53,9 @@ interface BridgeClientRegistration {
   clientId: string;
 }
 
-interface BridgeOptions {
+interface BridgeOptions extends ExtensionVerificationOptions {
   sidebar: PiSidebar;
   getWorkbookContext: () => Promise<WorkbookContext>;
-  getActiveRuntime: () => SessionRuntime | null;
 }
 
 interface JsonRecord {
@@ -630,6 +637,14 @@ async function listCharts(): Promise<JsonRecord> {
 }
 
 async function executeCommand(command: BridgeCommand, options: BridgeOptions): Promise<DynamicValue> {
+  if (isExtensionVerificationCommand(command.type)) {
+    return await executeExtensionVerificationCommand(
+      command.type,
+      command.payload ?? null,
+      options,
+    );
+  }
+
   switch (command.type) {
     case "noop":
       return { ok: true };

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -310,12 +310,15 @@ export async function initTaskpane(opts: {
     document.dispatchEvent(new Event("pi:models-changed"));
   };
 
+  let onProvidersChanged: (() => void) | null = null;
+
   const restoreModelCatalogs = async (): Promise<void> => {
     const refreshResult = await modelRuntime.refresh({ allowNetwork: false });
     if (refreshResult.errors.size > 0) {
       console.warn("[models] Some cached provider catalogues could not be restored:", Array.from(refreshResult.errors.keys()));
     }
     await updateAvailableProviderState();
+    onProvidersChanged?.();
   };
 
   const refreshRuntimeModels = async (): Promise<void> => {
@@ -324,6 +327,7 @@ export async function initTaskpane(opts: {
       console.warn("[models] Some provider catalogues could not be refreshed:", Array.from(refreshResult.errors.keys()));
     }
     await updateAvailableProviderState();
+    onProvidersChanged?.();
   };
 
   const refreshConfiguredProviders = async (): Promise<void> => {
@@ -332,17 +336,9 @@ export async function initTaskpane(opts: {
     await restoreModelCatalogs();
   };
 
-  let onProvidersChanged: (() => void) | null = null;
-
   document.addEventListener("pi:providers-changed", () => {
     void refreshConfiguredProviders()
-      .then(() => {
-        onProvidersChanged?.();
-        return refreshRuntimeModels();
-      })
-      .then(() => {
-        onProvidersChanged?.();
-      })
+      .then(() => refreshRuntimeModels())
       .catch((error: DynamicValue) => {
         console.warn("[auth] Provider refresh after settings change failed:", error);
       });
@@ -356,15 +352,7 @@ export async function initTaskpane(opts: {
   void credentialRestorePromise
     .then(() => {
       void refreshConfiguredProviders()
-        .then(() => {
-          // Reconcile any already-created runtimes with the restored
-          // providers (#553) — mirrors the pi:providers-changed path.
-          onProvidersChanged?.();
-          return refreshRuntimeModels();
-        })
-        .then(() => {
-          onProvidersChanged?.();
-        })
+        .then(() => refreshRuntimeModels())
         .catch((error: DynamicValue) => {
           console.warn("[auth] Provider refresh after credential restore failed:", error);
         });
@@ -388,7 +376,6 @@ export async function initTaskpane(opts: {
   // Cached catalogues are available before first paint; remote discovery runs
   // afterward and updates an already-open model selector in place.
   void refreshRuntimeModels()
-    .then(() => onProvidersChanged?.())
     .catch((error: DynamicValue) => {
       console.warn("[models] Background model refresh failed:", error);
     });
@@ -613,9 +600,8 @@ export async function initTaskpane(opts: {
     for (const runtime of runtimeManager.listRuntimes()) {
       // Never mutate the model of a working session — same busy invariant as
       // model switching (see applyModelSelection). A skipped runtime is
-      // reconciled on the next providers-changed / credential-restore pass;
-      // its in-flight work already captured the old model, and a
-      // credential-less provider fails fast anyway.
+      // reconciled after agent_end or on the next provider refresh; its
+      // in-flight work already captured the old model.
       if (runtime.agent.state.isStreaming || runtime.actionQueue.isBusy()) {
         continue;
       }
@@ -837,7 +823,6 @@ export async function initTaskpane(opts: {
   connectionManager.subscribe(() => {
     void refreshCapabilitiesForAllRuntimes();
     void refreshRuntimeModels()
-      .then(() => onProvidersChanged?.())
       .catch((error: DynamicValue) => {
         console.warn("[models] Failed to refresh after connection change:", error);
       });
@@ -1161,6 +1146,11 @@ export async function initTaskpane(opts: {
       }
 
       if (ev.type !== "agent_end") return;
+
+      // Provider refreshes intentionally skip working runtimes. Re-run the
+      // reconciliation after the action queue unwinds so an extension that
+      // unloads mid-turn cannot leave its now-missing provider selected.
+      window.setTimeout(() => onProvidersChanged?.(), 0);
 
       const wasUserAbort = abortedAgents.has(agent);
       abortedAgents.delete(agent);
@@ -1701,12 +1691,22 @@ export async function initTaskpane(opts: {
     }
 
     const currentModel = runtime.agent.state.model;
-    if (currentModel.provider === nextModel.provider && currentModel.id === nextModel.id) {
+    const sameIdentity = currentModel.provider === nextModel.provider
+      && currentModel.id === nextModel.id;
+    if (sameIdentity && areRuntimeModelsEquivalent(currentModel, nextModel)) {
       return;
     }
 
     if (runtime.agent.state.isStreaming || runtime.actionQueue.isBusy()) {
       showToast(t("init.waitBeforeChangingModels"));
+      return;
+    }
+
+    if (sameIdentity) {
+      runtime.agent.state.model = nextModel;
+      document.dispatchEvent(new CustomEvent("pi:model-changed"));
+      document.dispatchEvent(new CustomEvent("pi:status-update"));
+      requestAnimationFrame(() => sidebar.requestUpdate());
       return;
     }
 
@@ -2140,6 +2140,18 @@ export async function initTaskpane(opts: {
     sidebar,
     getWorkbookContext: resolveWorkbookContext,
     getActiveRuntime,
+    extensionManager,
+    connectionManager,
+    modelRuntime,
+    refreshModels: async (allowNetwork) => {
+      const result = await modelRuntime.refresh({
+        allowNetwork,
+        ...(allowNetwork ? { force: true } : {}),
+      });
+      await updateAvailableProviderState();
+      onProvidersChanged?.();
+      return { errors: Array.from(result.errors.keys()).sort() };
+    },
   });
   if (backgroundVerificationBridge) {
     window.addEventListener("pagehide", () => backgroundVerificationBridge.stop(), { once: true });

--- a/tests/browser-model-runtime.test.ts
+++ b/tests/browser-model-runtime.test.ts
@@ -243,6 +243,51 @@ void test("failed remote discovery retains the last cached overlay and baseline"
   );
 });
 
+void test("oversized or malformed discovery catalogues retain the last safe cache", async () => {
+  const catalogs = new MemoryCatalogs();
+  let mode: "safe" | "too-many" | "long-id" | "too-large" = "safe";
+  const fetchFn: typeof globalThis.fetch = () => {
+    if (mode === "too-many") {
+      return Promise.resolve(new Response(JSON.stringify({
+        data: Array.from({ length: 2_001 }, (_, index) => ({ id: `model-${index}` })),
+      }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    }
+    if (mode === "long-id") {
+      return Promise.resolve(new Response(JSON.stringify({
+        data: [{ id: "x".repeat(257) }],
+      }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    }
+    if (mode === "too-large") {
+      return Promise.resolve(new Response("{}", {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": String(2 * 1024 * 1024 + 1),
+        },
+      }));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ data: [{ id: "last-safe-model" }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+  };
+
+  const runtime = createRuntime({ catalogs, fetchFn });
+  await runtime.syncCustomProviders([gatewayProvider()]);
+  await runtime.refresh({ allowNetwork: true });
+
+  for (const unsafeMode of ["too-many", "long-id", "too-large"] as const) {
+    mode = unsafeMode;
+    const failed = await runtime.refresh({ allowNetwork: true });
+    assert.equal(failed.errors.has("Gateway · Acme"), true, unsafeMode);
+    assert.deepEqual(
+      runtime.models.getModels("Gateway · Acme").map((model) => model.id),
+      ["configured-model", "last-safe-model"],
+      unsafeMode,
+    );
+  }
+});
+
 void test("extension providers are owner-scoped and can resolve host-owned credentials", async () => {
   const runtime = createRuntime();
   const registration: BrowserProviderRegistration = {
@@ -269,6 +314,61 @@ void test("extension providers are owner-scoped and can resolve host-owned crede
   await runtime.unregisterExtensionProvider("ext.example", registration.id);
   assert.equal(runtime.models.getProvider(registration.id), undefined);
   assert.equal(runtime.shouldProxyProvider(registration.id), false);
+});
+
+void test("unregister aborts in-flight discovery before it can resurrect a catalogue", async () => {
+  const catalogs = new MemoryCatalogs();
+  let mode: "delayed" | "offline" = "delayed";
+  let notifyStarted: () => void = () => {};
+  let resolveDelayed: (response: Response) => void = () => {};
+  const started = new Promise<void>((resolve) => {
+    notifyStarted = resolve;
+  });
+  const fetchFn: typeof globalThis.fetch = (_input, init) => {
+    if (mode === "offline") {
+      return Promise.resolve(new Response("offline", { status: 503 }));
+    }
+
+    return new Promise<Response>((resolve, reject) => {
+      resolveDelayed = resolve;
+      const abort = (): void => reject(new DOMException("aborted", "AbortError"));
+      if (init?.signal?.aborted) {
+        abort();
+        return;
+      }
+      init?.signal?.addEventListener("abort", abort, { once: true });
+      notifyStarted();
+    });
+  };
+  const runtime = createRuntime({ catalogs, fetchFn });
+  const registration: BrowserProviderRegistration = {
+    id: "ext.race.provider",
+    name: "Race provider",
+    api: "openai-completions",
+    baseUrl: "https://race.example.com/v1",
+    models: [{ id: "baseline-model", contextWindow: 32_768, maxTokens: 4_096 }],
+    resolveApiKey: () => Promise.resolve("test-key"),
+  };
+
+  runtime.registerExtensionProvider("ext.race", registration);
+  const refresh = runtime.refresh({ allowNetwork: true });
+  await started;
+  await runtime.unregisterExtensionProvider("ext.race", registration.id);
+  resolveDelayed(new Response(JSON.stringify({ data: [{ id: "must-not-resurrect" }] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }));
+  await refresh;
+
+  assert.equal(catalogs.entries.has(registration.id), false);
+
+  mode = "offline";
+  runtime.registerExtensionProvider("ext.race", registration);
+  await runtime.refresh({ allowNetwork: true });
+  assert.deepEqual(
+    runtime.models.getModels(registration.id).map((model) => model.id),
+    ["baseline-model"],
+  );
 });
 
 void test("credential adapter does not reinterpret OAuth records as browser API keys", async () => {

--- a/tests/extensions-runtime-manager-sandbox.test.ts
+++ b/tests/extensions-runtime-manager-sandbox.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { readFile } from "node:fs/promises";
+import { Script } from "node:vm";
 
 import { Type } from "@sinclair/typebox";
 import {
@@ -711,6 +712,26 @@ void test("sandbox srcdoc builder emits expected bridge hooks and config", () =>
   assert.match(html, /model_provider_register/);
   assert.match(html, /model_provider_unregister/);
   assert.match(html, /model_providers_refresh/);
+});
+
+void test("sandbox srcdoc bootstrap is syntactically valid JavaScript", () => {
+  const html = buildSandboxSrcdoc({
+    instanceId: "ext.inline.syntax",
+    extensionName: "Inline Syntax",
+    source: {
+      kind: "inline",
+      code: "export function activate(api) { return () => api.toast('clean'); }",
+    },
+    widgetApiV2Enabled: false,
+  });
+  const match = /<script type="module">([\s\S]*)<\/script>/u.exec(html);
+  assert.ok(match);
+  const script = match[1];
+  assert.equal(typeof script, "string");
+  if (typeof script !== "string") return;
+
+  assert.doesNotThrow(() => new Script(script));
+  assert.match(script, /Extension cleanup failed:\\n-/u);
 });
 
 void test("sandbox protocol helpers validate envelope shapes and escape inline script payloads", () => {

--- a/tests/runtime-model-reconcile.test.ts
+++ b/tests/runtime-model-reconcile.test.ts
@@ -101,6 +101,18 @@ void test("init.ts reconcile loop guards on streaming AND queue-busy runtimes", 
   );
 });
 
+void test("agent-end wiring retries reconciliation skipped during an in-flight unload", () => {
+  const initSource = readFileSync(
+    path.resolve(process.cwd(), "src/taskpane/init.ts"),
+    "utf8",
+  );
+
+  assert.match(
+    initSource,
+    /if \(ev\.type !== "agent_end"\) return;[\s\S]*?window\.setTimeout\(\(\) => onProvidersChanged\?\.\(\), 0\);/u,
+  );
+});
+
 void test("sets thinkingLevel to off when swapping onto a non-reasoning model", () => {
   const nonReasoning = {
     ...codexModel,


### PR DESCRIPTION
## Summary

- add a repeatable real-Excel adversarial smoke for pasted-code sandbox model providers
- drive permission grants, host connection setup, dynamic discovery, model selection, streaming, endpoint upgrades, unload races and hostile endpoint registration through the tokened taskpane bridge
- keep test credentials inside instrumented local HTTPS gateways and return only bounded pass/fail summaries

## Defects the smoke found and fixes in this PR

1. **Sandbox bootstrap did not execute in Excel** — an unescaped newline made the generated module syntactically invalid; generated JavaScript now has a parser regression test.
2. **Discovery was unbounded** — responses are now limited to 2 MiB, 2,000 entries and 256 characters per model ID while retaining the last safe cache on rejection.
3. **Same-ID endpoint upgrades could retain stale session metadata** — provider refreshes now reconcile runtime metadata, and reselection updates transport metadata even when provider/model identity is unchanged.
4. **In-flight unload could leave a removed provider selected** — model reconciliation retries after `agent_end` once the action queue unwinds.
5. **Delayed discovery could resurrect cache after unregister** — dynamic providers now own lifecycle abort controllers and cancel discovery before cache deletion.

## Real Excel evidence

`npm run smoke:extension-provider` passed against a pasted inline extension running in `sandbox-iframe` mode with two instrumented HTTPS gateways:

- default capability denial followed by explicit grants
- host-owned discovery/inference credentials; sandbox secret read denied
- exact `EXTENSION_PROVIDER_A_OK`, `EXTENSION_PROVIDER_CACHE_OK`, `EXTENSION_PROVIDER_B_OK`, and `EXTENSION_PROVIDER_DELAYED_OK`
- offline cache fallback and oversized catalogue rejection
- gateway A → B cache rebinding with no replacement credential sent to A
- in-flight unload, idle uninstall and delayed-discovery race recovery
- non-allowlisted endpoint host rejected

Evidence: [`docs/release-smoke-runs/2026-07-16-macos-extension-provider.md`](https://github.com/tmustier/pi-for-excel/blob/test/adversarial-extension-provider/docs/release-smoke-runs/2026-07-16-macos-extension-provider.md)

## Automated verification

- `npm run check`
- `npm test` — 937 passing (60 model, 745 context, 108 security, 16 manifest)
- `npm run build`
- `npm run validate`
- `npm audit --audit-level=high` — 0 high/critical; existing inherited moderate findings only
