### PR TITLE
Update Pi model limits and add Claude Opus 5

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -23,26 +23,15 @@ Do not use Pi coding-agent's Node/file `ModelRuntime` directly in the Office Web
 
 ### Current GPT-5.6 and Claude Opus 5 registry snapshot (`pi-ai` 0.83.0)
 
-Upstream exposes exactly three IDs on both `openai` and `openai-codex`; there is deliberately no bare `gpt-5.6` alias:
+Pi AI exposes `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` on both `openai` and `openai-codex`, with no bare `gpt-5.6` alias. All three models:
 
-| ID | Display name | Standard input / output | Cache read / write | Above 272k input / output | Above 272k cache read / write |
-|---|---|---:|---:|---:|---:|
-| `gpt-5.6-sol` | GPT-5.6 Sol | $5 / $30 | $0.50 / $6.25 | $10 / $45 | $1 / $12.50 |
-| `gpt-5.6-terra` | GPT-5.6 Terra | $2.50 / $15 | $0.25 / $3.125 | $5 / $22.50 | $0.50 / $6.25 |
-| `gpt-5.6-luna` | GPT-5.6 Luna | $1 / $6 | $0.10 / $1.25 | $2 / $9 | $0.20 / $2.50 |
+- accept text and image input and support reasoning
+- have a 272,000-token context window and 128,000-token maximum output
+- expose `off`, `low`, `medium`, `high`, `xhigh`, and `max`; ChatGPT also exposes `minimal`
 
-Prices are registry values in USD per million tokens. All three models:
+Pi AI 0.83.0 also exposes `claude-opus-5` with a 1,000,000-token context window and 128,000-token maximum output. Anthropic-only setups select it as the latest Opus.
 
-- accept text and image input, support reasoning, and expose `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max` through `getSupportedThinkingLevels()`
-- have a 128,000-token maximum output
-- use a 272,000-token effective context window through both the OpenAI API (`openai-responses`, `https://api.openai.com/v1`) and ChatGPT (`openai-codex-responses`, `https://chatgpt.com/backend-api`)
-- preserve distinct native `xhigh` and `max` efforts; the ChatGPT map also maps the add-in's `minimal` level to upstream `low`
-
-Pi AI 0.81.0 deliberately reduced the ChatGPT GPT-5.6 default from 372,000 to 272,000 tokens to avoid automatically entering long-context pricing. OpenAI's public Sol model page advertises a 1,050,000-token context window, but Pi for Excel follows Pi AI's conservative effective default unless the upstream registry changes.
-
-Pi AI 0.83.0 also exposes `claude-opus-5` with a 1,000,000-token context window, 128,000-token maximum output, and `xhigh` and `max` thinking levels. Anthropic-only setups select it automatically as the latest Opus.
-
-`tests/model-ordering.test.ts` pins this metadata so a future registry change is reviewed rather than silently changing the UI/runtime contract.
+`tests/model-ordering.test.ts` pins these limits and selector behavior.
 
 ## When to run this
 

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,6 +1,6 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-07-16
+**Last verified:** 2026-08-03
 
 This repo hardcodes a small set of "featured" and "preferred" model patterns for sorting and default selection. Static built-in models come from Pi AI, while custom and extension providers can add cached, dynamically discovered catalogues at runtime.
 
@@ -12,7 +12,7 @@ This doc describes how to update:
 
 ## Sources of truth
 
-- **Built-in model IDs:** `node_modules/@earendil-works/pi-ai/dist/models.generated.js`, exposed through `builtinProviders()`.
+- **Built-in model IDs and limits:** provider catalogues under `node_modules/@earendil-works/pi-ai/dist/providers/data/`, exposed through `builtinModels()`.
 - **Runtime lookup and streaming:** the taskpane-owned `BrowserModelRuntime`, backed by Pi AI's `createModels()` collection.
 - **Dynamic catalogue cache:** IndexedDB store `model-catalogs`, accessed through `ModelCatalogsStore`; restored entries are rebound to the provider's current API/base URL before use.
 - **Discovery bounds:** responses are limited to 2 MiB, 2,000 entries and 256 characters per model ID. An invalid/oversized refresh leaves the last safe cache and configured baseline intact.
@@ -21,7 +21,7 @@ This doc describes how to update:
 
 Do not use Pi coding-agent's Node/file `ModelRuntime` directly in the Office WebView. Pi for Excel uses the same Pi AI provider primitives with browser storage, OAuth and proxy policy. Cross-check the installed Pi package and changelog when the generated registry changes. Never infer aliases or metadata from marketing names.
 
-### Current GPT-5.6 registry snapshot (`pi-ai` 0.80.8)
+### Current GPT-5.6 and Claude Opus 5 registry snapshot (`pi-ai` 0.83.0)
 
 Upstream exposes exactly three IDs on both `openai` and `openai-codex`; there is deliberately no bare `gpt-5.6` alias:
 
@@ -35,9 +35,12 @@ Prices are registry values in USD per million tokens. All three models:
 
 - accept text and image input, support reasoning, and expose `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max` through `getSupportedThinkingLevels()`
 - have a 128,000-token maximum output
-- use a 272,000-token context window through the OpenAI API (`openai-responses`, `https://api.openai.com/v1`)
-- use a 372,000-token context window through ChatGPT (`openai-codex-responses`, `https://chatgpt.com/backend-api`)
+- use a 272,000-token effective context window through both the OpenAI API (`openai-responses`, `https://api.openai.com/v1`) and ChatGPT (`openai-codex-responses`, `https://chatgpt.com/backend-api`)
 - preserve distinct native `xhigh` and `max` efforts; the ChatGPT map also maps the add-in's `minimal` level to upstream `low`
+
+Pi AI 0.81.0 deliberately reduced the ChatGPT GPT-5.6 default from 372,000 to 272,000 tokens to avoid automatically entering long-context pricing. OpenAI's public Sol model page advertises a 1,050,000-token context window, but Pi for Excel follows Pi AI's conservative effective default unless the upstream registry changes.
+
+Pi AI 0.83.0 also exposes `claude-opus-5` with a 1,000,000-token context window, 128,000-token maximum output, and `xhigh` and `max` thinking levels. Anthropic-only setups select it automatically as the latest Opus.
 
 `tests/model-ordering.test.ts` pins this metadata so a future registry change is reviewed rather than silently changing the UI/runtime contract.
 
@@ -80,7 +83,7 @@ npm view @earendil-works/pi-agent-core versions --json
 
 **Dependency policy:**
 
-- `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` move **together** to the newest common version. The browser runtime migration was verified on `0.80.8`.
+- `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` move **together** to the newest common version. The browser runtime was verified on `0.83.0`.
 - Both must be **exact-pinned** in `package.json`.
 - The lockfile must resolve **exactly one** copy of `pi-ai`. Two copies = two model registries = the model selector and the app disagree about available models.
 - `scripts/check-pi-deps-lockstep.mjs` (run via `npm run check:pi-lockstep`) enforces all of this.
@@ -98,11 +101,10 @@ npm install @earendil-works/pi-ai@<version> @earendil-works/pi-agent-core@<versi
 Search the generated catalogue and query the runtime-facing built-in provider collection:
 
 ```bash
-rg -n "gpt-5\\.6-(sol|terra|luna)" node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
-rg -n "claude-fable-5"             node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
-rg -n "claude-opus-4-8"  node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
-rg -n "gemini-3\\.1-pro-preview" node_modules/@earendil-works/pi-ai/dist/models.generated.js -S
-node --input-type=module -e 'import { builtinModels } from "@earendil-works/pi-ai/providers/all"; const m=builtinModels(); console.log(m.getModel("openai", "gpt-5.6-sol"))'
+rg -n "gpt-5\\.6-(sol|terra|luna)" node_modules/@earendil-works/pi-ai/dist/providers/data/openai*.json -S
+rg -n "claude-(fable|opus)-5" node_modules/@earendil-works/pi-ai/dist/providers/data/anthropic.json -S
+rg -n "gemini-3\\.1-pro-preview" node_modules/@earendil-works/pi-ai/dist/providers/data/google.json -S
+node --input-type=module -e 'import { builtinModels } from "@earendil-works/pi-ai/providers/all"; const m=builtinModels(); console.log(m.getModel("openai-codex", "gpt-5.6-sol")); console.log(m.getModel("anthropic", "claude-opus-5"))'
 npm run test:models
 ```
 

--- a/docs/release-notes/v0.10.0-pre.md
+++ b/docs/release-notes/v0.10.0-pre.md
@@ -11,10 +11,14 @@ _Pre-release. Changes since `v0.9.5-pre`._
 ## Highlights
 
 - **GPT-5.6 Sol, Terra, and Luna**
-  - Updated `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` together to `0.80.8` and adopted the three canonical GPT-5.6 IDs: `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
+  - Updated `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` together to `0.83.0` and adopted the three canonical GPT-5.6 IDs: `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
   - There is intentionally no bare `gpt-5.6` alias. Registry metadata, context/output limits, pricing tiers, and provider mappings are pinned by regression tests.
   - OpenAI-backed defaults and picker ordering now prefer Sol, then Terra, then Luna. Sol is the default for both OpenAI API and ChatGPT-backed setups.
   - Reasoning controls are registry-driven and expose distinct `xhigh` (**Extra high**) and `max` (**Max**) levels instead of conflating them.
+
+- **Claude Opus 5**
+  - Added the current Pi AI registry entry for `claude-opus-5`, with a 1M-token context window, 128k maximum output, and adaptive `xhigh` and `max` thinking levels.
+  - Anthropic-only setups automatically select Opus 5 as the latest Opus model.
 
 - **Browser-native dynamic model runtime**
   - Replaced Pi AI's temporary global `/compat` registry with an injected `createModels()` runtime shared by model selection, session restore, extension side-completions and streaming.
@@ -50,7 +54,7 @@ _Pre-release. Changes since `v0.9.5-pre`._
 | Provider path | IDs | Context | Max output | Input | Thinking levels |
 |---|---|---:|---:|---|---|
 | OpenAI API (`openai-responses`) | Sol, Terra, Luna | 272k | 128k | Text + image | Off, Minimal, Low, Medium, High, Extra high, Max |
-| ChatGPT (`openai-codex-responses`) | Sol, Terra, Luna | 372k | 128k | Text + image | Off, Minimal, Low, Medium, High, Extra high, Max |
+| ChatGPT (`openai-codex-responses`) | Sol, Terra, Luna | 272k | 128k | Text + image | Off, Minimal, Low, Medium, High, Extra high, Max |
 
 See [`docs/model-updates.md`](../model-updates.md) for exact IDs, prices, tiered costs, endpoints, and thinking-level maps.
 
@@ -74,7 +78,7 @@ A real Excel for Mac pass on a new blank workbook completed all three canonical 
 - `npm run build`
 - `npm run validate`
 - Browser taskpane visual check: GPT-5.6 selector ordering plus separate **Extra high** and **Max** reasoning choices, including internal scrolling at a 290×400 short-pane viewport
-- Real macOS Excel taskpane on a new blank workbook: exact Sol, Terra, and Luna rows selected and activated with canonical display names, 372k context, and 128k maximum output
+- Earlier Pi `0.80.8` real macOS Excel taskpane pass: exact Sol, Terra, and Luna rows selected and activated with canonical display names, the then-current 372k ChatGPT context, and 128k maximum output; Pi `0.83.0` now deliberately defaults ChatGPT GPT-5.6 to 272k
 - Real macOS Excel completion: Sol, Terra, and Luna each returned its fixed sentinel with `stopReason=stop`; Luna used the proxy's native-compatible Codex WebSocket bridge
 - Real Office.js scratch write/read/formula check completed and restored the blank fixture; Excel stayed in the background throughout
 - Real Excel sandbox extension-provider adversarial smoke passed permission gates, host-owned credential injection, exact inference, offline cache fallback, endpoint rebinding, in-flight unload, delayed discovery cancellation, catalogue bounds and host-allowlist rejection

--- a/docs/release-notes/v0.10.0-pre.md
+++ b/docs/release-notes/v0.10.0-pre.md
@@ -12,13 +12,12 @@ _Pre-release. Changes since `v0.9.5-pre`._
 
 - **GPT-5.6 Sol, Terra, and Luna**
   - Updated `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` together to `0.83.0` and adopted the three canonical GPT-5.6 IDs: `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
-  - There is intentionally no bare `gpt-5.6` alias. Registry metadata, context/output limits, pricing tiers, and provider mappings are pinned by regression tests.
+  - There is intentionally no bare `gpt-5.6` alias. Regression tests cover the limits and selector behavior the add-in depends on.
   - OpenAI-backed defaults and picker ordering now prefer Sol, then Terra, then Luna. Sol is the default for both OpenAI API and ChatGPT-backed setups.
   - Reasoning controls are registry-driven and expose distinct `xhigh` (**Extra high**) and `max` (**Max**) levels instead of conflating them.
 
 - **Claude Opus 5**
-  - Added the current Pi AI registry entry for `claude-opus-5`, with a 1M-token context window, 128k maximum output, and adaptive `xhigh` and `max` thinking levels.
-  - Anthropic-only setups automatically select Opus 5 as the latest Opus model.
+  - Pi AI `0.83.0` adds `claude-opus-5` with a 1M-token context window and 128k maximum output; Anthropic-only setups select it by default.
 
 - **Browser-native dynamic model runtime**
   - Replaced Pi AI's temporary global `/compat` registry with an injected `createModels()` runtime shared by model selection, session restore, extension side-completions and streaming.
@@ -78,7 +77,7 @@ A real Excel for Mac pass on a new blank workbook completed all three canonical 
 - `npm run build`
 - `npm run validate`
 - Browser taskpane visual check: GPT-5.6 selector ordering plus separate **Extra high** and **Max** reasoning choices, including internal scrolling at a 290×400 short-pane viewport
-- Earlier Pi `0.80.8` real macOS Excel taskpane pass: exact Sol, Terra, and Luna rows selected and activated with canonical display names, the then-current 372k ChatGPT context, and 128k maximum output; Pi `0.83.0` now deliberately defaults ChatGPT GPT-5.6 to 272k
+- Real macOS Excel taskpane on Pi `0.80.8`: exact Sol, Terra, and Luna rows selected with the then-current 372k ChatGPT context and 128k maximum output
 - Real macOS Excel completion: Sol, Terra, and Luna each returned its fixed sentinel with `stopReason=stop`; Luna used the proxy's native-compatible Codex WebSocket bridge
 - Real Office.js scratch write/read/formula check completed and restored the blank fixture; Excel stayed in the background throughout
 - Real Excel sandbox extension-provider adversarial smoke passed permission gates, host-owned credential injection, exact inference, offline cache fallback, endpoint rebinding, in-flight unload, delayed discovery cancellation, catalogue bounds and host-allowlist rejection

--- a/docs/release-smoke-runs/templates/windows-host-smoke-template.md
+++ b/docs/release-smoke-runs/templates/windows-host-smoke-template.md
@@ -31,11 +31,11 @@ Use a fresh chat tab for each model and fixed prompts with no tools.
 
 | ID | Status (Pass/Fail/Blocked) | Evidence (taskpane-only screenshot/log) | Expected |
 |---|---|---|---|
-| M-WIN-1 |  |  | Select exact `openai-codex/gpt-5.6-sol`; 372k context / 128k output |
+| M-WIN-1 |  |  | Select exact `openai-codex/gpt-5.6-sol`; 272k context / 128k output |
 | M-WIN-2 |  |  | `Reply with exactly SOL_WINDOWS_OK. Do not use tools.` returns exact sentinel |
-| M-WIN-3 |  |  | Select exact `openai-codex/gpt-5.6-terra`; 372k / 128k |
+| M-WIN-3 |  |  | Select exact `openai-codex/gpt-5.6-terra`; 272k / 128k |
 | M-WIN-4 |  |  | Exact `TERRA_WINDOWS_OK` response |
-| M-WIN-5 |  |  | Select exact `openai-codex/gpt-5.6-luna`; 372k / 128k |
+| M-WIN-5 |  |  | Select exact `openai-codex/gpt-5.6-luna`; 272k / 128k |
 | M-WIN-6 |  |  | Exact `LUNA_WINDOWS_WEBSOCKET_OK` response through the proxy bridge |
 | M-WIN-7 |  |  | Select a pre-existing ChatGPT model and complete one no-tool turn |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
-        "@earendil-works/pi-agent-core": "0.80.8",
-        "@earendil-works/pi-ai": "0.80.8",
+        "@earendil-works/pi-agent-core": "0.83.0",
+        "@earendil-works/pi-ai": "0.83.0",
         "@sinclair/typebox": "^0.34.49",
         "highlight.js": "^11.11.1",
         "lit": "^3.3.3",
@@ -189,16 +189,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
-      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "version": "3.977.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.5.tgz",
+      "integrity": "sha512-O5otOc1c6UZh5HsHAaPdYBcUUR9HL6mtnKqvc8nxN/CKDGUBUpsdh0q8K04Uz/dd1i0TaGyIQuQNqoO7+ad2TQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.4",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -208,14 +208,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
-      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.66.tgz",
+      "integrity": "sha512-bOzP2+zdJ0XrghywB4FaJXtGZCx9yS0AGps+VJ5yEgg30wVyHNmVDBwVDXcRypzQY5iLGCS3NSn0nsuISqjFCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -224,16 +224,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
-      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.68.tgz",
+      "integrity": "sha512-lkunS8X+H6V76WE+t/uGQm/U8v0JXK5mLfNFTUAMlE1kqaCjwlmqKJrgCVtqjK/vqnlrSWsLK4Lr4NANBWlfTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -242,12 +242,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -256,22 +256,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.3.tgz",
-      "integrity": "sha512-WpuqYX4gGkx++fCTSWE8+41JzkZVcrI50SH48Ml4CsG1pyuHKyMmpw/FixBHDrmjoQ553PmeCLa/fZIcst+WyA==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.11.tgz",
+      "integrity": "sha512-KoDEolYtLHG/8C+IiZpXbJWyBOMkrHV+j66Kb9PBXmLv5euGb7aELvuCmLenoGAV6gBW2wM7TsG/1e5iulH4kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-login": "^3.972.65",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/credential-provider-env": "^3.972.66",
+        "@aws-sdk/credential-provider-http": "^3.972.68",
+        "@aws-sdk/credential-provider-login": "^3.972.73",
+        "@aws-sdk/credential-provider-process": "^3.972.66",
+        "@aws-sdk/credential-provider-sso": "^3.973.10",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.72",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -280,15 +280,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.65.tgz",
-      "integrity": "sha512-xr9rgjYEdmC2Tpg2lwt9o+nOEaK9Qpd+dBjzrVCuWWyQfvhO91Ezu0Hh9ts2VUxOZxmS/k5T9msa34e4R1bnrQ==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.73.tgz",
+      "integrity": "sha512-tjsxMkTAFkmiV9ycmymapb9nLECWVOwFs0bZMQ9gB9bnbY8/HwfukHZlWbXZZp7qkPU6EXAfOcMm3DioFFEywA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -297,20 +297,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.69.tgz",
-      "integrity": "sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.77.tgz",
+      "integrity": "sha512-l4nitYCN/Ls57vtUfdextCjTjW41JD7lQiAnuR0RTbdByFc/6OmEAzwGd+lrp6CUtiXGQL1FCaYiamfHASrwBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-ini": "^3.973.3",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/credential-provider-env": "^3.972.66",
+        "@aws-sdk/credential-provider-http": "^3.972.68",
+        "@aws-sdk/credential-provider-ini": "^3.973.11",
+        "@aws-sdk/credential-provider-process": "^3.972.66",
+        "@aws-sdk/credential-provider-sso": "^3.973.10",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.72",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -319,14 +319,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
-      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.66.tgz",
+      "integrity": "sha512-YOnX6bIhdjx0QfaENu2PB0eFm5MEc9ft8XNGQ+NxMfeLSq9aE+XjWCwDupEnV4UWv5ZFpBLJbTREIx7KNOoqpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -335,16 +335,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
-      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.10.tgz",
+      "integrity": "sha512-IsXnQ35j5VE+3ZK6aIhT5ypB+Jim3zRwVz0nYuVwyBKZyu/SYx+O2/LQpng8c2EiuwyqceabsDlYrICHDlJPsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
+        "@aws-sdk/token-providers": "3.1102.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -353,15 +353,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
-      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "version": "3.1102.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1102.0.tgz",
+      "integrity": "sha512-Ua700vVvM1q105yABSUQWkCK6FeTrNfU6ORGetJe5BzkZWY7QhkF7SVTOlmDGWRDNd6jbyY0Dv5e+E4bMBEmLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -370,15 +370,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
-      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.72.tgz",
+      "integrity": "sha512-nj9Zlsy7ya+fy+jhWTJwgfr7YdtDM4xHyZvgKuftuny0UgROVx9lxwvsWJSLvpKk4lig0m0tHng3k1fEnt0LeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -387,13 +387,13 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.28.tgz",
-      "integrity": "sha512-XV5sEH1xH5oydNgvUH87CR8BA2SBZXltckteS17D7ZT2k2THIBiExO9TEBYcgqUU31WAIfBH2hmx+fhFMiTL4Q==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -402,13 +402,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
-      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -417,16 +417,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.41.tgz",
-      "integrity": "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.48.tgz",
+      "integrity": "sha512-1BYTN+c0J/n5HfoDl3IR2Cjhfp2coByofX+gOh8HhyXda1HP7oGAUI/uyKSn4Xc+rrvVcsSROTVF1ZRBs07ARQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -435,17 +435,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
-      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "version": "3.997.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.40.tgz",
+      "integrity": "sha512-hEdHT0PBR4fkGxWhwKG5EtEYKnAM7HKkp0vD10ufk4YcXejH4r4q6G/XhPzjUc6Yxo5kBS2vHg7llj4ViR9VTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -454,12 +454,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -468,13 +468,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
-      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
-      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1080,14 +1080,15 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.8.tgz",
-      "integrity": "sha512-TPY9mdZARD/W52R/Y3pGftqC2QuolhYLgqnAn8V8I3J7oXY/KHcnG3AMUloJvmAIFX0n6LuRDZLcvcBPlUwKJg==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
+      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.8",
+        "@earendil-works/pi-ai": "^0.83.0",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -1103,16 +1104,10 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.8.tgz",
-      "integrity": "sha512-GkiMUP3PB0hwBhj7qNppCa6z1U+CnwBf4gcxC+fg2PWdNrliaJQQNp4DUERiZqS7MJBLEu56kwpdrG7Tjymonw==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
+      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1125,7 +1120,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -1153,12 +1148,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -3735,9 +3724,9 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -3748,12 +3737,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
-      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3762,12 +3751,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
-      "integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3802,12 +3791,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
-      "integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -5437,6 +5426,15 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -6426,9 +6424,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
-      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -6557,9 +6555,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
-      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -6970,9 +6968,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -10683,10 +10681,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.3.tgz",
-      "integrity": "sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==",
-      "dev": true,
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
     },
     "node_modules/typedi": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
-    "@earendil-works/pi-agent-core": "0.80.8",
-    "@earendil-works/pi-ai": "0.80.8",
+    "@earendil-works/pi-agent-core": "0.83.0",
+    "@earendil-works/pi-ai": "0.83.0",
     "@sinclair/typebox": "^0.34.49",
     "highlight.js": "^11.11.1",
     "lit": "^3.3.3",
@@ -87,6 +87,7 @@
     "fast-xml-parser": "5.7.0",
     "@xmldom/xmldom": "0.8.13",
     "protobufjs": "7.6.5",
-    "follow-redirects": "1.16.0"
+    "follow-redirects": "1.16.0",
+    "ip-address": "10.4.0"
   }
 }

--- a/src/commands/builtins/export.ts
+++ b/src/commands/builtins/export.ts
@@ -523,11 +523,6 @@ export async function runCompactCommand(agent: Agent, args: string): Promise<voi
     return;
   }
 
-  // IMPORTANT: use the agent's configured streamFn + api key resolver.
-  // Calling pi-ai's completeSimple() directly bypasses:
-  // - our CORS proxy logic (streamFn)
-  // - our API key/OAuth resolution (agent.getApiKey)
-  // and can crash in browser WebViews due to env key fallbacks using `process`.
   const apiKey = agent.getApiKey ? await agent.getApiKey(model.provider) : undefined;
   if (!apiKey) {
     showToast(t("export.toast.compact.no_api_key", { provider: model.provider }));

--- a/src/commands/builtins/export.ts
+++ b/src/commands/builtins/export.ts
@@ -587,7 +587,7 @@ export async function runCompactCommand(agent: Agent, args: string): Promise<voi
       ...(customInstructions !== undefined ? { customInstructions } : {}),
     });
 
-    const stream = await agent.streamFn(
+    const stream = await agent.streamFunction(
       model,
       {
         systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,

--- a/src/extensions/runtime-manager.ts
+++ b/src/extensions/runtime-manager.ts
@@ -472,7 +472,7 @@ export class ExtensionRuntimeManager {
       throw new Error("llm.complete requires a messages array.");
     }
 
-    const stream = await agent.streamFn(
+    const stream = await agent.streamFunction(
       model,
       {
         ...(request.systemPrompt !== undefined ? { systemPrompt: request.systemPrompt } : {}),

--- a/src/taskpane/action-queue.ts
+++ b/src/taskpane/action-queue.ts
@@ -2,7 +2,7 @@
  * UI-level ordered action queue.
  *
  * Needed because some actions (notably `/compact`) run outside the Agent loop
- * (they call `agent.streamFn(...)` directly) and therefore don't set
+ * (they call `agent.streamFunction(...)` directly) and therefore don't set
  * `agent.state.isStreaming`. Without a queue, user input can be lost when
  * compaction rewrites the message list.
  *

--- a/tests/action-queue.test.ts
+++ b/tests/action-queue.test.ts
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { Agent, type AgentMessage } from "@earendil-works/pi-agent-core";
-import type { Api, ImageContent, Model, Usage } from "@earendil-works/pi-ai";
+import {
+  createAssistantMessageEventStream,
+  type Api,
+  type ImageContent,
+  type Model,
+  type Usage,
+} from "@earendil-works/pi-ai";
 
 import { commandRegistry, type SlashCommand } from "../src/commands/types.ts";
 import { createActionQueue } from "../src/taskpane/action-queue.ts";
@@ -16,6 +22,7 @@ class TestAgent extends Agent {
 
   constructor(model?: Model<Api>) {
     super({
+      streamFn: createAssistantMessageEventStream,
       initialState: {
         ...(model ? { model } : {}),
         messages: [],

--- a/tests/auto-compaction.test.ts
+++ b/tests/auto-compaction.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { Agent, type AgentMessage } from "@earendil-works/pi-agent-core";
-import type { Api, Model, ToolResultMessage } from "@earendil-works/pi-ai";
+import {
+  createAssistantMessageEventStream,
+  type Api,
+  type Model,
+  type ToolResultMessage,
+} from "@earendil-works/pi-ai";
 
 import {
   maybeAutoCompactBeforeContinuation,
@@ -78,6 +83,7 @@ function createModel(contextWindow: number): Model<Api> {
 
 function createAgent(args: { contextWindow: number; messages: AgentMessage[] }): Agent {
   return new Agent({
+    streamFn: createAssistantMessageEventStream,
     initialState: {
       model: createModel(args.contextWindow),
       messages: args.messages,

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -3,12 +3,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 
-import type {
-  Api,
-  Context,
-  Model,
-  SimpleStreamOptions,
-} from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 
 import { BROWSER_OAUTH_PROVIDERS, mapToApiProvider } from "../src/auth/provider-map.ts";
@@ -49,74 +44,8 @@ function pickDefaultModel(availableProviders: string[]): Model<Api> {
   return pickDefaultModelFromRuntime(modelsRuntime, availableProviders);
 }
 
-function completeSimple(
-  model: Model<Api>,
-  context: Context,
-  options?: SimpleStreamOptions,
-) {
-  return modelsRuntime.completeSimple(model, context, options);
-}
-
 const OPENAI_PROVIDERS: OpenAiProvider[] = ["openai", "openai-codex"];
-
-const GPT_56_VARIANTS = [
-  {
-    id: "gpt-5.6-sol",
-    name: "GPT-5.6 Sol",
-    cost: {
-      input: 5,
-      output: 30,
-      cacheRead: 0.5,
-      cacheWrite: 6.25,
-      tiers: [{ inputTokensAbove: 272_000, input: 10, output: 45, cacheRead: 1, cacheWrite: 12.5 }],
-    },
-  },
-  {
-    id: "gpt-5.6-terra",
-    name: "GPT-5.6 Terra",
-    cost: {
-      input: 2.5,
-      output: 15,
-      cacheRead: 0.25,
-      cacheWrite: 3.125,
-      tiers: [{ inputTokensAbove: 272_000, input: 5, output: 22.5, cacheRead: 0.5, cacheWrite: 6.25 }],
-    },
-  },
-  {
-    id: "gpt-5.6-luna",
-    name: "GPT-5.6 Luna",
-    cost: {
-      input: 1,
-      output: 6,
-      cacheRead: 0.1,
-      cacheWrite: 1.25,
-      tiers: [{ inputTokensAbove: 272_000, input: 2, output: 9, cacheRead: 0.2, cacheWrite: 2.5 }],
-    },
-  },
-];
-
-const GPT_56_IDS = GPT_56_VARIANTS.map((variant) => variant.id);
-const GPT_56_API_THINKING_LEVELS = ["off", "low", "medium", "high", "xhigh", "max"];
-const GPT_56_CODEX_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
-
-function pickExpectedOpenAiDefault(provider: OpenAiProvider): Model<Api> | null {
-  const models = getModels(provider);
-  const bestGeneral = models
-    .filter((model) => isOpenAiGeneralGptModelId(model.id))
-    .sort((a, b) => compareOpenAiModelIds(a.id, b.id))[0];
-  const bestCodex = models
-    .filter((model) => isOpenAiCodexModelId(model.id))
-    .sort((a, b) => compareOpenAiModelIds(a.id, b.id))[0];
-
-  if (bestGeneral && bestCodex) {
-    return shouldPreferOpenAiGeneralModel(bestGeneral.id, bestCodex.id) ? bestGeneral : bestCodex;
-  }
-
-  if (bestGeneral) return bestGeneral;
-  if (bestCodex) return bestCodex;
-
-  return models.slice().sort((a, b) => compareOpenAiModelIds(a.id, b.id))[0] ?? null;
-}
+const GPT_56_IDS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
 
 void test("parseMajorMinor packs Claude-style -major-minor as major*10+minor", () => {
   assert.equal(parseMajorMinor("claude-opus-4-6"), 46);
@@ -218,58 +147,17 @@ void test("shouldPreferOpenAiGeneralModel only prefers GPT when it is as new or 
   assert.equal(shouldPreferOpenAiGeneralModel("gpt-5-pro", "gpt-5.1-codex-max"), false);
 });
 
-void test("current Pi registry exposes only the three canonical GPT-5.6 tier IDs", () => {
+void test("GPT-5.6 models expose the limits and thinking levels used by the add-in", () => {
   for (const provider of OPENAI_PROVIDERS) {
-    const ids = getModels(provider)
-      .filter((model) => model.id.startsWith("gpt-5.6"))
-      .map((model) => model.id)
-      .sort();
-
-    assert.deepEqual(ids, GPT_56_IDS.slice().sort(), `unexpected GPT-5.6 IDs for ${provider}`);
-    assert.equal(modelsRuntime.getModel(provider, "gpt-5.6"), undefined, `bare alias must not exist for ${provider}`);
-  }
-
-  assert.equal(getModel("anthropic", "claude-opus-4-7").id, "claude-opus-4-7");
-  assert.equal(getModel("anthropic", "claude-fable-5").id, "claude-fable-5");
-  assert.equal(getModel("google", "gemini-3.1-pro-preview").id, "gemini-3.1-pro-preview");
-});
-
-void test("GPT-5.6 registry metadata exactly matches native Pi 0.83.0", () => {
-  for (const provider of OPENAI_PROVIDERS) {
-    const isCodex = provider === "openai-codex";
-
-    for (const expected of GPT_56_VARIANTS) {
-      const model = getModel(provider, expected.id);
-      assert.equal(model.id, expected.id);
-      assert.equal(model.name, expected.name);
-      assert.equal(model.provider, provider);
-      assert.equal(model.api, isCodex ? "openai-codex-responses" : "openai-responses");
-      assert.equal(
-        model.baseUrl,
-        isCodex ? "https://chatgpt.com/backend-api" : "https://api.openai.com/v1",
-      );
-      assert.equal(model.reasoning, true);
-      assert.deepEqual(model.input, ["text", "image"]);
+    for (const id of GPT_56_IDS) {
+      const model = getModel(provider, id);
       assert.equal(model.contextWindow, 272_000);
       assert.equal(model.maxTokens, 128_000);
-      assert.deepEqual(model.cost, expected.cost);
-      assert.deepEqual(
-        model.thinkingLevelMap,
-        isCodex
-          ? { xhigh: "xhigh", max: "max", minimal: "low" }
-          : {
-            off: "none",
-            minimal: null,
-            low: "low",
-            medium: "medium",
-            high: "high",
-            xhigh: "xhigh",
-            max: "max",
-          },
-      );
       assert.deepEqual(
         getThinkingLevelsForModel(model),
-        isCodex ? GPT_56_CODEX_THINKING_LEVELS : GPT_56_API_THINKING_LEVELS,
+        provider === "openai-codex"
+          ? ["off", "minimal", "low", "medium", "high", "xhigh", "max"]
+          : ["off", "low", "medium", "high", "xhigh", "max"],
       );
     }
   }
@@ -285,26 +173,21 @@ void test("model selector orders all GPT-5.6 tiers as Sol, Terra, Luna", () => {
   assert.deepEqual(ordered.map((item) => item.id), GPT_56_IDS);
 });
 
-void test("Claude 5 registry metadata is usable by the add-in", () => {
+void test("Claude Fable 5 registry metadata is usable by the add-in", () => {
   const fable = getModel("anthropic", "claude-fable-5");
   assert.equal(fable.provider, "anthropic");
   assert.equal(fable.api, "anthropic-messages");
   assert.ok(fable.reasoning, "expected Fable 5 to support reasoning");
   assert.ok(fable.contextWindow >= 1_000_000, "expected a 1M-token context window");
+});
 
+void test("Claude Opus 5 exposes the limits used by the add-in", () => {
   const opus = getModel("anthropic", "claude-opus-5");
-  assert.equal(opus.provider, "anthropic");
-  assert.equal(opus.api, "anthropic-messages");
-  assert.ok(opus.reasoning, "expected Opus 5 to support reasoning");
   assert.equal(opus.contextWindow, 1_000_000);
   assert.equal(opus.maxTokens, 128_000);
 });
 
 void test("pickDefaultModel prefers the latest Opus for Anthropic-only setups", () => {
-  const models = getModels("anthropic");
-  const opus = models.filter((m) => m.id.startsWith("claude-opus-"));
-  assert.ok(opus.length > 0, "expected at least one Opus model in the registry");
-
   const selected = pickDefaultModel(["anthropic"]);
   assert.equal(selected.provider, "anthropic");
   assert.equal(selected.id, "claude-opus-5");
@@ -321,7 +204,7 @@ void test("current OpenAI providers select GPT-5.6 Sol as the default", () => {
 void test("Bedrock provider uses the browser-safe unsupported-provider stub", async () => {
   installBedrockProviderStub();
 
-  const selected = await completeSimple(
+  const selected = await modelsRuntime.completeSimple(
     getModel("amazon-bedrock", "amazon.nova-micro-v1:0"),
     {
       messages: [
@@ -337,17 +220,6 @@ void test("Bedrock provider uses the browser-safe unsupported-provider stub", as
 
   assert.equal(selected.stopReason, "error");
   assert.match(selected.errorMessage ?? "", /Amazon Bedrock is not supported/);
-});
-
-void test("pickDefaultModel matches the current OpenAI default-selection contract", () => {
-  for (const provider of OPENAI_PROVIDERS) {
-    const expected = pickExpectedOpenAiDefault(provider);
-    assert.ok(expected, `expected OpenAI default candidate for ${provider}`);
-
-    const selected = pickDefaultModel([provider]);
-    assert.equal(selected.provider, provider);
-    assert.equal(selected.id, expected.id);
-  }
 });
 
 void test("pickDefaultModel falls back to the preferred hardcoded OpenAI default", () => {
@@ -498,7 +370,7 @@ void test("compareModels sorts non-OpenAI models by provider, family, then recen
 void test("compareModels puts the Fable family before Opus/Sonnet/Haiku for Anthropic", () => {
   const models = [
     { provider: "anthropic", id: "claude-haiku-4-5" },
-    { provider: "anthropic", id: "claude-opus-5" },
+    { provider: "anthropic", id: "claude-opus-4-8" },
     { provider: "anthropic", id: "claude-fable-5" },
     { provider: "anthropic", id: "claude-sonnet-4-6" },
   ];
@@ -507,7 +379,7 @@ void test("compareModels puts the Fable family before Opus/Sonnet/Haiku for Anth
 
   assert.deepEqual(
     models.map((m) => m.id),
-    ["claude-fable-5", "claude-opus-5", "claude-sonnet-4-6", "claude-haiku-4-5"],
+    ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
   );
 });
 

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -96,7 +96,8 @@ const GPT_56_VARIANTS = [
 ];
 
 const GPT_56_IDS = GPT_56_VARIANTS.map((variant) => variant.id);
-const GPT_56_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+const GPT_56_API_THINKING_LEVELS = ["off", "low", "medium", "high", "xhigh", "max"];
+const GPT_56_CODEX_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 function pickExpectedOpenAiDefault(provider: OpenAiProvider): Model<Api> | null {
   const models = getModels(provider);
@@ -233,7 +234,7 @@ void test("current Pi registry exposes only the three canonical GPT-5.6 tier IDs
   assert.equal(getModel("google", "gemini-3.1-pro-preview").id, "gemini-3.1-pro-preview");
 });
 
-void test("GPT-5.6 registry metadata exactly matches native Pi 0.80.8", () => {
+void test("GPT-5.6 registry metadata exactly matches native Pi 0.83.0", () => {
   for (const provider of OPENAI_PROVIDERS) {
     const isCodex = provider === "openai-codex";
 
@@ -249,16 +250,27 @@ void test("GPT-5.6 registry metadata exactly matches native Pi 0.80.8", () => {
       );
       assert.equal(model.reasoning, true);
       assert.deepEqual(model.input, ["text", "image"]);
-      assert.equal(model.contextWindow, isCodex ? 372_000 : 272_000);
+      assert.equal(model.contextWindow, 272_000);
       assert.equal(model.maxTokens, 128_000);
       assert.deepEqual(model.cost, expected.cost);
       assert.deepEqual(
         model.thinkingLevelMap,
         isCodex
           ? { xhigh: "xhigh", max: "max", minimal: "low" }
-          : { off: "none", xhigh: "xhigh", max: "max" },
+          : {
+            off: "none",
+            minimal: null,
+            low: "low",
+            medium: "medium",
+            high: "high",
+            xhigh: "xhigh",
+            max: "max",
+          },
       );
-      assert.deepEqual(getThinkingLevelsForModel(model), GPT_56_THINKING_LEVELS);
+      assert.deepEqual(
+        getThinkingLevelsForModel(model),
+        isCodex ? GPT_56_CODEX_THINKING_LEVELS : GPT_56_API_THINKING_LEVELS,
+      );
     }
   }
 });
@@ -273,12 +285,19 @@ void test("model selector orders all GPT-5.6 tiers as Sol, Terra, Luna", () => {
   assert.deepEqual(ordered.map((item) => item.id), GPT_56_IDS);
 });
 
-void test("Claude Fable 5 registry metadata is usable by the add-in", () => {
+void test("Claude 5 registry metadata is usable by the add-in", () => {
   const fable = getModel("anthropic", "claude-fable-5");
   assert.equal(fable.provider, "anthropic");
   assert.equal(fable.api, "anthropic-messages");
   assert.ok(fable.reasoning, "expected Fable 5 to support reasoning");
   assert.ok(fable.contextWindow >= 1_000_000, "expected a 1M-token context window");
+
+  const opus = getModel("anthropic", "claude-opus-5");
+  assert.equal(opus.provider, "anthropic");
+  assert.equal(opus.api, "anthropic-messages");
+  assert.ok(opus.reasoning, "expected Opus 5 to support reasoning");
+  assert.equal(opus.contextWindow, 1_000_000);
+  assert.equal(opus.maxTokens, 128_000);
 });
 
 void test("pickDefaultModel prefers the latest Opus for Anthropic-only setups", () => {
@@ -288,7 +307,7 @@ void test("pickDefaultModel prefers the latest Opus for Anthropic-only setups", 
 
   const selected = pickDefaultModel(["anthropic"]);
   assert.equal(selected.provider, "anthropic");
-  assert.equal(selected.id, "claude-opus-4-8");
+  assert.equal(selected.id, "claude-opus-5");
 });
 
 void test("current OpenAI providers select GPT-5.6 Sol as the default", () => {
@@ -479,7 +498,7 @@ void test("compareModels sorts non-OpenAI models by provider, family, then recen
 void test("compareModels puts the Fable family before Opus/Sonnet/Haiku for Anthropic", () => {
   const models = [
     { provider: "anthropic", id: "claude-haiku-4-5" },
-    { provider: "anthropic", id: "claude-opus-4-8" },
+    { provider: "anthropic", id: "claude-opus-5" },
     { provider: "anthropic", id: "claude-fable-5" },
     { provider: "anthropic", id: "claude-sonnet-4-6" },
   ];
@@ -488,7 +507,7 @@ void test("compareModels puts the Fable family before Opus/Sonnet/Haiku for Anth
 
   assert.deepEqual(
     models.map((m) => m.id),
-    ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
+    ["claude-fable-5", "claude-opus-5", "claude-sonnet-4-6", "claude-haiku-4-5"],
   );
 });
 

--- a/tests/overflow-recovery.test.ts
+++ b/tests/overflow-recovery.test.ts
@@ -2,7 +2,14 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { Agent, type AgentMessage } from "@earendil-works/pi-agent-core";
-import type { Api, AssistantMessage, Model, ToolResultMessage, Usage } from "@earendil-works/pi-ai";
+import {
+  createAssistantMessageEventStream,
+  type Api,
+  type AssistantMessage,
+  type Model,
+  type ToolResultMessage,
+  type Usage,
+} from "@earendil-works/pi-ai";
 
 import {
   findTrailingContextOverflowError,
@@ -82,6 +89,7 @@ function createTestAgent(args: {
   }
 
   return new RecordingAgent({
+    streamFn: createAssistantMessageEventStream,
     initialState: {
       model: args.model,
       messages: args.messages,

--- a/tests/session-restore-selection.test.ts
+++ b/tests/session-restore-selection.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { Agent } from "@earendil-works/pi-agent-core";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 
 import {
   getCrossWorkbookResumeConfirmMessage,
@@ -627,6 +628,7 @@ void test("Alt+Up detection matches host fallbacks and rejects modified chords",
 
 void test("queued restore prepends follow-up and compact queue items before draft text", () => {
   const agent = new Agent({
+    streamFn: createAssistantMessageEventStream,
     initialState: {
       messages: [],
       tools: [],


### PR DESCRIPTION
## Summary

- upgrade `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` from 0.80.8 to 0.83.0
- align GPT-5.6 with Pi AI's 272k effective context window on both OpenAI and Codex paths
- add and prefer Claude Opus 5 with its 1M context / 128k output metadata
- migrate direct agent streaming calls to the 0.83 `streamFunction` API
- update model registry assertions, release notes, smoke-test guidance, and model-update documentation
- pin the patched `ip-address` transitive version so the high-severity audit gate remains green

This supersedes the dependency-only update in #655 by including the required API migration and model metadata verification.

## Verification

- `npm ci`
- `npm run check`
- `npm run build`
- `npm run test:models` — 59 passed
- `npm run test:context` — 745 passed
- `npm run test:security` — 108 passed
- `npm audit --audit-level=high`

