### PR TITLE
docs: require model-driven end-to-end local acceptance

### DIFF
--- a/.agents/skills/excel-background-verification/SKILL.md
+++ b/.agents/skills/excel-background-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: excel-background-verification
-description: Verify pi-for-excel work against a real local Excel desktop host while keeping Excel in the background. Use after changes to workbook tools, recovery, taskpane UI, Office.js host behavior, chart/image paths, or any adversarial verification where browser-only tests are insufficient.
+description: Run real taskpane prompt to model to workbook-tool end-to-end acceptance tests in local Excel without taking foreground focus. Use for local verification of behavior changes and dependency upgrades, including tools, recovery, UI, auth, providers and Office.js paths. Direct Office.js probes and browser fallback checks are supporting evidence only.
 ---
 
 # Excel Background Verification
@@ -9,8 +9,21 @@ Use this skill to verify work in **real Excel with the real pi-for-excel taskpan
 
 The workflow has two channels:
 
-1. **Computer-use observation** (`pi-computer-use`, strict AX mode) verifies the Excel window/taskpane visually and semantically while asserting the foreground app does not change.
-2. **Taskpane background bridge** lets the real taskpane run Office.js probes, controlled scratch writes, and optional prompt submissions from inside Excel via a tokened loopback HTTPS server.
+1. **Computer-use observation** verifies the Excel window/taskpane visually and semantically while asserting the foreground app does not change. Use tools actually exposed in the current session, such as `computer_use` with `sky.get_app_state`.
+2. **Taskpane background bridge** submits real prompts through the sidebar and independently reads results from inside Excel via a tokened loopback HTTPS server. Direct Office.js probes diagnose setup; they do not replace model-driven testing.
+
+## End-to-end acceptance gate
+
+For behavior changes and dependency upgrades, require all of the following before claiming local acceptance:
+
+1. Record the tested source revision or tree. Select a current approved provider/model through the actual taskpane and record its ID and thinking level.
+2. Submit a real prompt through the sidebar. Let the model execute the workbook tools; do not perform the requested edits through test helpers.
+3. Observe actual tool execution and a completed model response. Bridge `ok: true` and `idle: true` alone do not prove success; inspect the response stop reason and errors.
+4. Independently read the workbook and assert expected values, formulas and relevant formatting or objects. Do not rely on the model's self-report.
+5. Clean up isolated scratch data and independently confirm cleanup. Verify the foreground app and window stayed unchanged.
+6. Report the provider/model, thinking level, prompt, tools observed, assertions and remaining coverage gaps. One Codex test does not establish Anthropic or WPS coverage.
+
+Keep unit tests, builds, CI, screenshots and direct host probes as supporting checks. If the real path cannot run, report the blocker and hold acceptance unless the user explicitly waives it. Documentation-only changes need no runtime test.
 
 Do not use raw keyboard/mouse/coordinate actions in this workflow. If a step requires foreground focus or raw input, stop and report that the background lane cannot verify that path.
 
@@ -18,8 +31,9 @@ Do not use raw keyboard/mouse/coordinate actions in this workflow. If a step req
 
 - Excel has the dev manifest sideloaded, pointing to `https://localhost:3141/src/taskpane.html`.
 - `cert.pem` and `key.pem` exist in the repo root and are trusted by the local WebView.
-- `pi-computer-use.app` has macOS Accessibility + Screen Recording permissions.
+- The available computer-use tool has macOS Accessibility and Screen Recording permissions. Do not assume a nested Pi session exposes older `list_apps` / `observe` tool names.
 - Run from the repo root.
+- Start the normal HTTPS CORS proxy when the configured provider route needs it (`npm run proxy:https`). A loaded pane with a stopped proxy can return `Load failed` on real model requests.
 
 ## Start the bridge + dev server
 
@@ -48,13 +62,15 @@ Check server health:
 curl -k https://localhost:3157/health
 ```
 
-If `clients` is empty, reload the taskpane without foregrounding Excel: use `pi-computer-use` in strict AX mode to press the Pi taskpane close button, then press the ribbon **Open Pi** button. Do not use raw input fallbacks.
+If `clients` is empty, first inspect the real Excel window. A workbook and loaded Pi pane are required; the startup window alone is insufficient. Confirm the sideloaded URL and running HTTPS server before changing manifests or caches. If the pane shows a network error, use a background semantic `AXPress` on **Try Again** after starting the server. Otherwise close/reopen the pane with semantic controls. Never use raw input fallbacks or focus Excel.
 
 If `clients` lists more than one taskpane, pass `--clientId <id-from-health>` to mutating `background:verify:command` calls so writes target the intended workbook. The server refuses untargeted commands when multiple live clients are connected.
 
 ## Computer-use observe lane
 
-Run Pi in strict AX mode and allow only observation/search tools unless a semantic AX button press is explicitly required:
+Prefer the current session's signed `computer_use` observation surface. Observe with `sky.get_app_state`, and use semantic accessibility actions only when background behavior is guaranteed. Do not assume a general click operation is focus-safe.
+
+For an older installation that actually exposes the following tools, this observation-only invocation is an alternative:
 
 ```bash
 PI_COMPUTER_USE_STEALTH=1 PI_COMPUTER_USE_STRICT_AX=1 \
@@ -108,13 +124,19 @@ PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run 
 PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- clearRange '{"address":"Sheet1!A1:B2","applyTo":"contents"}'
 ```
 
-When the product path itself is under test, submit an actual prompt through the sidebar instead of only calling Office.js helpers:
+For acceptance, submit an actual prompt through the sidebar. Use a scratch sheet name that does not already exist. For example, select a currently approved model, then ask it to create the sheet and write the formulas:
 
 ```bash
+PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- selectModel \
+  '{"provider":"openai-codex","modelId":"gpt-5.6-sol"}'
 PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- submitPrompt \
-  '{"text":"Write SMOKE into A1, then report exactly what changed.","waitForIdle":true,"timeoutMs":120000}'
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- readRange '{"address":"Sheet1!A1"}'
+  '{"text":"Use workbook tools to create a new sheet _pi_e2e_smoke; stop if it exists. Write 2 and 3 into A1:A2, write =SUM(A1:A2) into A3, and read back the values and formula. Leave the sheet for independent inspection. Do not change other sheets.","waitForIdle":true,"timeoutMs":120000}' --timeout 130000
+PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- readRange '{"address":"_pi_e2e_smoke!A1:A3"}'
 ```
+
+Assert that A3 is 5 and retains its formula. Ask the model to delete only the scratch sheet, then use `officeProbe` to confirm it is gone. Adapt the prompt to exercise the changed feature; this arithmetic example does not cover every change.
+
+The bridge's `submitPrompt` uses the sidebar send path. Do not send `/new` or `/name` through it expecting slash-command dispatch: these can be sent literally to the model. Create a test chat through the actual UI, verify its identity and idle state, then select the model. A restored session label does not prove which model answered; check `lastAssistant.model` and `stopReason` after the real prompt.
 
 Use the outputs as verification artifacts:
 

--- a/.agents/skills/excel-background-verification/SKILL.md
+++ b/.agents/skills/excel-background-verification/SKILL.md
@@ -1,175 +1,105 @@
 ---
 name: excel-background-verification
-description: Run real taskpane prompt to model to workbook-tool end-to-end acceptance tests in local Excel without taking foreground focus. Use for local verification of behavior changes and dependency upgrades, including tools, recovery, UI, auth, providers and Office.js paths. Direct Office.js probes and browser fallback checks are supporting evidence only.
+description: Run model-driven end-to-end tests in real local Excel while keeping it in the background. Use for local acceptance of behavior changes and dependency upgrades involving workbook tools, taskpane UI, recovery, auth or providers.
 ---
 
-# Excel Background Verification
+# Background Excel end-to-end tests
 
-Use this skill to verify work in **real Excel with the real pi-for-excel taskpane** without taking over the user's foreground app.
+Follow the acceptance policy in `docs/coding-standards.md`. The model performs the work through the taskpane; the test bridge submits prompts and independently reads the workbook.
 
-The workflow has two channels:
+## Set up
 
-1. **Computer-use observation** verifies the Excel window/taskpane visually and semantically while asserting the foreground app does not change. Use tools actually exposed in the current session, such as `computer_use` with `sky.get_app_state`.
-2. **Taskpane background bridge** submits real prompts through the sidebar and independently reads results from inside Excel via a tokened loopback HTTPS server. Direct Office.js probes diagnose setup; they do not replace model-driven testing.
+Run from the worktree containing the code under test. You need:
 
-## End-to-end acceptance gate
+- a scratch workbook open in Excel with the Pi taskpane loaded
+- the sideloaded manifest pointing to `https://localhost:3141/src/taskpane.html`
+- trusted `cert.pem` and `key.pem` files in the worktree
+- an approved current model with working authentication
+- a computer-use tool with Accessibility and Screen Recording permissions
 
-For behavior changes and dependency upgrades, require all of the following before claiming local acceptance:
-
-1. Record the tested source revision or tree. Select a current approved provider/model through the actual taskpane and record its ID and thinking level.
-2. Submit a real prompt through the sidebar. Let the model execute the workbook tools; do not perform the requested edits through test helpers.
-3. Observe actual tool execution and a completed model response. Bridge `ok: true` and `idle: true` alone do not prove success; inspect the response stop reason and errors.
-4. Independently read the workbook and assert expected values, formulas and relevant formatting or objects. Do not rely on the model's self-report.
-5. Clean up isolated scratch data and independently confirm cleanup. Verify the foreground app and window stayed unchanged.
-6. Report the provider/model, thinking level, prompt, tools observed, assertions and remaining coverage gaps. One Codex test does not establish Anthropic or WPS coverage.
-
-Keep unit tests, builds, CI, screenshots and direct host probes as supporting checks. If the real path cannot run, report the blocker and hold acceptance unless the user explicitly waives it. Documentation-only changes need no runtime test.
-
-Do not use raw keyboard/mouse/coordinate actions in this workflow. If a step requires foreground focus or raw input, stop and report that the background lane cannot verify that path.
-
-## Prerequisites
-
-- Excel has the dev manifest sideloaded, pointing to `https://localhost:3141/src/taskpane.html`.
-- `cert.pem` and `key.pem` exist in the repo root and are trusted by the local WebView.
-- The available computer-use tool has macOS Accessibility and Screen Recording permissions. Do not assume a nested Pi session exposes older `list_apps` / `observe` tool names.
-- Run from the repo root.
-- Start the normal HTTPS CORS proxy when the configured provider route needs it (`npm run proxy:https`). A loaded pane with a stopped proxy can return `Load failed` on real model requests.
-
-## Start the bridge + dev server
+Inspect existing listeners before starting servers. Reuse the correct test setup or stop only processes you own.
 
 ```bash
-TOKEN_FILE=$(mktemp /tmp/pi-background-verify-token.XXXXXX)
-chmod 600 "$TOKEN_FILE"
+RUN_DIR=$(mktemp -d /tmp/pi-excel-e2e.XXXXXX)
 TOKEN=$(node scripts/background-verify-bridge-server.mjs token)
-printf '%s' "$TOKEN" > "$TOKEN_FILE"
 
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" \
-PI_BACKGROUND_VERIFY_HOST=localhost \
-  npm run background:verify:bridge \
-  > /tmp/pi-background-verify-bridge-server.log 2>&1 &
-echo $! > /tmp/pi-background-verify-bridge-server.pid
+PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost \
+  npm run background:verify:bridge > "$RUN_DIR/bridge.log" 2>&1 &
+BRIDGE_PID=$!
 
 VITE_PI_BACKGROUND_VERIFY_URL=https://localhost:3157 \
 VITE_PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" \
-  npm run dev \
-  > /tmp/pi-for-excel-vite-background-verify.log 2>&1 &
-echo $! > /tmp/pi-for-excel-vite-background-verify.pid
+  npm run dev > "$RUN_DIR/vite.log" 2>&1 &
+VITE_PID=$!
+
+curl --fail https://localhost:3157/health
 ```
 
-Check server health:
+Wait for server readiness before probing. Keep the bridge loopback-only and tokened; do not print or commit its token. Start `npm run proxy:https` if the configured provider route needs the local CORS proxy.
+
+If `clients` is empty, inspect Excel with `computer_use` / `sky.get_app_state`. Check the workbook, pane, manifest URL and server before changing caches. For a pane showing a network error, use a semantic accessibility `AXPress` on Try Again after starting the server.
+
+Use background semantic accessibility actions only. If an action requires foreground focus or raw keyboard/mouse input, report the blocker. Record the foreground app and window before and after the test.
+
+## Run the test
+
+Create a test chat through the actual UI. The bridge's `submitPrompt` sends message text, so `/new` and `/name` can reach the model literally rather than dispatching commands.
+
+Define a command shorthand in the same shell:
 
 ```bash
-curl -k https://localhost:3157/health
+bridge() {
+  PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost \
+    npm run background:verify:command -- "$@"
+}
+
+bridge status
+bridge selectModel '{"provider":"openai-codex","modelId":"gpt-5.6-sol"}'
 ```
 
-If `clients` is empty, first inspect the real Excel window. A workbook and loaded Pi pane are required; the startup window alone is insufficient. Confirm the sideloaded URL and running HTTPS server before changing manifests or caches. If the pane shows a network error, use a background semantic `AXPress` on **Try Again** after starting the server. Otherwise close/reopen the pane with semantic controls. Never use raw input fallbacks or focus Excel.
+Use a currently approved model. If health lists multiple clients, pass `--clientId <id>` to target the scratch workbook on each command.
 
-If `clients` lists more than one taskpane, pass `--clientId <id-from-health>` to mutating `background:verify:command` calls so writes target the intended workbook. The server refuses untargeted commands when multiple live clients are connected.
-
-## Computer-use observe lane
-
-Prefer the current session's signed `computer_use` observation surface. Observe with `sky.get_app_state`, and use semantic accessibility actions only when background behavior is guaranteed. Do not assume a general click operation is focus-safe.
-
-For an older installation that actually exposes the following tools, this observation-only invocation is an alternative:
+Adapt the prompt to the changed feature. This example exercises model-driven sheet creation, writes, formulas and reads:
 
 ```bash
-PI_COMPUTER_USE_STEALTH=1 PI_COMPUTER_USE_STRICT_AX=1 \
-pi --tools list_apps,list_windows,observe,search_ui,inspect_ui \
-  --no-context-files --no-skills \
-  -p 'Use only computer-use tools. Do not focus any window and do not call act. Report the frontmost app, observe Microsoft Excel, and find evidence of Pi for Excel, Open Pi, the taskpane prompt, model/status footer, and any feature under test.'
+bridge submitPrompt \
+  '{"text":"Use workbook tools to create a new sheet _pi_e2e_smoke; stop if it exists. Write 2 and 3 into A1:A2 and =SUM(A1:A2) into A3. Read back the values and formula. Leave the sheet for independent inspection. Do not change other sheets.","waitForIdle":true,"timeoutMs":120000}' \
+  --timeout 130000
+
+bridge readRange '{"address":"_pi_e2e_smoke!A1:A3"}'
 ```
 
-Required evidence:
+Check actual tool execution and `lastAssistant.model` / `stopReason`. An idle runtime can also mean the request failed. Independently assert that A3 is 5 and retains `=SUM(A1:A2)`; check formatting or objects when relevant.
 
-- Excel window title/id and `isOnscreen=true`.
-- Taskpane evidence (`Pi for Excel`, `Open Pi`, prompt/model/status or feature-specific text).
-- Frontmost app before/after is the same non-Excel app.
-- Optional screenshot saved with a helper script or `observe` image.
-
-## Taskpane bridge commands
-
-The taskpane bridge commands run in the real Excel taskpane process. Use them to **mutate scratch workbook state, read it back, and clean up**; passive read-only probes are only the baseline evidence.
+Clean up through the model, then verify the scratch sheet is gone:
 
 ```bash
-TOKEN=$(cat "$TOKEN_FILE")
-
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- status
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- officeProbe
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- readUsedRange
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- readRange '{"address":"Sheet1!A1:B5"}'
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- listCharts
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- configureProxy \
-  '{"enabled":true,"url":"https://localhost:3003"}'
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- selectModel \
-  '{"provider":"openai-codex","modelId":"gpt-5.6-sol"}'
+bridge submitPrompt \
+  '{"text":"Delete only _pi_e2e_smoke using your workbook tool. This scratch-sheet deletion is approved. Leave all other sheets unchanged.","waitForIdle":true,"timeoutMs":120000}' \
+  --timeout 130000
+bridge officeProbe
 ```
 
-### Controlled write smoke
+## Diagnose failures
 
-Run this whenever the change affects workbook IO, Office.js host behavior, recovery, chart/range tools, or anything where browser-only tests are too weak:
+| Symptom | Check |
+|---|---|
+| No bridge client | Workbook and Pi pane open; Vite URL and bridge environment configured |
+| Pane loads, model returns `Load failed` | Configured proxy is running and reachable |
+| Cannot set the WebKit textarea through accessibility | Submit through the bridge |
+| Unsaved workbook has no workbook ID | Identify it through the client and sheet/range evidence |
+
+Use `officeProbe`, `readRange`, `readUsedRange` and `listCharts` for independent inspection. `workbookWriteProbe` is a reversible Office.js diagnostic, not a model test. `writeRange` and `clearRange` can prepare fixtures, but must not perform the work the model is meant to do. `configureProxy` changes saved settings; restore them after transport-specific tests.
+
+## Report and clean up
+
+Record the tested revision, provider/model, thinking level, prompt, observed tools, independent assertions, cleanup and unchanged foreground app/window. State untested provider or host paths. Keep useful logs and screenshots without credentials.
+
+Stop the test servers and any proxy you started. If the user needs a running development environment, explicitly hand over the normal dev server and proxy; stop the test bridge and remove its token.
 
 ```bash
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- workbookWriteProbe \
-  '{"sheetName":"_pi_background_verify","keepSheet":false}'
+kill "$BRIDGE_PID" "$VITE_PID"
+unset TOKEN
 ```
 
-`workbookWriteProbe` creates or reuses a scratch sheet, writes a marker + numeric inputs + formula, reads the resulting range, then deletes the created scratch sheet or restores the previous scratch range. Its output is the minimum proof that the real hidden taskpane can write to and read from the real workbook without foregrounding Excel.
-
-For custom setup/assert/cleanup:
-
-```bash
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- writeRange \
-  '{"address":"Sheet1!A1:B2","values":[["pi background smoke",2],["sum",3]]}'
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- readRange '{"address":"Sheet1!A1:B2"}'
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- clearRange '{"address":"Sheet1!A1:B2","applyTo":"contents"}'
-```
-
-For acceptance, submit an actual prompt through the sidebar. Use a scratch sheet name that does not already exist. For example, select a currently approved model, then ask it to create the sheet and write the formulas:
-
-```bash
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- selectModel \
-  '{"provider":"openai-codex","modelId":"gpt-5.6-sol"}'
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- submitPrompt \
-  '{"text":"Use workbook tools to create a new sheet _pi_e2e_smoke; stop if it exists. Write 2 and 3 into A1:A2, write =SUM(A1:A2) into A3, and read back the values and formula. Leave the sheet for independent inspection. Do not change other sheets.","waitForIdle":true,"timeoutMs":120000}' --timeout 130000
-PI_BACKGROUND_VERIFY_TOKEN="$TOKEN" PI_BACKGROUND_VERIFY_HOST=localhost npm run background:verify:command -- readRange '{"address":"_pi_e2e_smoke!A1:A3"}'
-```
-
-Assert that A3 is 5 and retains its formula. Ask the model to delete only the scratch sheet, then use `officeProbe` to confirm it is gone. Adapt the prompt to exercise the changed feature; this arithmetic example does not cover every change.
-
-The bridge's `submitPrompt` uses the sidebar send path. Do not send `/new` or `/name` through it expecting slash-command dispatch: these can be sent literally to the model. Create a test chat through the actual UI, verify its identity and idle state, then select the model. A restored session label does not prove which model answered; check `lastAssistant.model` and `stopReason` after the real prompt.
-
-Use the outputs as verification artifacts:
-
-- `status`: proves taskpane origin, hidden/background visibility, Office/Excel globals, active runtime/model, input state.
-- `officeProbe`: proves Office.js can read the real workbook from the hidden taskpane.
-- `workbookWriteProbe`: proves the hidden taskpane can perform reversible real workbook writes and read back formula results.
-- `writeRange` / `clearRange`: deterministic setup and cleanup for feature-specific smoke tests.
-- `configureProxy`: explicitly enables/disables the app's configured proxy for transport-specific real-host checks.
-- `selectModel`: opens the real model selector, filters it, clicks the exact provider/model row, and verifies that model became active.
-- `submitPrompt`: exercises the real app prompt → runtime/model/tool loop from the hidden taskpane.
-- `readRange` / `readUsedRange`: verify workbook contents changed as expected.
-- `listCharts`: verify chart creation/update/delete metadata.
-
-For adversarial verification, wrap mutating and read-back commands with a frontmost check using `pi-computer-use` helper or strict AX `list_apps`. Completion evidence must include `frontmostSameApp=true` and `frontmostSameWindow=true` (or equivalent before/after app/window IDs).
-
-## Safety rules
-
-- Keep the bridge loopback-only and tokened. Never run it without `PI_BACKGROUND_VERIFY_TOKEN`.
-- Never commit or print the token in docs/logs intended for sharing.
-- The bridge is dev-only: the taskpane only connects when Vite injects `VITE_PI_BACKGROUND_VERIFY_URL` and `VITE_PI_BACKGROUND_VERIFY_TOKEN`.
-- Prefer controlled, reversible writes over passive observation when workbook behavior is under test. Use scratch sheets/ranges, capture before/after output, and clean up or restore state.
-- For app-level verification, use the normal product path (`submitPrompt` or the specific UI/tool path under test) and then assert the resulting workbook state via bridge read-back.
-- If `pi-computer-use` offers raw pointer/keyboard/focus fallback, refuse it for background verification.
-- Clean up when done:
-
-```bash
-kill "$(cat /tmp/pi-background-verify-bridge-server.pid)" 2>/dev/null || true
-kill "$(cat /tmp/pi-for-excel-vite-background-verify.pid)" 2>/dev/null || true
-rm -f "$TOKEN_FILE"
-```
-
-## Known limitations
-
-- Strict AX can observe and press some semantic controls, but WebKit text-area `setText` may fail. Use the bridge for verification rather than typing prompts into the taskpane.
-- Unsaved workbooks may have `workbookContext.workbookId=null`; use sheet/range/chart evidence instead.
-- This is a background verification lane, not a replacement for full foreground/manual release smoke on a dedicated host when raw GUI interaction is the behavior under test.
+Confirm the owned listeners have exited, then remove the worktree when it is no longer serving the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ Notes for agents working in this repo.
 
 ## Verification
 
-Local acceptance means a real taskpane prompt → approved current model → workbook tools → real Excel/WPS result, independently checked and cleaned up. Keep the host in the background. Unit tests, builds, browser fallback checks, and direct Office.js probes support this gate; they do not replace it. Record the revision, provider/model, thinking level, tool execution and read-back evidence. If blocked, report the missing coverage and hold acceptance unless explicitly waived. See `.agents/skills/excel-background-verification/SKILL.md`.
+Use the local acceptance policy in `docs/coding-standards.md` and the `.agents/skills/excel-background-verification/SKILL.md` workflow.
+
 - `npm run check`
 - `npm run build`
 - `npm run test:models`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ Notes for agents working in this repo.
 - Type assertions and lint suppressions must stay local and explain the safety invariant.
 
 ## Verification
+
+Local acceptance means a real taskpane prompt → approved current model → workbook tools → real Excel/WPS result, independently checked and cleaned up. Keep the host in the background. Unit tests, builds, browser fallback checks, and direct Office.js probes support this gate; they do not replace it. Record the revision, provider/model, thinking level, tool execution and read-back evidence. If blocked, report the missing coverage and hold acceptance unless explicitly waived. See `.agents/skills/excel-background-verification/SKILL.md`.
 - `npm run check`
 - `npm run build`
 - `npm run test:models`

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -79,9 +79,8 @@ The `check:innerhtml` script keeps raw `.innerHTML` out of application code.
 
 ## Tests and verification
 
-- For local acceptance of behavior changes and dependency upgrades, run the real taskpane prompt → model → tools → workbook path in the background. Independently read the result and verify cleanup. Record the revision, provider/model, thinking level, prompt and observed tool execution.
-- Unit tests, CI, builds and direct Office.js probes are supporting evidence. A model's success claim or an idle runtime alone is insufficient. Report blocked end-to-end coverage and hold acceptance unless explicitly waived. Documentation-only changes do not require a runtime test.
-- Prove behavior through public interfaces or real seams; avoid tests that only prove a mock implementation.
+- Accept behavior changes and dependency upgrades through a real taskpane prompt → model → tools → workbook test, with independent read-back and scratch cleanup. Keep the host in the background.
+- Unit tests, CI, builds and direct host probes support this acceptance test. If it is blocked, report the missing coverage and obtain an explicit waiver before accepting the change. Documentation-only changes need no runtime test.
 - For prompt/context/tool-disclosure/session wiring, run `npm run test:context`.
 - For proxy/bridge/auth/HTML safety paths, run `npm run test:security`.
 - For model/provider registry changes, run `npm run test:models` and consult `docs/model-updates.md`.

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -79,6 +79,8 @@ The `check:innerhtml` script keeps raw `.innerHTML` out of application code.
 
 ## Tests and verification
 
+- For local acceptance of behavior changes and dependency upgrades, run the real taskpane prompt → model → tools → workbook path in the background. Independently read the result and verify cleanup. Record the revision, provider/model, thinking level, prompt and observed tool execution.
+- Unit tests, CI, builds and direct Office.js probes are supporting evidence. A model's success claim or an idle runtime alone is insufficient. Report blocked end-to-end coverage and hold acceptance unless explicitly waived. Documentation-only changes do not require a runtime test.
 - Prove behavior through public interfaces or real seams; avoid tests that only prove a mock implementation.
 - For prompt/context/tool-disclosure/session wiring, run `npm run test:context`.
 - For proxy/bridge/auth/HTML safety paths, run `npm run test:security`.


### PR DESCRIPTION
## Summary
- Put the local acceptance policy in coding-standards.md; AGENTS.md links to it.
- Shorten the Excel verification skill from 1,554 to 710 words, removing repeated rules and the obsolete helper invocation.
- Keep one model-driven workflow with independent read-back and cleanup, plus the setup failures observed during real testing.

## Verification
- Skill validator passed
- Shell examples pass bash syntax checking
- Skill frontmatter and docs/skills drift tests: 6 passed
- npm run check passed in pre-commit
- Documentation-only; no runtime behavior changed. The workflow reflects the completed GPT-5.6 Sol end-to-end Excel test.