### PR TITLE
Fix manual gateway registry metadata and OpenRouter compatibility

### DIFF
--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -16,20 +16,23 @@ This doc describes how to update:
 - **Runtime lookup and streaming:** the taskpane-owned `BrowserModelRuntime`, backed by Pi AI's `createModels()` collection.
 - **Dynamic catalogue cache:** IndexedDB store `model-catalogs`, accessed through `ModelCatalogsStore`; restored entries are rebound to the provider's current API/base URL before use.
 - **Discovery bounds:** responses are limited to 2 MiB, 2,000 entries and 256 characters per model ID. An invalid/oversized refresh leaves the last safe cache and configured baseline intact.
-- **Custom gateways:** baseline models remain in `CustomProvidersStore`; `/models` discovery overlays them without deleting the configured fallback model.
+- **Manual gateways:** models remain in `CustomProvidersStore` and register through the same collection without `/models` discovery. An exact endpoint, model ID and API match supplies metadata from the shared registry; an explicit context limit takes precedence. Unknown models retain the existing defaults. Previously discovered additions are no longer loaded for manual-form entries.
 - **Extension providers:** `api.models.registerProvider()` declarations are runtime-owned and unload with their extension. Unregistering aborts in-flight discovery before deleting its cache so late responses cannot resurrect stale entries.
 
 Do not use Pi coding-agent's Node/file `ModelRuntime` directly in the Office WebView. Pi for Excel uses the same Pi AI provider primitives with browser storage, OAuth and proxy policy. Cross-check the installed Pi package and changelog when the generated registry changes. Never infer aliases or metadata from marketing names.
 
-### Current GPT-5.6 registry snapshot (`pi-ai` 0.83.0)
+Manual gateway metadata is a save-time snapshot. Existing entries retain saved limits until edited; clear the context field when re-saving to use current registry defaults. Other manual gateway snapshots are excluded from metadata lookup.
+
+### Current GPT-5.6 registry snapshot (`pi-ai` 0.85.1)
 
 Upstream exposes exactly three IDs on both `openai` and `openai-codex`; there is deliberately no bare `gpt-5.6` alias:
 
-| ID | Display name | Standard input / output | Cache read / write | Above 272k input / output | Above 272k cache read / write |
+| ID | Provider | Standard input / output | Cache read / write | Above 272k input / output | Above 272k cache read / write |
 |---|---|---:|---:|---:|---:|
-| `gpt-5.6-sol` | GPT-5.6 Sol | $5 / $30 | $0.50 / $6.25 | $10 / $45 | $1 / $12.50 |
-| `gpt-5.6-terra` | GPT-5.6 Terra | $2.50 / $15 | $0.25 / $3.125 | $5 / $22.50 | $0.50 / $6.25 |
-| `gpt-5.6-luna` | GPT-5.6 Luna | $1 / $6 | $0.10 / $1.25 | $2 / $9 | $0.20 / $2.50 |
+| `gpt-5.6-sol` | OpenAI API | $4 / $20 | $0.40 / $5 | $8 / $30 | $0.80 / $10 |
+| `gpt-5.6-sol` | ChatGPT | $5 / $30 | $0.50 / $6.25 | $10 / $45 | $1 / $12.50 |
+| `gpt-5.6-terra` | Both | $2 / $12 | $0.20 / $2.50 | $4 / $18 | $0.40 / $5 |
+| `gpt-5.6-luna` | Both | $0.20 / $1.20 | $0.02 / $0.25 | $0.40 / $1.80 | $0.04 / $0.50 |
 
 Prices are registry values in USD per million tokens. All three models:
 
@@ -206,7 +209,7 @@ npm run sideload
 #### “I updated models but they don’t show up” checklist
 
 1) **Provider filter:** the model picker only shows models for connected providers (saved API key/OAuth, keyless configured custom providers, or connected extension providers).
-2) **Dynamic catalogue:** custom OpenAI-compatible gateways request `<baseUrl>/models` in the background. The configured model remains as a baseline if discovery is unsupported. Check the local proxy when CORS blocks discovery.
+2) **Catalogue:** manual-form gateways expose only configured models. Other discovery-enabled registrations request `<baseUrl>/models` and retain their baseline when discovery fails.
 3) **Excel caching:** quit Excel completely (Cmd+Q) and reopen.
 4) **Hot reload note:** taskpane JS/CSS is served from Vite; edits to model-selection files (`src/models/model-ordering.ts`, `src/models/featured-models.ts`, `src/taskpane/default-model.ts`) should apply via HMR without needing to re-sideload, as long as Excel is pointed at the same running dev server.
 5) **Vite optimized deps:** after dependency bumps, clear and restart:

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -1,6 +1,6 @@
 # Model / dependency update playbook
 
-**Last verified:** 2026-08-05
+**Last verified:** 2026-09-08
 
 This repo hardcodes a small set of "featured" and "preferred" model patterns for sorting and default selection. Static built-in models come from Pi AI, while custom and extension providers can add cached, dynamically discovered catalogues at runtime.
 

--- a/docs/upstream-divergences.md
+++ b/docs/upstream-divergences.md
@@ -220,6 +220,16 @@ record.
 
 ---
 
+## 9. OpenRouter native Anthropic compatibility
+
+Pi AI 0.85.1 advertises `supportsMidConvoEffort` on OpenRouter Claude models. The live OpenRouter route tested on 8 September 2026 rejected the resulting `configuration_update` with HTTP 400, including in a fresh Opus 5 chat.
+
+Pi for Excel disables that flag at the stream boundary for OpenRouter's `anthropic-messages` models. It retains the registry's native API, context limits, pricing, thinking levels and ordinary adaptive effort. Registry objects are not mutated. Browser requests on this route use the configured proxy because direct requests failed with a browser connection error. The default proxy permits the exact `openrouter.ai` host; explicit operator allowlists still take precedence.
+
+Remove the effort override when Pi AI models OpenRouter's endpoint capabilities correctly or OpenRouter supports the mid-conversation feature. Keep browser routing separate from that decision.
+
+Files: `src/auth/stream-proxy.ts`, `tests/browser-model-runtime.test.ts`.
+
 ## Non-divergences worth noting
 
 ### Compaction call shape

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.120.0",
-        "@earendil-works/pi-agent-core": "0.83.0",
-        "@earendil-works/pi-ai": "0.83.0",
+        "@earendil-works/pi-agent-core": "0.85.1",
+        "@earendil-works/pi-ai": "0.85.1",
         "@sinclair/typebox": "^0.34.52",
         "highlight.js": "^11.12.0",
         "lit": "^3.3.3",
@@ -189,17 +189,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
-      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.4",
-        "@smithy/signature-v4": "^5.6.5",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -208,15 +208,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
-      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -224,17 +224,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
-      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -242,13 +242,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -256,23 +256,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.3.tgz",
-      "integrity": "sha512-WpuqYX4gGkx++fCTSWE8+41JzkZVcrI50SH48Ml4CsG1pyuHKyMmpw/FixBHDrmjoQ553PmeCLa/fZIcst+WyA==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-login": "^3.972.65",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -280,16 +280,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.65.tgz",
-      "integrity": "sha512-xr9rgjYEdmC2Tpg2lwt9o+nOEaK9Qpd+dBjzrVCuWWyQfvhO91Ezu0Hh9ts2VUxOZxmS/k5T9msa34e4R1bnrQ==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -297,21 +297,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.69.tgz",
-      "integrity": "sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==",
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-ini": "^3.973.3",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -319,15 +319,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
-      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -335,17 +335,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
-      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/token-providers": "3.1088.0",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -353,16 +353,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
-      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -370,16 +370,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
-      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -387,14 +387,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.28.tgz",
-      "integrity": "sha512-XV5sEH1xH5oydNgvUH87CR8BA2SBZXltckteS17D7ZT2k2THIBiExO9TEBYcgqUU31WAIfBH2hmx+fhFMiTL4Q==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -402,14 +402,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
-      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -417,17 +417,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.41.tgz",
-      "integrity": "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/signature-v4": "^5.6.5",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -435,18 +435,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
-      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -454,13 +454,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -468,14 +468,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
-      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.5",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -500,12 +500,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
-      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -525,12 +525,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
-      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1051,13 +1051,27 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
-      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
+    "node_modules/@earendil-works/chord": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
+      "integrity": "sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.83.0",
+        "esbuild": "0.28.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+      "integrity": "sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1083,20 +1097,19 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
-      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1108,12 +1121,13 @@
       }
     },
     "node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -1132,6 +1146,431 @@
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
       "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -3264,26 +3703,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -3339,24 +3758,6 @@
       ],
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.146.0",
@@ -3712,12 +4113,12 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3725,13 +4126,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
-      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3739,13 +4140,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
-      "integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3779,13 +4180,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
-      "integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3793,9 +4194,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5666,6 +6067,47 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6433,9 +6875,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
-      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -6564,9 +7006,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
-      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -9108,13 +9550,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -11283,7 +11722,9 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11292,7 +11733,9 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.120.0",
-    "@earendil-works/pi-agent-core": "0.83.0",
-    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-agent-core": "0.85.1",
+    "@earendil-works/pi-ai": "0.85.1",
     "@sinclair/typebox": "^0.34.52",
     "highlight.js": "^11.12.0",
     "lit": "^3.3.3",

--- a/scripts/cors-proxy-server.mjs
+++ b/scripts/cors-proxy-server.mjs
@@ -180,6 +180,7 @@ const DEFAULT_ALLOWED_TARGET_HOSTS = new Set([
   "api.github.com",
   "auth.openai.com",
   "api.openai.com",
+  "openrouter.ai",
   "chatgpt.com",
   "oauth2.googleapis.com",
   "generativelanguage.googleapis.com",

--- a/src/auth/custom-gateways.ts
+++ b/src/auth/custom-gateways.ts
@@ -272,7 +272,8 @@ export async function saveOpenAiGatewayConfig(
   const endpointUrl = normalizeGatewayEndpointUrl(input.endpointUrl);
   const modelId = normalizeGatewayModelId(input.modelId);
   const registryModel = models?.getModels().find((model) => (
-    model.baseUrl === endpointUrl
+    !model.provider.startsWith(OPENAI_GATEWAY_PROVIDER_PREFIX)
+    && model.baseUrl === endpointUrl
     && model.id === modelId
     && model.api === OPENAI_GATEWAY_TYPE
   ));

--- a/src/auth/custom-gateways.ts
+++ b/src/auth/custom-gateways.ts
@@ -2,7 +2,7 @@
  * Helpers for custom OpenAI-compatible gateway providers.
  */
 
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, Model, Models } from "@earendil-works/pi-ai";
 import type { CustomProvider } from "../storage/local/custom-providers-store.js";
 
 const OPENAI_GATEWAY_ID_PREFIX = "pi-openai-gateway:";
@@ -194,8 +194,13 @@ function createGatewayModel(args: {
   modelId: string;
   providerName: string;
   contextWindow: number;
+  registryModel?: Model<Api>;
 }): Model<"openai-completions"> {
-  const maxTokens = Math.min(DEFAULT_OPENAI_GATEWAY_MAX_TOKENS, args.contextWindow);
+  const registryModel = args.registryModel;
+  const maxTokens = Math.min(
+    registryModel?.maxTokens ?? DEFAULT_OPENAI_GATEWAY_MAX_TOKENS,
+    args.contextWindow,
+  );
 
   return {
     id: args.modelId,
@@ -203,9 +208,12 @@ function createGatewayModel(args: {
     api: "openai-completions",
     provider: args.providerName,
     baseUrl: args.endpointUrl,
-    reasoning: false,
-    input: ["text"],
-    cost: {
+    reasoning: registryModel?.reasoning ?? false,
+    ...(registryModel?.thinkingLevelMap !== undefined
+      ? { thinkingLevelMap: registryModel.thinkingLevelMap }
+      : {}),
+    input: registryModel?.input ?? ["text"],
+    cost: registryModel?.cost ?? {
       input: 0,
       output: 0,
       cacheRead: 0,
@@ -259,10 +267,18 @@ export async function listOpenAiGatewayConfigs(
 export async function saveOpenAiGatewayConfig(
   customProvidersStore: CustomProvidersStoreLike,
   input: SaveOpenAiGatewayInput,
+  models?: Pick<Models, "getModels">,
 ): Promise<OpenAiGatewayConfig> {
   const endpointUrl = normalizeGatewayEndpointUrl(input.endpointUrl);
   const modelId = normalizeGatewayModelId(input.modelId);
-  const contextWindow = normalizeGatewayContextWindow(input.contextWindow);
+  const registryModel = models?.getModels().find((model) => (
+    model.baseUrl === endpointUrl
+    && model.id === modelId
+    && model.api === OPENAI_GATEWAY_TYPE
+  ));
+  const contextWindow = normalizeGatewayContextWindow(
+    input.contextWindow ?? registryModel?.contextWindow,
+  );
   const existingGateways = await listOpenAiGatewayConfigs(customProvidersStore);
 
   if (input.id) {
@@ -300,6 +316,7 @@ export async function saveOpenAiGatewayConfig(
         modelId,
         providerName,
         contextWindow,
+        ...(registryModel !== undefined ? { registryModel } : {}),
       }),
     ],
   };

--- a/src/auth/oauth-provider-registry.ts
+++ b/src/auth/oauth-provider-registry.ts
@@ -9,8 +9,8 @@
 
 import type {
   AuthEvent,
-  AuthInteraction,
   AuthPrompt,
+  ProviderAuthInteraction,
   OAuthCredential,
   OAuthCredentials,
   OAuthLoginCallbacks,
@@ -96,9 +96,9 @@ function handleAuthEvent(callbacks: OAuthLoginCallbacks, event: AuthEvent): void
   callbacks.onProgress?.(event.message);
 }
 
-function createAuthInteraction(callbacks: OAuthLoginCallbacks): AuthInteraction {
+function createAuthInteraction(callbacks: OAuthLoginCallbacks): ProviderAuthInteraction {
   return {
-    ...(callbacks.signal !== undefined ? { signal: callbacks.signal } : {}),
+    signal: callbacks.signal ?? new AbortController().signal,
     prompt: (prompt) => handleAuthPrompt(callbacks, prompt),
     notify: (event) => handleAuthEvent(callbacks, event),
   };
@@ -117,7 +117,9 @@ function createGitHubCopilotBrowserProvider(): BrowserOAuthProvider {
       return fromOAuthCredential(await oauth.login(createAuthInteraction(callbacks)));
     },
     async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-      return fromOAuthCredential(await oauth.refresh(toOAuthCredential(credentials)));
+      return fromOAuthCredential(
+        await oauth.refresh(toOAuthCredential(credentials), new AbortController().signal),
+      );
     },
     getApiKey(credentials: OAuthCredentials): string {
       return credentials.access;

--- a/src/auth/stream-proxy.ts
+++ b/src/auth/stream-proxy.ts
@@ -9,6 +9,7 @@
  */
 
 import { uuidv7 } from "@earendil-works/pi-agent-core";
+import { hasApi } from "@earendil-works/pi-ai";
 import type {
   Api,
   AssistantMessageEventStream,
@@ -547,6 +548,13 @@ async function proxySupportsCodexWebSocketBridge(proxyUrl: string): Promise<bool
   return supported;
 }
 
+function normalizeOpenRouterModel(model: Model<Api>): Model<Api> {
+  if (model.provider !== "openrouter" || !hasApi(model, "anthropic-messages")) return model;
+  if (!model.compat?.supportsMidConvoEffort) return model;
+  // OpenRouter rejects the configuration_update beta; ordinary adaptive effort works.
+  return { ...model, compat: { ...model.compat, supportsMidConvoEffort: false } };
+}
+
 export function createOfficeStreamFn(
   getProxyUrl: GetProxyUrl,
   modelsRuntime: Models,
@@ -572,7 +580,7 @@ export function createOfficeStreamFn(
       return contextWithoutTools;
     })();
 
-    const normalizedModel = normalizeGoogleOAuthModel(modelsRuntime, model);
+    const normalizedModel = normalizeOpenRouterModel(normalizeGoogleOAuthModel(modelsRuntime, model));
 
     const callRecord = recordCall(
       normalizedModel,
@@ -585,7 +593,15 @@ export function createOfficeStreamFn(
 
     const proxyUrl = await getProxyUrl();
     const needsCodexBridge = requiresCodexWebSocketBridge(normalizedModel);
+    const needsOpenRouterProxy = normalizedModel.provider === "openrouter"
+      && normalizedModel.api === "anthropic-messages";
     if (!proxyUrl) {
+      if (needsOpenRouterProxy) {
+        throw new Error(
+          "OpenRouter's native Anthropic transport requires the Pi for Excel proxy in this browser. " +
+          "Enable Proxy in Settings and run the latest pi-for-excel-proxy helper.",
+        );
+      }
       if (needsCodexBridge) {
         throw new Error(
           "GPT-5.6 Luna currently requires the latest Pi for Excel proxy for ChatGPT WebSocket transport. " +
@@ -595,7 +611,7 @@ export function createOfficeStreamFn(
       return modelsRuntime.streamSimple(normalizedModel, effectiveContext, effectiveOptions);
     }
 
-    if (!shouldProxyProvider(normalizedModel.provider, options?.apiKey, isRuntimeProvider)) {
+    if (!needsOpenRouterProxy && !shouldProxyProvider(normalizedModel.provider, options?.apiKey, isRuntimeProvider)) {
       return modelsRuntime.streamSimple(normalizedModel, effectiveContext, effectiveOptions);
     }
 

--- a/src/commands/builtins/custom-gateway-settings.ts
+++ b/src/commands/builtins/custom-gateway-settings.ts
@@ -2,6 +2,7 @@
  * Settings section for custom OpenAI-compatible gateways.
  */
 
+import type { Models } from "@earendil-works/pi-ai";
 import { getAppStorage } from "../../storage/local/app-storage.js";
 
 import {
@@ -22,6 +23,7 @@ import { showToast } from "../../ui/toast.js";
 import { t } from "../../language/index.js";
 
 interface BuildCustomGatewaySectionOptions {
+  models?: Pick<Models, "getModels">;
   onProvidersChanged: () => void;
   /**
    * Include the section's own title + hint. Defaults to true; the settings
@@ -299,7 +301,7 @@ export async function buildCustomGatewaySection(
           modelId: modelInput.value,
           apiKey: apiKeyInput.value,
           ...(contextWindow !== undefined ? { contextWindow } : {}),
-        });
+        }, options.models);
 
         await reloadGateways();
         renderList();

--- a/src/commands/builtins/settings-pages/dependencies.ts
+++ b/src/commands/builtins/settings-pages/dependencies.ts
@@ -3,6 +3,7 @@
  * `taskpane/init.ts` via `configureSettingsPages`.
  */
 
+import type { Models } from "@earendil-works/pi-ai";
 import type { ConnectionManager } from "../../../connections/manager.js";
 import type { ExecutionMode } from "../../../execution/mode.js";
 import type { ExtensionRuntimeManager } from "../../../extensions/runtime-manager.js";
@@ -30,6 +31,7 @@ export interface SettingsPagesDependencies {
   setExecutionMode?: (mode: ExecutionMode) => Promise<void>;
   getModelSwitchBehavior?: () => ModelSwitchBehavior;
   setModelSwitchBehavior?: (behavior: ModelSwitchBehavior) => Promise<void>;
+  models?: Pick<Models, "getModels">;
   extensionsHub?: ExtensionsHubDependencies;
   onRulesSaved?: () => Promise<void> | void;
   backups?: BackupsPageCallbacks;

--- a/src/commands/builtins/settings-pages/gateway-page.ts
+++ b/src/commands/builtins/settings-pages/gateway-page.ts
@@ -5,6 +5,7 @@
 import { t } from "../../../language/index.js";
 import type { SettingsShellPage } from "../../../ui/settings-shell.js";
 import { buildCustomGatewaySection } from "../custom-gateway-settings.js";
+import { getSettingsPagesDependencies } from "./dependencies.js";
 
 export function createGatewayPage(): SettingsShellPage {
   return {
@@ -13,7 +14,9 @@ export function createGatewayPage(): SettingsShellPage {
     title: () => t("custom-gateway.title"),
     subtitle: () => t("custom-gateway.hint"),
     render: async (ctx) => {
+      const models = getSettingsPagesDependencies().models;
       const section = await buildCustomGatewaySection({
+        ...(models !== undefined ? { models } : {}),
         onProvidersChanged: () => {
           document.dispatchEvent(new CustomEvent("pi:providers-changed"));
         },

--- a/src/dev-auth-policy.ts
+++ b/src/dev-auth-policy.ts
@@ -35,5 +35,6 @@ export function isLocalPiAuthHost(hostHeader: string | string[] | undefined): bo
 export function isPiAuthRequestAllowed(input: PiAuthRequestPolicyInput): boolean {
   if (!isLoopbackAddress(input.remoteAddress)) return false;
   if (input.allowNonLocalHost === true) return true;
-  return isLocalPiAuthHost(input.hostHeader ?? input.authorityHeader);
+  const authorities = [input.hostHeader, input.authorityHeader].filter((header) => header !== undefined);
+  return authorities.length > 0 && authorities.every(isLocalPiAuthHost);
 }

--- a/src/dev-auth-policy.ts
+++ b/src/dev-auth-policy.ts
@@ -1,6 +1,7 @@
 export interface PiAuthRequestPolicyInput {
   remoteAddress?: string;
   hostHeader?: string | string[];
+  authorityHeader?: string | string[];
   allowNonLocalHost?: boolean;
 }
 
@@ -34,5 +35,5 @@ export function isLocalPiAuthHost(hostHeader: string | string[] | undefined): bo
 export function isPiAuthRequestAllowed(input: PiAuthRequestPolicyInput): boolean {
   if (!isLoopbackAddress(input.remoteAddress)) return false;
   if (input.allowNonLocalHost === true) return true;
-  return isLocalPiAuthHost(input.hostHeader);
+  return isLocalPiAuthHost(input.hostHeader ?? input.authorityHeader);
 }

--- a/src/language/locales/en.json
+++ b/src/language/locales/en.json
@@ -79,7 +79,7 @@
   "custom-gateway.configLabelEndpoint": "Endpoint",
   "custom-gateway.configLabelModel": "Model",
   "custom-gateway.configLabelName": "Name",
-  "custom-gateway.contextWindowHint": "Used for Pi's local context budgeting and auto-compaction. Set this to your gateway model's real context window.",
+  "custom-gateway.contextWindowHint": "Leave blank to use registered model limits, or 16,384 tokens for an unknown model. Enter a value to override.",
   "custom-gateway.deleteButton": "Delete",
   "custom-gateway.deleteConfirmMsg": "Delete gateway \"{name}\"? This removes its stored API key from this add-in.",
   "custom-gateway.deleteConfirmTitle": "Delete custom gateway?",

--- a/src/language/locales/zh-CN.json
+++ b/src/language/locales/zh-CN.json
@@ -79,7 +79,7 @@
   "custom-gateway.configLabelEndpoint": "端点",
   "custom-gateway.configLabelModel": "模型",
   "custom-gateway.configLabelName": "名称",
-  "custom-gateway.contextWindowHint": "用于 Pi 的本地上下文预算和自动压缩。请设置为你的网关模型的实际上下文窗口。",
+  "custom-gateway.contextWindowHint": "留空时使用已注册模型的限制；未知模型默认为 16,384 个 token。输入数值可覆盖默认值。",
   "custom-gateway.deleteButton": "删除",
   "custom-gateway.deleteConfirmMsg": "删除网关\"{name}\"？这将从此加载项中删除其存储的 API 密钥。",
   "custom-gateway.deleteConfirmTitle": "删除自定义网关？",

--- a/src/models/browser-model-runtime.ts
+++ b/src/models/browser-model-runtime.ts
@@ -16,6 +16,7 @@ import {
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 
 import { originalFetch } from "../auth/cors-proxy.js";
+import { isOpenAiGatewayProvider } from "../auth/custom-gateways.js";
 import { normalizeProxyUrl } from "../auth/proxy-validation.js";
 import type { CustomProvider } from "../storage/local/custom-providers-store.js";
 import {
@@ -49,6 +50,8 @@ export interface BrowserProviderModelDefinition {
   id: string;
   name?: string;
   reasoning?: boolean;
+  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
+  cost?: Model<Api>["cost"];
   input?: readonly ("text" | "image")[];
   contextWindow?: number;
   maxTokens?: number;
@@ -60,8 +63,8 @@ export interface BrowserProviderRegistration {
   api: BrowserProviderApi;
   baseUrl: string;
   models: readonly BrowserProviderModelDefinition[];
-  /** Defaults to `${baseUrl}/models` for OpenAI-compatible providers. */
-  modelsUrl?: string;
+  /** Omit to derive the discovery URL; null keeps only the supplied models. */
+  modelsUrl?: string | null;
   resolveApiKey: () => Promise<string | undefined>;
   /** Keyless local providers can opt in while still satisfying Pi AI auth semantics. */
   allowKeyless?: boolean;
@@ -182,8 +185,9 @@ function createModel(args: {
     provider: args.providerId,
     baseUrl: args.baseUrl,
     reasoning: args.definition.reasoning ?? false,
+    ...(args.definition.thinkingLevelMap !== undefined ? { thinkingLevelMap: args.definition.thinkingLevelMap } : {}),
     input: args.definition.input ? [...args.definition.input] : ["text"],
-    cost: {
+    cost: args.definition.cost ?? {
       input: 0,
       output: 0,
       cacheRead: 0,
@@ -406,9 +410,10 @@ function createRegisteredProvider(
     baseUrl,
     definition,
   }));
-  const modelsUrlRaw = registration.modelsUrl
-    ?? deriveModelsUrl(baseUrl, registration.api);
-  const modelsUrl = modelsUrlRaw
+  const modelsUrlRaw = registration.modelsUrl === undefined
+    ? deriveModelsUrl(baseUrl, registration.api)
+    : registration.modelsUrl;
+  const modelsUrl = modelsUrlRaw != null
     ? normalizeHttpUrl(modelsUrlRaw, "Provider modelsUrl")
     : undefined;
 
@@ -475,6 +480,8 @@ function customProviderRegistrations(provider: CustomProvider): BrowserProviderR
       id: model.id,
       name: model.name,
       reasoning: model.reasoning,
+      ...(model.thinkingLevelMap !== undefined ? { thinkingLevelMap: model.thinkingLevelMap } : {}),
+      cost: model.cost,
       input: model.input,
       contextWindow: model.contextWindow,
       maxTokens: model.maxTokens,
@@ -498,6 +505,7 @@ function customProviderRegistrations(provider: CustomProvider): BrowserProviderR
     api: providerApi,
     baseUrl: provider.baseUrl,
     models,
+    ...(isOpenAiGatewayProvider(provider) ? { modelsUrl: null } : {}),
     resolveApiKey: () => Promise.resolve(provider.apiKey),
     allowKeyless: !provider.apiKey,
   }));

--- a/src/taskpane/init.ts
+++ b/src/taskpane/init.ts
@@ -1636,6 +1636,7 @@ export async function initTaskpane(opts: {
     setExecutionMode,
     getModelSwitchBehavior,
     setModelSwitchBehavior,
+    models: modelRuntime.models,
     onRulesSaved: async () => {
       await refreshWorkbookState();
     },

--- a/tests/browser-model-runtime.test.ts
+++ b/tests/browser-model-runtime.test.ts
@@ -5,6 +5,7 @@ import type {
   Credential,
   ModelsStore,
   ModelsStoreEntry,
+  SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
 
 import {
@@ -12,6 +13,8 @@ import {
   type BrowserProviderRegistration,
 } from "../src/models/browser-model-runtime.ts";
 import type { CustomProvider } from "../src/storage/local/custom-providers-store.ts";
+import { saveOpenAiGatewayConfig } from "../src/auth/custom-gateways.ts";
+import { createOfficeStreamFn } from "../src/auth/stream-proxy.ts";
 import {
   ProviderCredentialsStore,
   type ProviderKeysStoreLike,
@@ -56,6 +59,49 @@ class MemoryCatalogs implements ModelsStore {
     return Promise.resolve();
   }
 }
+
+void test("Office streaming preserves OpenRouter's registry transport without unsupported effort updates", async (t) => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  Object.defineProperty(globalThis, "document", { configurable: true, value: new EventTarget() });
+  t.after(() => {
+    if (originalDocument) Object.defineProperty(globalThis, "document", originalDocument);
+    else Reflect.deleteProperty(globalThis, "document");
+  });
+  const runtime = createRuntime();
+  for (const id of ["anthropic/claude-opus-5", "openai/gpt-5.6-sol"]) {
+    const model = runtime.models.getModel("openrouter", id);
+    assert.ok(model);
+    let requestUrl = "";
+    let requestBody = "";
+    let betaHeaders = "";
+    const stream = createOfficeStreamFn(() => Promise.resolve("https://localhost:3004"), runtime.models);
+    const streamOptions: SimpleStreamOptions = {
+      apiKey: "synthetic-key",
+      maxTokens: 256,
+      reasoning: "high",
+      fetch: (url, init) => {
+        requestUrl = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+        assert.ok(typeof init?.body === "string");
+        requestBody = init.body;
+        betaHeaders = new Headers(init?.headers).get("anthropic-beta") ?? "";
+        return Promise.resolve(new Response("test endpoint", { status: 400 }));
+      },
+    };
+    const events = await stream(model, { messages: [{ role: "user", content: "test", timestamp: 0 }] }, streamOptions);
+    await events.result();
+    if (model.api === "anthropic-messages") {
+      assert.ok(requestUrl.startsWith("https://localhost:3004/?url="));
+      assert.doesNotMatch(requestBody, /"role":"system"/u);
+      assert.match(requestBody, /"thinking":\{"type":"adaptive"/u);
+      assert.doesNotMatch(betaHeaders, /mid-conversation-output-config/u);
+      await assert.rejects(createOfficeStreamFn(() => Promise.resolve(undefined), runtime.models)(
+        model, { messages: [] },
+      ), /requires the Pi for Excel proxy/u);
+    } else {
+      assert.equal(requestUrl, "https://openrouter.ai/api/v1/chat/completions");
+    }
+  }
+});
 
 function createRuntime(args?: {
   providerKeys?: MemoryProviderKeys;
@@ -105,7 +151,7 @@ void test("browser runtime exposes built-in models through IndexedDB-backed cred
   assert.equal(auth?.auth.apiKey, "test-key");
 });
 
-void test("custom gateway discovery merges remote model ids and persists the catalogue", async () => {
+void test("discovery-enabled custom providers merge remote model ids and persist the catalogue", async () => {
   const catalogs = new MemoryCatalogs();
   let requestedUrl = "";
   let authorization = "";
@@ -140,6 +186,73 @@ void test("custom gateway discovery merges remote model ids and persists the cat
     catalogs.entries.get("Gateway · Acme")?.models.map((model) => model.id),
     ["remote-a", "remote-b"],
   );
+});
+
+void test("a gateway saved through the manual form uses only its configured model, including after reload", async () => {
+  const providers = new Map<string, CustomProvider>();
+  const registry = createRuntime().models;
+  await saveOpenAiGatewayConfig({
+    get: (id) => Promise.resolve(providers.get(id) ?? null),
+    set: (provider) => { providers.set(provider.id, provider); return Promise.resolve(); },
+    delete: (id) => { providers.delete(id); return Promise.resolve(); },
+    getAll: () => Promise.resolve([...providers.values()]),
+  }, {
+    displayName: "Manual gateway",
+    endpointUrl: "https://openrouter.ai/api/v1",
+    modelId: "openai/gpt-5.6-sol",
+    apiKey: "synthetic-key",
+  }, registry);
+  const provider = [...providers.values()][0];
+  const model = provider?.models?.[0];
+  assert.ok(provider);
+  assert.ok(model);
+  const catalogs = new MemoryCatalogs();
+  catalogs.entries.set(model.provider, { models: [{ ...model, id: "formerly-discovered" }] });
+  let requests = 0;
+  const fetchFn: typeof fetch = () => {
+    requests += 1;
+    return Promise.resolve(new Response("not supported", { status: 404 }));
+  };
+  for (let boot = 0; boot < 2; boot += 1) {
+    const runtime = createRuntime({ catalogs, fetchFn });
+    await runtime.syncCustomProviders([provider]);
+    await runtime.refresh({ allowNetwork: false });
+    const result = await runtime.refresh({ allowNetwork: true, force: true });
+    assert.equal(result.errors.size, 0);
+    assert.deepEqual((await runtime.models.getAvailable(model.provider)).map((entry) => entry.id), [model.id]);
+    const registered = runtime.models.getModel(model.provider, model.id);
+    const known = registry.getModel("openrouter", model.id);
+    assert.ok(known);
+    assert.equal(registered?.contextWindow, known.contextWindow);
+    assert.equal(registered?.maxTokens, known.maxTokens);
+    assert.deepEqual(registered?.thinkingLevelMap, known.thinkingLevelMap);
+    assert.deepEqual(registered?.cost, known.cost);
+    assert.equal((await runtime.models.getAuth(model.provider))?.auth.apiKey, "synthetic-key");
+  }
+  assert.equal(requests, 0);
+});
+
+void test("provider discovery distinguishes omitted, explicit and null URLs", async () => {
+  for (const modelsUrl of [undefined, "https://catalog.example.com/models", null]) {
+    const requests: string[] = [];
+    const runtime = createRuntime({ fetchFn: (input) => {
+      requests.push(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+      return Promise.resolve(Response.json({ data: [{ id: "discovered" }] }));
+    } });
+    runtime.registerExtensionProvider("test-owner", {
+      id: "test-provider",
+      name: "Test provider",
+      api: "openai-completions",
+      baseUrl: "https://gateway.example.com/v1",
+      models: [{ id: "baseline" }],
+      resolveApiKey: () => Promise.resolve("synthetic-key"),
+      ...(modelsUrl !== undefined ? { modelsUrl } : {}),
+    });
+    await runtime.refresh({ allowNetwork: true });
+    assert.deepEqual(requests, modelsUrl === null ? [] : [modelsUrl ?? "https://gateway.example.com/v1/models"]);
+    assert.deepEqual(runtime.models.getModels("test-provider").map((model) => model.id),
+      modelsUrl === null ? ["baseline"] : ["baseline", "discovered"]);
+  }
 });
 
 void test("a fresh runtime restores discovered models without network access", async () => {

--- a/tests/cors-proxy-server.security.test.mjs
+++ b/tests/cors-proxy-server.security.test.mjs
@@ -267,6 +267,7 @@ test("proxy default allowlist includes supported OAuth and web search providers"
   const requiredHosts = [
     "platform.claude.com",
     "auth.openai.com",
+    "openrouter.ai",
     "s.jina.ai",
     "api.firecrawl.dev",
     "google.serper.dev",

--- a/tests/custom-gateways.test.ts
+++ b/tests/custom-gateways.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import type { Api, Model } from "@earendil-works/pi-ai";
 import type { CustomProvider } from "../src/storage/local/custom-providers-store.js";
 
 import {
@@ -12,6 +13,31 @@ import {
   saveOpenAiGatewayConfig,
   type CustomProvidersStoreLike,
 } from "../src/auth/custom-gateways.ts";
+
+const knownRegistryModel: Model<Api> = {
+  id: "openai/gpt-5.6-sol",
+  name: "OpenAI: GPT-5.6 Sol",
+  api: "openai-completions",
+  provider: "openrouter",
+  baseUrl: "https://openrouter.ai/api/v1",
+  reasoning: true,
+  thinkingLevelMap: {
+    off: "none",
+    low: "low",
+    high: "high",
+  },
+  input: ["text", "image"],
+  cost: {
+    input: 2,
+    output: 10,
+    cacheRead: 0.2,
+    cacheWrite: 2.5,
+  },
+  contextWindow: 1_050_000,
+  maxTokens: 128_000,
+  headers: { "X-Registry-Only": "not-copied" },
+  compat: { thinkingFormat: "openrouter" },
+};
 
 class MemoryCustomProvidersStore implements CustomProvidersStoreLike {
   private readonly providers = new Map<string, CustomProvider>();
@@ -55,6 +81,77 @@ void test("saveOpenAiGatewayConfig stores normalized endpoint/model/provider", a
   assert.equal(listed.length, 1);
   assert.equal(listed[0]?.providerName, saved.providerName);
   assert.equal(listed[0]?.contextWindow, DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW);
+});
+
+void test("saveOpenAiGatewayConfig uses matched registry metadata by default", async () => {
+  const store = new MemoryCustomProvidersStore();
+
+  const saved = await saveOpenAiGatewayConfig(store, {
+    endpointUrl: "https://openrouter.ai/api/v1/",
+    modelId: knownRegistryModel.id,
+  }, {
+    getModels: () => [knownRegistryModel],
+  });
+
+  assert.equal(saved.contextWindow, 1_050_000);
+
+  const storedModel = (await store.get(saved.id))?.models?.[0];
+  assert.equal(storedModel?.contextWindow, 1_050_000);
+  assert.equal(storedModel?.maxTokens, 128_000);
+  assert.equal(storedModel?.reasoning, true);
+  assert.deepEqual(storedModel?.thinkingLevelMap, knownRegistryModel.thinkingLevelMap);
+  assert.deepEqual(storedModel?.input, ["text", "image"]);
+  assert.deepEqual(storedModel?.cost, knownRegistryModel.cost);
+  assert.equal(storedModel?.headers, undefined);
+  assert.equal(storedModel?.compat, undefined);
+});
+
+void test("saveOpenAiGatewayConfig lets explicit context override matched registry context", async () => {
+  const store = new MemoryCustomProvidersStore();
+
+  const saved = await saveOpenAiGatewayConfig(store, {
+    endpointUrl: knownRegistryModel.baseUrl,
+    modelId: knownRegistryModel.id,
+    contextWindow: 64_000,
+  }, {
+    getModels: () => [knownRegistryModel],
+  });
+
+  const storedModel = (await store.get(saved.id))?.models?.[0];
+  assert.equal(saved.contextWindow, 64_000);
+  assert.equal(storedModel?.contextWindow, 64_000);
+  assert.equal(storedModel?.maxTokens, 64_000);
+  assert.equal(storedModel?.reasoning, true);
+});
+
+void test("saveOpenAiGatewayConfig falls back when registry endpoint, id, or API differs", async () => {
+  const mismatchedModels: Model<Api>[] = [
+    { ...knownRegistryModel, baseUrl: "https://different.example.com/v1" },
+    { ...knownRegistryModel, id: "openai/different-model" },
+    { ...knownRegistryModel, api: "openai-responses" },
+  ];
+
+  for (const registryModel of mismatchedModels) {
+    const store = new MemoryCustomProvidersStore();
+    const saved = await saveOpenAiGatewayConfig(store, {
+      endpointUrl: knownRegistryModel.baseUrl,
+      modelId: knownRegistryModel.id,
+    }, {
+      getModels: () => [registryModel],
+    });
+
+    const storedModel = (await store.get(saved.id))?.models?.[0];
+    assert.equal(saved.contextWindow, DEFAULT_OPENAI_GATEWAY_CONTEXT_WINDOW);
+    assert.equal(storedModel?.reasoning, false);
+    assert.deepEqual(storedModel?.input, ["text"]);
+    assert.deepEqual(storedModel?.cost, {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    assert.equal(storedModel?.maxTokens, 4_096);
+  }
 });
 
 void test("saveOpenAiGatewayConfig stores custom context window metadata", async () => {

--- a/tests/custom-gateways.test.ts
+++ b/tests/custom-gateways.test.ts
@@ -124,11 +124,12 @@ void test("saveOpenAiGatewayConfig lets explicit context override matched regist
   assert.equal(storedModel?.reasoning, true);
 });
 
-void test("saveOpenAiGatewayConfig falls back when registry endpoint, id, or API differs", async () => {
+void test("saveOpenAiGatewayConfig rejects mismatched metadata and manual gateway self-matches", async () => {
   const mismatchedModels: Model<Api>[] = [
     { ...knownRegistryModel, baseUrl: "https://different.example.com/v1" },
     { ...knownRegistryModel, id: "openai/different-model" },
     { ...knownRegistryModel, api: "openai-responses" },
+    { ...knownRegistryModel, provider: "Gateway · previous manual snapshot" },
   ];
 
   for (const registryModel of mismatchedModels) {

--- a/tests/dev-auth-policy.test.ts
+++ b/tests/dev-auth-policy.test.ts
@@ -52,4 +52,7 @@ void test("HTTP/2 authority preserves both dev-auth loopback restrictions", () =
   assert.equal(isPiAuthRequestAllowed({ remoteAddress: "10.0.2.15", authorityHeader: "localhost:3141" }), false);
   assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1" }), false);
   assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1", hostHeader: "example.com", authorityHeader: "localhost:3141" }), false);
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1", hostHeader: "localhost:3141", authorityHeader: "10.0.2.2:3141" }), false);
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1", hostHeader: "localhost:3141", authorityHeader: "" }), false);
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1", hostHeader: "localhost:3141", authorityHeader: "localhost:3141" }), true);
 });

--- a/tests/dev-auth-policy.test.ts
+++ b/tests/dev-auth-policy.test.ts
@@ -45,3 +45,11 @@ void test("isPiAuthRequestAllowed has an explicit non-local-host opt-in for disp
   assert.equal(isPiAuthRequestAllowed({ remoteAddress: "127.0.0.1", hostHeader: "10.0.2.2:3141", allowNonLocalHost: true }), true);
   assert.equal(isPiAuthRequestAllowed({ remoteAddress: "10.0.2.15", hostHeader: "10.0.2.2:3141", allowNonLocalHost: true }), false);
 });
+
+void test("HTTP/2 authority preserves both dev-auth loopback restrictions", () => {
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1", authorityHeader: "localhost:3141" }), true);
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1", authorityHeader: "10.0.2.2:3141" }), false);
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "10.0.2.15", authorityHeader: "localhost:3141" }), false);
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1" }), false);
+  assert.equal(isPiAuthRequestAllowed({ remoteAddress: "::1", hostHeader: "example.com", authorityHeader: "localhost:3141" }), false);
+});

--- a/tests/model-ordering.test.ts
+++ b/tests/model-ordering.test.ts
@@ -64,6 +64,13 @@ const GPT_56_VARIANTS = [
     id: "gpt-5.6-sol",
     name: "GPT-5.6 Sol",
     cost: {
+      input: 4,
+      output: 20,
+      cacheRead: 0.4,
+      cacheWrite: 5,
+      tiers: [{ inputTokensAbove: 272_000, input: 8, output: 30, cacheRead: 0.8, cacheWrite: 10 }],
+    },
+    codexCost: {
       input: 5,
       output: 30,
       cacheRead: 0.5,
@@ -75,22 +82,22 @@ const GPT_56_VARIANTS = [
     id: "gpt-5.6-terra",
     name: "GPT-5.6 Terra",
     cost: {
-      input: 2.5,
-      output: 15,
-      cacheRead: 0.25,
-      cacheWrite: 3.125,
-      tiers: [{ inputTokensAbove: 272_000, input: 5, output: 22.5, cacheRead: 0.5, cacheWrite: 6.25 }],
+      input: 2,
+      output: 12,
+      cacheRead: 0.2,
+      cacheWrite: 2.5,
+      tiers: [{ inputTokensAbove: 272_000, input: 4, output: 18, cacheRead: 0.4, cacheWrite: 5 }],
     },
   },
   {
     id: "gpt-5.6-luna",
     name: "GPT-5.6 Luna",
     cost: {
-      input: 1,
-      output: 6,
-      cacheRead: 0.1,
-      cacheWrite: 1.25,
-      tiers: [{ inputTokensAbove: 272_000, input: 2, output: 9, cacheRead: 0.2, cacheWrite: 2.5 }],
+      input: 0.2,
+      output: 1.2,
+      cacheRead: 0.02,
+      cacheWrite: 0.25,
+      tiers: [{ inputTokensAbove: 272_000, input: 0.4, output: 1.8, cacheRead: 0.04, cacheWrite: 0.5 }],
     },
   },
 ];
@@ -254,7 +261,7 @@ void test("GPT-5.6 registry exposes the metadata used by the app", () => {
       assert.deepEqual(model.input, ["text", "image"]);
       assert.equal(model.contextWindow, 272_000);
       assert.equal(model.maxTokens, 128_000);
-      assert.deepEqual(model.cost, expected.cost);
+      assert.deepEqual(model.cost, isCodex && "codexCost" in expected ? expected.codexCost : expected.cost);
       assert.equal(model.thinkingLevelMap?.minimal, isCodex ? "low" : null);
       assert.equal(model.thinkingLevelMap?.xhigh, "xhigh");
       assert.equal(model.thinkingLevelMap?.max, "max");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,7 @@ function piAuthPlugin(): Plugin {
         // local browser). QEMU user networking can make WPS guest traffic appear
         // loopback to Vite, so also require a localhost/127.0.0.1 Host header by default.
         const remote = req.socket?.remoteAddress;
-        if (!isPiAuthRequestAllowed({ remoteAddress: remote, hostHeader: req.headers.host, allowNonLocalHost })) {
+        if (!isPiAuthRequestAllowed({ remoteAddress: remote, hostHeader: req.headers.host, authorityHeader: req.headers[":authority"], allowNonLocalHost })) {
           res.statusCode = 403;
           res.setHeader("Content-Type", "application/json; charset=utf-8");
           res.setHeader("Cache-Control", "no-store");


### PR DESCRIPTION
## Summary
- Update Pi AI and Agent Core to 0.85.1.
- Keep manual gateways on their configured model without discovery; use matching shared-registry metadata at save time while preserving explicit context overrides.
- Route native OpenRouter Anthropic requests through the configured proxy and disable its unsupported mid-conversation effort capability without mutating registry models.
- Accept loopback HTTP/2 authority for development auth while retaining strict host checks.

Related: #700, #702. This implements a scoped alternative to #702; it does not claim to resolve every UI symptom in #700.

## Verification
- Check and production build passed.
- 922 tests passed: models (61), context (749), security (112).
- Real background Excel: built-in OpenRouter wrote and independently read back 42; native Claude completed two tool-reading turns; the manual gateway changed a cell and independently read back 43.
- Manual gateway save made no discovery requests. Native Claude steady-prefix checks showed no prefix changes.
- HTTP/2 loopback auth returned 200; non-local authority returned 403.
- Temporary harness, isolated credentials/storage, scratch worksheet and owned servers cleaned up.

## Compatibility notes
Manual metadata is a save-time snapshot. Existing gateways retain their saved context override until edited; clear the context field to use current registry defaults. The narrow OpenRouter effort override and its removal condition are documented.

Independent agent review complete. Conflicting HTTP/2 authority handling was fixed in b492db2 and independently re-tested through a real HTTP/2 server. No remaining review blockers. No merge requested.

---
Stack: #713 (`chore/anti-slop`) is based on this branch. Merge this PR first, then retarget #713 to `main`.