### PR TITLE
chore(deps): move pinned @xmldom/xmldom, tmp and js-yaml past new high advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4609,9 +4609,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7675,9 +7675,9 @@
       "peer": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "node": "^22.19.0 || >=24"
   },
   "overrides": {
-    "tmp": "0.2.6",
+    "tmp": "0.2.7",
     "nanoid": "3.3.18",
     "axios": "1.19.0",
     "minimatch": "10.2.4",
@@ -86,7 +86,7 @@
     "tar": "7.5.22",
     "adm-zip": "0.6.0",
     "fast-xml-parser": "5.7.0",
-    "@xmldom/xmldom": "0.8.13",
+    "@xmldom/xmldom": "0.8.15",
     "protobufjs": "7.6.5",
     "follow-redirects": "1.16.0"
   }


### PR DESCRIPTION
## Why

`npm audit --audit-level=high` — the first step in CI — started failing on `main` on 10 September (last green: `77ee30c`, 8 September; red: `b6184cd`). No code changed; advisories were published against versions our `overrides` pin. Every open PR, including dependabot's, is red at that step.

## What

| Package | From | To | Path | Advisory |
| --- | --- | --- | --- | --- |
| `@xmldom/xmldom` | 0.8.13 (override) | 0.8.15 | `office-addin-debugging` → `office-addin-manifest-converter` (dev) | GHSA-6gmq-8vp8-gcm6 and nine others, all `<=0.8.14` |
| `js-yaml` | 4.3.1 | 4.3.2 | `office-addin-debugging` → `@microsoft/teamsfx-core` (dev) | merge-key CPU advisory, `4.0.0 – 4.3.1` |
| `tmp` | 0.2.6 (override) | 0.2.7 | not currently installed | GHSA-7c78-jf6q-g5cm, `>=0.2.6 <0.2.7` |

Three lockfile entries change. `npm audit fix` would have touched 60 transitive packages; that churn is left to dependabot's existing PRs.

## Verified

- `npm audit --audit-level=high` exits 0 (0 high, 16 moderate — same moderate set as before)
- `npm run check`
- `npm run test:models && npm run test:context && npm run test:security && npm run test:manifest` — 938 tests pass
- `npm run build`
- `npm run validate` — the manifest tooling is the consumer of `@xmldom/xmldom`

Runtime testing not applicable: no shipped code changes (all three packages are dev-only, under `office-addin-debugging`).