### PR TITLE
refactor: tool details as schemas, decoded once at the UI seam; fix StringEnum literal types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Notes for agents working in this repo.
 - No explicit `any`, `as any`, or non-null assertions.
 - `unknown` only at the seam (JSON decode, host object, bridge/sandbox message, caught error); parse it into a concrete domain type on the next line. Never add `unknown` further in: `npm run check:unknown-burndown` fails if the count rises (see `docs/coding-standards.md`).
 - Do not add generic object/record guards (`isRecord`, `isObjectValue`, `isPlainObject`, `is…PayloadShape`, etc.); an object check alone does not establish a domain contract. Parse the domain shape, preferably with a TypeBox schema and `Static<>`.
-- Schemas use `typebox` (pinned to pi-ai's version; one copy ships). `StringEnum` comes from `@earendil-works/pi-ai`.
+- Schemas use `typebox` (pinned to pi-ai's version; one copy ships). Import `StringEnum` from `src/tools/string-enum.ts` (pi-ai's, with a `const` type parameter so inline arrays keep literal types).
 - Type assertions and lint suppressions must stay local and explain the safety invariant; do not add blanket safety comments.
 
 ## Verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Notes for agents working in this repo.
 - Keep human-readable output in `result.content`.
 - Put stable machine metadata in `result.details`.
 - UI should prefer `details`, with fallback for older persisted sessions.
-- Reuse guards/types from `src/tools/tool-details.ts`.
+- Every details payload is a TypeBox schema in `src/tools/tool-details.ts` with its type as `Static<>`; add a new payload there and to `toolDetailsSchemasByKind`. The UI decodes `result.details` once with `decodeToolDetails()` and switches on `kind`; do not add per-kind `isXDetails` guards.
 
 ### Workbook identity + session restore
 - Never persist raw `Office.context.document.url`.

--- a/docs/clean-base-followups.md
+++ b/docs/clean-base-followups.md
@@ -21,7 +21,9 @@ the ESLint ban on `unknown` are gone; every former alias site now says
 the anti-slop `no-unknown-*` rules as a ratchet (baseline 461 sites in `src`:
 384 parameters, 77 returns) and fails if the count rises. Both TypeBox majors
 are gone too: everything imports `typebox`, pinned to pi-ai's exact version so
-one copy ships, and `StringEnum` comes from pi-ai.
+one copy ships, and `StringEnum` is pi-ai's behind `src/tools/string-enum.ts`
+(a `const` type parameter; without it an inline array widens the static type
+to `string`, which #718 did to two tools before it was caught).
 
 Still to do: parse boundary values into domain types so the count falls.
 

--- a/docs/clean-base-followups.md
+++ b/docs/clean-base-followups.md
@@ -30,20 +30,20 @@ Still to do: parse boundary values into domain types so the count falls.
 Probe:
 
 ```bash
-npm run check:unknown-burndown                                                  # 461 at the alias deletion
-rg -c '^(export )?function is\w+\(\w+: unknown' src | awk -F: '{s+=$2} END{print s}'  # 233 hand-written guards
+npm run check:unknown-burndown                                                  # 461 at the alias deletion; 430 after settings contract + tool-details
+rg -c '^(export )?function is\w+\(\w+: unknown' src | awk -F: '{s+=$2} END{print s}'  # 233 hand-written guards; 179 after tool-details
 ```
 
 Where the uses are, and what proper typing means for each:
 
 | Category | Approx. uses | Target |
 | --- | ---: | --- |
-| Hand-written guard functions (`isOptionalString(value: DynamicValue): value is ...`), concentrated in `src/tools/tool-details.ts`, `src/workbook/recovery/*`, `src/files/workspace.ts`, `src/conventions/store.ts` | 630 | One TypeBox schema per DTO, `Static<>` for the type, one `decode(schema, raw)` helper at the boundary. Delete the guards; do not rename them. |
+| Hand-written guard functions (`isOptionalString(value: unknown): value is ...`), concentrated in `src/workbook/recovery/*`, `src/files/workspace.ts`, `src/conventions/store.ts` (`src/tools/tool-details.ts` done 2026-09-10: 54 guards → schemas, `decodeToolDetails` at the renderer seam) | 630 → ~500 | One TypeBox schema per DTO, `Static<>` for the type, one `decode(schema, raw)` helper at the boundary. Delete the guards; do not rename them. |
 | `DynamicObject` shape guards | 115 | Falls out of the schema work. |
 | Extension sandbox and bridge payloads | 90 | `JsonValue` (`src/utils/json.ts`) where the protocol is JSON; TypeBox for structured messages. |
-| UI rendering of tool `details` | 90 | Typed by the details union once tools decode. |
+| UI rendering of tool `details` | 90 | Done 2026-09-10: `src/ui/tool-renderers.ts`, `bridge-setup-card.ts` and `web-search-setup-card.ts` take `ExcelToolDetails` and switch on `kind`. |
 | Error callbacks `(error: DynamicValue) =>` | 33 | `(error: Error)`; normalise once at the catch site. `getErrorMessage` stays the one function that accepts a thrown value. |
-| Office.js and WPS host values | 40 | Typed host adapter interfaces (`src/host/wps/jsapi.ts` is the pattern). |
+| Office.js and WPS host values | 40 | Typed host adapter interfaces (`src/host/wps/jsapi.ts` is the pattern). Includes cell-value grids: `range.values` is `any[][]` in Office.js, so `unknown[][]` runs through 110 sites and into `ReadRangeCsvDetails.values` / `DepNodeDetail.value`; type it once at the adapter, then tighten those two schemas. |
 | Storage `get<T = DynamicValue>()` | 20 | See next section. |
 
 Suggested order from here: persisted DTOs (largest, and it removes `get<T>`);
@@ -260,10 +260,15 @@ corrupt-recovery-log fallback (seam tests only).
 - Two TypeBox majors shipped in the bundle (`@sinclair/typebox` 0.34 and
   `typebox` 1.x). Settled on `typebox` 1.3.7 (2026-09-10), pinned to pi-ai's
   version and enforced by `check:pi-lockstep`.
-- `npm audit --audit-level=high` reports two high findings, both transitive
-  (`@xmldom/xmldom`, `js-yaml`), on `main` and on every branch since. The
-  pre-push hook blocks on them; pushes during the review used `--no-verify`
-  after confirming the finding set was unchanged.
+- `npm audit --audit-level=high` reported two high findings, both transitive
+  (`@xmldom/xmldom`, `js-yaml`), until the Dependabot merges of 2026-09-10;
+  clean since, so pushes no longer need `--no-verify`.
+- Tests are not typechecked. `tsconfig.json` includes `src/**` only;
+  `tsconfig.eslint.json` adds `tests/**` for ESLint parsing, and
+  `tsc --noEmit -p tsconfig.eslint.json` reports 533 errors there
+  (2026-09-10). Type-level contracts therefore cannot live in `tests/`; the
+  `StringEnum` literal regression from #718 is guarded structurally
+  (`src/tools/string-enum.ts`) rather than by a test for that reason.
 - `tests/browser/extensions-overlays.browser-test.ts` ("an installed extension
   can replace and dismiss its visible overlay") timed out once in eight full
   serial runs waiting for the welcome overlay to detach. Root-caused and fixed:

--- a/scripts/check-unknown-burndown.mjs
+++ b/scripts/check-unknown-burndown.mjs
@@ -12,7 +12,7 @@
  */
 import { spawnSync } from "node:child_process";
 
-const BASELINE = 439; // 2026-09-11: 373 no-unknown-parameters, 66 no-unknown-returns, 0 no-unknown-type-aliases
+const BASELINE = 430; // 2026-09-11: 364 no-unknown-parameters, 66 no-unknown-returns, 0 no-unknown-type-aliases
 
 const result = spawnSync(
   "npx",

--- a/src/audit/cell-diff.ts
+++ b/src/audit/cell-diff.ts
@@ -2,24 +2,30 @@
  * Workbook cell change diff helpers.
  */
 
+import { Type, type Static } from "typebox";
+
 import { cellAddress, parseCell, qualifiedAddress } from "../excel/helpers.js";
 
 const DEFAULT_SAMPLE_LIMIT = 12;
 const DEFAULT_PREVIEW_CHARS = 80;
 
-export interface WorkbookCellChange {
-  address: string;
-  beforeValue: string;
-  afterValue: string;
-  beforeFormula?: string;
-  afterFormula?: string;
-}
+export const workbookCellChangeSchema = Type.Object({
+  address: Type.String(),
+  beforeValue: Type.String(),
+  afterValue: Type.String(),
+  beforeFormula: Type.Optional(Type.String()),
+  afterFormula: Type.Optional(Type.String()),
+});
 
-export interface WorkbookCellChangeSummary {
-  changedCount: number;
-  truncated: boolean;
-  sample: WorkbookCellChange[];
-}
+export type WorkbookCellChange = Static<typeof workbookCellChangeSchema>;
+
+export const workbookCellChangeSummarySchema = Type.Object({
+  changedCount: Type.Number(),
+  truncated: Type.Boolean(),
+  sample: Type.Array(workbookCellChangeSchema),
+});
+
+export type WorkbookCellChangeSummary = Static<typeof workbookCellChangeSummarySchema>;
 
 export interface BuildWorkbookCellChangeSummaryArgs {
   sheetName: string;

--- a/src/connections/types.ts
+++ b/src/connections/types.ts
@@ -1,4 +1,10 @@
-export type ConnectionStatus = "connected" | "missing" | "invalid" | "error";
+import { Type, type Static } from "typebox";
+
+import { StringEnum } from "../tools/string-enum.js";
+
+export const connectionStatusSchema = StringEnum(["connected", "missing", "invalid", "error"]);
+
+export type ConnectionStatus = Static<typeof connectionStatusSchema>;
 
 export type ConnectionAuthKind = "api_key" | "bearer_token" | "oauth" | "custom";
 
@@ -59,21 +65,26 @@ export interface ConnectionPromptEntry {
   lastError?: string;
 }
 
-export type ConnectionToolErrorCode =
-  | "missing_connection"
-  | "invalid_connection"
-  | "connection_auth_failed";
+export const connectionToolErrorCodeSchema = StringEnum([
+  "missing_connection",
+  "invalid_connection",
+  "connection_auth_failed",
+]);
 
-export interface ConnectionToolErrorDetails {
-  kind: "connection_error";
-  ok: false;
-  errorCode: ConnectionToolErrorCode;
-  connectionId: string;
-  connectionTitle: string;
-  status: ConnectionStatus;
-  setupHint: string;
-  reason?: string;
-}
+export type ConnectionToolErrorCode = Static<typeof connectionToolErrorCodeSchema>;
+
+export const connectionToolErrorDetailsSchema = Type.Object({
+  kind: Type.Literal("connection_error"),
+  ok: Type.Literal(false),
+  errorCode: connectionToolErrorCodeSchema,
+  connectionId: Type.String(),
+  connectionTitle: Type.String(),
+  status: connectionStatusSchema,
+  setupHint: Type.String(),
+  reason: Type.Optional(Type.String()),
+});
+
+export type ConnectionToolErrorDetails = Static<typeof connectionToolErrorDetailsSchema>;
 
 export interface ConnectionRuntimeAuthFailure {
   message: string;

--- a/src/tools/DECISIONS.md
+++ b/src/tools/DECISIONS.md
@@ -116,6 +116,13 @@ Concise record of recent tool behavior choices to avoid regressions. Update this
 - **Execution policy:** classified as read/none for workbook coordinator purposes (it mutates prompt metadata, not workbook cells/structure).
 - **Rationale:** AGENTS.md-style persistent guidance without creating a separate workbook mutation path.
 
+## Tool details are schemas, decoded once at the UI seam
+- **Contract:** each `details` payload is a TypeBox schema in `src/tools/tool-details.ts`; the exported type is `Static<>` of the schema, so tools that construct the payload are checked against the same shape the UI validates at runtime.
+- **Seam:** `ToolResultMessage.details` reaches the renderer as `unknown` (older persisted sessions may carry any shape). `decodeToolDetails()` runs once per tool card and returns the `ExcelToolDetails` union or `undefined`; everything inward takes the union and switches on `kind`. A payload that fails its schema renders generically rather than partially.
+- **Extras:** schemas allow additional properties so cross-cutting metadata (`outputTruncation`) can be merged into any payload without each schema knowing about it.
+- **Cell values:** `read_range_csv.values` and `trace_dependencies` node values stay `unknown` until the host adapters type `range.values`; that is the host-boundary item in `docs/clean-base-followups.md`.
+- **No compiled validators:** `Value.Check` only. `typebox/compile` generates code at runtime, which the Office WebView CSP forbids. A decode costs roughly 10–20 µs.
+
 ## Global tool output truncation (Pi-style guardrail)
 - **Scope:** applied as a runtime wrapper around all registered tools (core + integrations + extensions) before tool results are persisted to message history.
 - **Limits:** **50KB** UTF-8 bytes and **2000 lines** (whichever is hit first), aligned with pi-coding-agent defaults. For models with context windows **below 128k**, limits scale linearly with the window (floors: **8KB** / **200 lines**) — resolved per execution from the active model via `src/context/window-budgets.ts` (#566).

--- a/src/tools/charts.ts
+++ b/src/tools/charts.ts
@@ -3,7 +3,7 @@
  */
 
 import { Type, type Static } from "typebox";
-import { StringEnum } from "@earendil-works/pi-ai";
+import { StringEnum } from "./string-enum.js";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { excelRun, parseRangeRef, qualifiedAddress } from "../excel/helpers.js";
 import {

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -6,7 +6,7 @@
  */
 
 import { Type, type Static } from "typebox";
-import { StringEnum } from "@earendil-works/pi-ai";
+import { StringEnum } from "./string-enum.js";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { excelRun, getRange, isCellInRange, qualifiedAddress } from "../excel/helpers.js";
 import {

--- a/src/tools/modify-structure.ts
+++ b/src/tools/modify-structure.ts
@@ -5,7 +5,7 @@
  */
 
 import { Type, type Static } from "typebox";
-import { StringEnum } from "@earendil-works/pi-ai";
+import { StringEnum } from "./string-enum.js";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { excelRun } from "../excel/helpers.js";
 import { getWorkbookChangeAuditLog } from "../audit/workbook-change-audit.js";

--- a/src/tools/string-enum.ts
+++ b/src/tools/string-enum.ts
@@ -1,0 +1,18 @@
+/**
+ * pi-ai's `StringEnum` with a `const` type parameter.
+ *
+ * pi-ai infers `T` as `readonly string[]` for an inline array, which turns the
+ * schema's static type into `string`. The `const` modifier keeps the literal
+ * tuple, so `Static<typeof schema>["action"]` stays the union of the listed
+ * values without `as const` at every call site. Runtime output is identical.
+ */
+
+import { StringEnum as piStringEnum } from "@earendil-works/pi-ai";
+import type { TUnsafe } from "typebox";
+
+export function StringEnum<const T extends readonly string[]>(
+  values: T,
+  options?: { description?: string; default?: T[number] },
+): TUnsafe<T[number]> {
+  return piStringEnum(values, options);
+}

--- a/src/tools/tmux.ts
+++ b/src/tools/tmux.ts
@@ -15,7 +15,7 @@ function isToolsTmuxPayloadShape(value: unknown): value is Record<string, unknow
 
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { Type, type Static, type TSchema } from "typebox";
-import { StringEnum } from "@earendil-works/pi-ai";
+import { StringEnum } from "./string-enum.js";
 
 import { validateOfficeProxyUrl } from "../auth/proxy-validation.js";
 import { getErrorMessage } from "../utils/errors.js";

--- a/src/tools/tool-details.ts
+++ b/src/tools/tool-details.ts
@@ -1,319 +1,410 @@
-function isToolsToolDetailsPayloadShape(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 /**
  * Structured tool result metadata for the UI.
  *
  * Tools still return human-readable markdown in `content`, but also attach a
  * small stable `details` payload so the UI doesn't need to parse strings.
+ *
+ * Each payload is a TypeBox schema; the exported types are `Static<>` of the
+ * schema so the type and the runtime check cannot drift. `details` reaches the
+ * UI as `unknown` (it may come from an older persisted session), so the UI
+ * decodes it once with `decodeToolDetails` and switches on `kind` from there.
  */
 
-import type { WorkbookCellChangeSummary } from "../audit/cell-diff.js";
-import type { ConnectionToolErrorDetails } from "../connections/types.js";
+import { Type, type Static, type TSchema } from "typebox";
+import { Value } from "typebox/value";
 
-export interface RecoveryCheckpointDetails {
-  status: "checkpoint_created" | "not_available";
-  snapshotId?: string;
-  reason?: string;
-}
+import { workbookCellChangeSummarySchema } from "../audit/cell-diff.js";
+import { connectionToolErrorDetailsSchema } from "../connections/types.js";
+import { StringEnum } from "./string-enum.js";
 
-export type ToolOutputTruncationStrategy = "head" | "tail";
+export const recoveryCheckpointDetailsSchema = Type.Object({
+  status: StringEnum(["checkpoint_created", "not_available"]),
+  snapshotId: Type.Optional(Type.String()),
+  reason: Type.Optional(Type.String()),
+});
 
-export type ToolOutputTruncationReason = "lines" | "bytes" | null;
+export type RecoveryCheckpointDetails = Static<typeof recoveryCheckpointDetailsSchema>;
 
-export interface ToolOutputTruncationDetails {
-  version: 1;
-  strategy: ToolOutputTruncationStrategy;
-  truncated: boolean;
-  truncatedBy: ToolOutputTruncationReason;
-  totalLines: number;
-  totalBytes: number;
-  outputLines: number;
-  outputBytes: number;
-  maxLines: number;
-  maxBytes: number;
-  fullOutputWorkspacePath?: string;
-}
+const toolOutputTruncationStrategySchema = StringEnum(["head", "tail"]);
 
-export interface WriteCellsDetails {
-  kind: "write_cells";
-  blocked: boolean;
+export type ToolOutputTruncationStrategy = Static<typeof toolOutputTruncationStrategySchema>;
+
+const toolOutputTruncationReasonSchema = Type.Union([
+  Type.Literal("lines"),
+  Type.Literal("bytes"),
+  Type.Null(),
+]);
+
+export type ToolOutputTruncationReason = Static<typeof toolOutputTruncationReasonSchema>;
+
+export const toolOutputTruncationDetailsSchema = Type.Object({
+  version: Type.Literal(1),
+  strategy: toolOutputTruncationStrategySchema,
+  truncated: Type.Boolean(),
+  truncatedBy: toolOutputTruncationReasonSchema,
+  totalLines: Type.Number(),
+  totalBytes: Type.Number(),
+  outputLines: Type.Number(),
+  outputBytes: Type.Number(),
+  maxLines: Type.Number(),
+  maxBytes: Type.Number(),
+  fullOutputWorkspacePath: Type.Optional(Type.String()),
+});
+
+export type ToolOutputTruncationDetails = Static<typeof toolOutputTruncationDetailsSchema>;
+
+/** Truncation is merged into whatever details a tool returned, alongside its own fields. */
+const truncatedToolDetailsSchema = Type.Object({
+  outputTruncation: toolOutputTruncationDetailsSchema,
+});
+
+const mutationDetailsProperties = {
+  blocked: Type.Boolean(),
   /** Sheet-qualified range when known, e.g. "Sheet1!A1:C3" */
-  address?: string;
-  existingCount?: number;
-  formulaErrorCount?: number;
-  changes?: WorkbookCellChangeSummary;
-  recovery?: RecoveryCheckpointDetails;
-}
+  address: Type.Optional(Type.String()),
+  existingCount: Type.Optional(Type.Number()),
+  formulaErrorCount: Type.Optional(Type.Number()),
+  changes: Type.Optional(workbookCellChangeSummarySchema),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+};
 
-export interface FillFormulaDetails {
-  kind: "fill_formula";
-  blocked: boolean;
-  /** Sheet-qualified range when known, e.g. "Sheet1!B2:B20" */
-  address?: string;
-  existingCount?: number;
-  formulaErrorCount?: number;
-  changes?: WorkbookCellChangeSummary;
-  recovery?: RecoveryCheckpointDetails;
-}
+export const writeCellsDetailsSchema = Type.Object({
+  kind: Type.Literal("write_cells"),
+  ...mutationDetailsProperties,
+});
 
-export interface FormatCellsDetails {
-  kind: "format_cells";
+export type WriteCellsDetails = Static<typeof writeCellsDetailsSchema>;
+
+export const fillFormulaDetailsSchema = Type.Object({
+  kind: Type.Literal("fill_formula"),
+  ...mutationDetailsProperties,
+});
+
+export type FillFormulaDetails = Static<typeof fillFormulaDetailsSchema>;
+
+export const formatCellsDetailsSchema = Type.Object({
+  kind: Type.Literal("format_cells"),
   /** Sheet-qualified range when known. May be a multi-range string. */
-  address?: string;
-  warningsCount?: number;
-  recovery?: RecoveryCheckpointDetails;
-}
+  address: Type.Optional(Type.String()),
+  warningsCount: Type.Optional(Type.Number()),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+});
 
-export interface ConditionalFormatDetails {
-  kind: "conditional_format";
-  action?: "add" | "clear";
-  address?: string;
-  recovery?: RecoveryCheckpointDetails;
-}
+export type FormatCellsDetails = Static<typeof formatCellsDetailsSchema>;
 
-export interface ModifyStructureDetails {
-  kind: "modify_structure";
-  action?: string;
-  recovery?: RecoveryCheckpointDetails;
-}
+export const conditionalFormatDetailsSchema = Type.Object({
+  kind: Type.Literal("conditional_format"),
+  action: Type.Optional(StringEnum(["add", "clear"])),
+  address: Type.Optional(Type.String()),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+});
 
-export interface CommentsDetails {
-  kind: "comments";
-  action?: string;
-  address?: string;
-  recovery?: RecoveryCheckpointDetails;
-}
+export type ConditionalFormatDetails = Static<typeof conditionalFormatDetailsSchema>;
 
-export interface ViewSettingsDetails {
-  kind: "view_settings";
-  action?: string;
-  address?: string;
-  recovery?: RecoveryCheckpointDetails;
-}
+export const modifyStructureDetailsSchema = Type.Object({
+  kind: Type.Literal("modify_structure"),
+  action: Type.Optional(Type.String()),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+});
 
-export interface ChartPositionDetails {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}
+export type ModifyStructureDetails = Static<typeof modifyStructureDetailsSchema>;
 
-export interface ChartListItemDetails {
-  name: string;
-  chartType: string;
-  title: string;
-  worksheet: string;
-  position: ChartPositionDetails;
-}
+export const commentsDetailsSchema = Type.Object({
+  kind: Type.Literal("comments"),
+  action: Type.Optional(Type.String()),
+  address: Type.Optional(Type.String()),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+});
 
-export interface ChartImageDetails {
-  base64: string;
-  mimeType: "image/png";
-  width: number;
-  height: number;
-}
+export type CommentsDetails = Static<typeof commentsDetailsSchema>;
 
-export interface ChartsDetails {
-  kind: "charts";
-  action?: string;
-  name?: string;
-  address?: string;
-  sourceRange?: string;
-  count?: number;
-  charts?: ChartListItemDetails[];
-  image?: ChartImageDetails;
-  recovery?: RecoveryCheckpointDetails;
-}
+export const viewSettingsDetailsSchema = Type.Object({
+  kind: Type.Literal("view_settings"),
+  action: Type.Optional(Type.String()),
+  address: Type.Optional(Type.String()),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+});
 
-export type TraceDependenciesMode = "precedents" | "dependents";
-export type TraceDependencySource = "api" | "formula_scan" | "mixed" | "none";
+export type ViewSettingsDetails = Static<typeof viewSettingsDetailsSchema>;
 
-export interface DepNodeDetail {
-  address: string;
-  value: unknown;
-  /** Excel number format string, e.g. "0.00%", "#,##0", "$#,##0.00". */
-  numberFormat?: string;
-  formula?: string;
-  /** Child nodes in traversal order (precedents for precedents mode, dependents for dependents mode). */
-  precedents: DepNodeDetail[];
-}
+export const chartPositionDetailsSchema = Type.Object({
+  top: Type.Number(),
+  left: Type.Number(),
+  width: Type.Number(),
+  height: Type.Number(),
+});
 
-export interface TraceDependenciesDetails {
-  kind: "trace_dependencies";
-  root: DepNodeDetail;
-  mode?: TraceDependenciesMode;
-  maxDepth?: number;
-  nodeCount?: number;
-  edgeCount?: number;
-  source?: TraceDependencySource;
-  truncated?: boolean;
-}
+export type ChartPositionDetails = Static<typeof chartPositionDetailsSchema>;
 
-export interface ExplainFormulaReferenceDetail {
-  address: string;
-  valuePreview?: string;
-  formulaPreview?: string;
-}
+export const chartListItemDetailsSchema = Type.Object({
+  name: Type.String(),
+  chartType: Type.String(),
+  title: Type.String(),
+  worksheet: Type.String(),
+  position: chartPositionDetailsSchema,
+});
 
-export interface ExplainFormulaDetails {
-  kind: "explain_formula";
-  cell: string;
-  hasFormula: boolean;
-  formula?: string;
-  valuePreview?: string;
-  explanation: string;
-  references: ExplainFormulaReferenceDetail[];
-  truncated?: boolean;
-}
+export type ChartListItemDetails = Static<typeof chartListItemDetailsSchema>;
 
-export interface ReadRangeCsvDetails {
-  kind: "read_range_csv";
+export const chartImageDetailsSchema = Type.Object({
+  base64: Type.String(),
+  mimeType: Type.Literal("image/png"),
+  width: Type.Number(),
+  height: Type.Number(),
+});
+
+export type ChartImageDetails = Static<typeof chartImageDetailsSchema>;
+
+export const chartsDetailsSchema = Type.Object({
+  kind: Type.Literal("charts"),
+  action: Type.Optional(Type.String()),
+  name: Type.Optional(Type.String()),
+  address: Type.Optional(Type.String()),
+  sourceRange: Type.Optional(Type.String()),
+  count: Type.Optional(Type.Number()),
+  charts: Type.Optional(Type.Array(chartListItemDetailsSchema)),
+  image: Type.Optional(chartImageDetailsSchema),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+});
+
+export type ChartsDetails = Static<typeof chartsDetailsSchema>;
+
+const traceDependenciesModeSchema = StringEnum(["precedents", "dependents"]);
+
+export type TraceDependenciesMode = Static<typeof traceDependenciesModeSchema>;
+
+const traceDependencySourceSchema = StringEnum(["api", "formula_scan", "mixed", "none"]);
+
+export type TraceDependencySource = Static<typeof traceDependencySourceSchema>;
+
+/**
+ * A cell value as the host returned it. `range.values` is untyped in Office.js
+ * and WPS; typing it belongs to the host adapters, after which this narrows.
+ */
+const hostCellValueSchema = Type.Unknown();
+
+export const depNodeDetailSchema = Type.Cyclic({
+  DepNode: Type.Object({
+    address: Type.String(),
+    value: hostCellValueSchema,
+    /** Excel number format string, e.g. "0.00%", "#,##0", "$#,##0.00". */
+    numberFormat: Type.Optional(Type.String()),
+    formula: Type.Optional(Type.String()),
+    /** Child nodes in traversal order (precedents for precedents mode, dependents for dependents mode). */
+    precedents: Type.Array(Type.Ref("DepNode")),
+  }),
+}, "DepNode");
+
+export type DepNodeDetail = Static<typeof depNodeDetailSchema>;
+
+export const traceDependenciesDetailsSchema = Type.Object({
+  kind: Type.Literal("trace_dependencies"),
+  root: depNodeDetailSchema,
+  mode: Type.Optional(traceDependenciesModeSchema),
+  maxDepth: Type.Optional(Type.Number()),
+  nodeCount: Type.Optional(Type.Number()),
+  edgeCount: Type.Optional(Type.Number()),
+  source: Type.Optional(traceDependencySourceSchema),
+  truncated: Type.Optional(Type.Boolean()),
+});
+
+export type TraceDependenciesDetails = Static<typeof traceDependenciesDetailsSchema>;
+
+export const explainFormulaReferenceDetailSchema = Type.Object({
+  address: Type.String(),
+  valuePreview: Type.Optional(Type.String()),
+  formulaPreview: Type.Optional(Type.String()),
+});
+
+export type ExplainFormulaReferenceDetail = Static<typeof explainFormulaReferenceDetailSchema>;
+
+export const explainFormulaDetailsSchema = Type.Object({
+  kind: Type.Literal("explain_formula"),
+  cell: Type.String(),
+  hasFormula: Type.Boolean(),
+  formula: Type.Optional(Type.String()),
+  valuePreview: Type.Optional(Type.String()),
+  explanation: Type.String(),
+  references: Type.Array(explainFormulaReferenceDetailSchema),
+  truncated: Type.Optional(Type.Boolean()),
+});
+
+export type ExplainFormulaDetails = Static<typeof explainFormulaDetailsSchema>;
+
+export const readRangeCsvDetailsSchema = Type.Object({
+  kind: Type.Literal("read_range_csv"),
   /** 0-indexed starting column (A=0, B=1, …) */
-  startCol: number;
+  startCol: Type.Number(),
   /** 1-indexed starting row */
-  startRow: number;
-  /** Raw values grid from Excel */
-  values: unknown[][];
+  startRow: Type.Number(),
+  /** Raw values grid from the host */
+  values: Type.Array(Type.Array(hostCellValueSchema)),
   /** Pre-serialized CSV string for the copy button */
-  csv: string;
-}
+  csv: Type.String(),
+});
 
-export type BridgeGateReason = "missing_bridge_url" | "invalid_bridge_url" | "bridge_unreachable";
+export type ReadRangeCsvDetails = Static<typeof readRangeCsvDetailsSchema>;
 
-export interface TmuxBridgeDetails {
-  kind: "tmux_bridge";
-  ok: boolean;
-  action: string;
-  bridgeUrl?: string;
-  session?: string;
-  sessionsCount?: number;
-  outputPreview?: string;
-  error?: string;
-  gateReason?: BridgeGateReason;
-  skillHint?: string;
-}
+const bridgeGateReasonSchema = StringEnum(["missing_bridge_url", "invalid_bridge_url", "bridge_unreachable"]);
 
-export interface PythonBridgeDetails {
-  kind: "python_bridge";
-  ok: boolean;
-  action: string;
-  bridgeUrl?: string;
-  exitCode?: number;
-  stdoutPreview?: string;
-  stderrPreview?: string;
-  resultPreview?: string;
-  truncated?: boolean;
-  error?: string;
-  gateReason?: BridgeGateReason;
-  skillHint?: string;
-}
+export type BridgeGateReason = Static<typeof bridgeGateReasonSchema>;
 
-export interface LibreOfficeBridgeDetails {
-  kind: "libreoffice_bridge";
-  ok: boolean;
-  action: string;
-  bridgeUrl?: string;
-  inputPath?: string;
-  targetFormat?: string;
-  outputPath?: string;
-  bytes?: number;
-  converter?: string;
-  error?: string;
-  gateReason?: BridgeGateReason;
-  skillHint?: string;
-}
+const bridgeGateProperties = {
+  error: Type.Optional(Type.String()),
+  gateReason: Type.Optional(bridgeGateReasonSchema),
+  skillHint: Type.Optional(Type.String()),
+};
 
-export interface PythonTransformRangeDetails {
-  kind: "python_transform_range";
-  blocked: boolean;
-  inputAddress?: string;
-  outputAddress?: string;
-  bridgeUrl?: string;
-  existingCount?: number;
-  rowsWritten?: number;
-  colsWritten?: number;
-  formulaErrorCount?: number;
-  changes?: WorkbookCellChangeSummary;
-  recovery?: RecoveryCheckpointDetails;
-  error?: string;
-  gateReason?: BridgeGateReason;
-  skillHint?: string;
-}
+export const tmuxBridgeDetailsSchema = Type.Object({
+  kind: Type.Literal("tmux_bridge"),
+  ok: Type.Boolean(),
+  action: Type.String(),
+  bridgeUrl: Type.Optional(Type.String()),
+  session: Type.Optional(Type.String()),
+  sessionsCount: Type.Optional(Type.Number()),
+  outputPreview: Type.Optional(Type.String()),
+  ...bridgeGateProperties,
+});
 
-export interface WorkbookHistorySnapshotSummary {
-  id: string;
-  at: number;
-  toolName: string;
-  address: string;
-  changedCount: number;
-  cellCount: number;
-  workbookId?: string;
-  workbookLabel?: string;
-}
+export type TmuxBridgeDetails = Static<typeof tmuxBridgeDetailsSchema>;
 
-export interface WorkbookHistoryDetails {
-  kind: "workbook_history";
-  action: "list" | "restore" | "delete" | "clear";
-  count?: number;
-  snapshots?: WorkbookHistorySnapshotSummary[];
-  snapshotId?: string;
-  restoredSnapshotId?: string;
-  inverseSnapshotId?: string;
-  address?: string;
-  changedCount?: number;
-  deletedCount?: number;
-  error?: string;
-}
+export const pythonBridgeDetailsSchema = Type.Object({
+  kind: Type.Literal("python_bridge"),
+  ok: Type.Boolean(),
+  action: Type.String(),
+  bridgeUrl: Type.Optional(Type.String()),
+  exitCode: Type.Optional(Type.Number()),
+  stdoutPreview: Type.Optional(Type.String()),
+  stderrPreview: Type.Optional(Type.String()),
+  resultPreview: Type.Optional(Type.String()),
+  truncated: Type.Optional(Type.Boolean()),
+  ...bridgeGateProperties,
+});
 
-export type SkillsSourceKind = "bundled" | "external";
+export type PythonBridgeDetails = Static<typeof pythonBridgeDetailsSchema>;
 
-export interface SkillsListEntryDetails {
-  name: string;
-  sourceKind: SkillsSourceKind;
-  location: string;
-}
+export const libreOfficeBridgeDetailsSchema = Type.Object({
+  kind: Type.Literal("libreoffice_bridge"),
+  ok: Type.Boolean(),
+  action: Type.String(),
+  bridgeUrl: Type.Optional(Type.String()),
+  inputPath: Type.Optional(Type.String()),
+  targetFormat: Type.Optional(Type.String()),
+  outputPath: Type.Optional(Type.String()),
+  bytes: Type.Optional(Type.Number()),
+  converter: Type.Optional(Type.String()),
+  ...bridgeGateProperties,
+});
 
-export interface SkillsListDetails {
-  kind: "skills_list";
-  count: number;
-  names: string[];
-  entries: SkillsListEntryDetails[];
-  externalDiscoveryEnabled: boolean;
-}
+export type LibreOfficeBridgeDetails = Static<typeof libreOfficeBridgeDetailsSchema>;
 
-export interface SkillsReadDetails {
-  kind: "skills_read";
-  skillName: string;
-  sourceKind: SkillsSourceKind;
-  location: string;
-  cacheHit: boolean;
-  refreshed: boolean;
-  sessionScoped: boolean;
-  readCount?: number;
-}
+export const pythonTransformRangeDetailsSchema = Type.Object({
+  kind: Type.Literal("python_transform_range"),
+  blocked: Type.Boolean(),
+  inputAddress: Type.Optional(Type.String()),
+  outputAddress: Type.Optional(Type.String()),
+  bridgeUrl: Type.Optional(Type.String()),
+  existingCount: Type.Optional(Type.Number()),
+  rowsWritten: Type.Optional(Type.Number()),
+  colsWritten: Type.Optional(Type.Number()),
+  formulaErrorCount: Type.Optional(Type.Number()),
+  changes: Type.Optional(workbookCellChangeSummarySchema),
+  recovery: Type.Optional(recoveryCheckpointDetailsSchema),
+  ...bridgeGateProperties,
+});
 
-export interface SkillsInstallDetails {
-  kind: "skills_install";
-  skillName: string;
-  location: string;
-}
+export type PythonTransformRangeDetails = Static<typeof pythonTransformRangeDetailsSchema>;
 
-export interface SkillsUninstallDetails {
-  kind: "skills_uninstall";
-  skillName: string;
-  removed: boolean;
-}
+export const workbookHistorySnapshotSummarySchema = Type.Object({
+  id: Type.String(),
+  at: Type.Number(),
+  toolName: Type.String(),
+  address: Type.String(),
+  changedCount: Type.Number(),
+  cellCount: Type.Number(),
+  workbookId: Type.Optional(Type.String()),
+  workbookLabel: Type.Optional(Type.String()),
+});
 
-export interface SkillsErrorDetails {
-  kind: "skills_error";
-  action: "read" | "install" | "uninstall";
-  message: string;
-  requestedName?: string;
-  availableNames?: string[];
-  externalDiscoveryEnabled: boolean;
-}
+export type WorkbookHistorySnapshotSummary = Static<typeof workbookHistorySnapshotSummarySchema>;
+
+export const workbookHistoryDetailsSchema = Type.Object({
+  kind: Type.Literal("workbook_history"),
+  action: StringEnum(["list", "restore", "delete", "clear"]),
+  count: Type.Optional(Type.Number()),
+  snapshots: Type.Optional(Type.Array(workbookHistorySnapshotSummarySchema)),
+  snapshotId: Type.Optional(Type.String()),
+  restoredSnapshotId: Type.Optional(Type.String()),
+  inverseSnapshotId: Type.Optional(Type.String()),
+  address: Type.Optional(Type.String()),
+  changedCount: Type.Optional(Type.Number()),
+  deletedCount: Type.Optional(Type.Number()),
+  error: Type.Optional(Type.String()),
+});
+
+export type WorkbookHistoryDetails = Static<typeof workbookHistoryDetailsSchema>;
+
+const skillsSourceKindSchema = StringEnum(["bundled", "external"]);
+
+export type SkillsSourceKind = Static<typeof skillsSourceKindSchema>;
+
+export const skillsListEntryDetailsSchema = Type.Object({
+  name: Type.String(),
+  sourceKind: skillsSourceKindSchema,
+  location: Type.String(),
+});
+
+export type SkillsListEntryDetails = Static<typeof skillsListEntryDetailsSchema>;
+
+export const skillsListDetailsSchema = Type.Object({
+  kind: Type.Literal("skills_list"),
+  count: Type.Number(),
+  names: Type.Array(Type.String()),
+  entries: Type.Array(skillsListEntryDetailsSchema),
+  externalDiscoveryEnabled: Type.Boolean(),
+});
+
+export type SkillsListDetails = Static<typeof skillsListDetailsSchema>;
+
+export const skillsReadDetailsSchema = Type.Object({
+  kind: Type.Literal("skills_read"),
+  skillName: Type.String(),
+  sourceKind: skillsSourceKindSchema,
+  location: Type.String(),
+  cacheHit: Type.Boolean(),
+  refreshed: Type.Boolean(),
+  sessionScoped: Type.Boolean(),
+  readCount: Type.Optional(Type.Number()),
+});
+
+export type SkillsReadDetails = Static<typeof skillsReadDetailsSchema>;
+
+export const skillsInstallDetailsSchema = Type.Object({
+  kind: Type.Literal("skills_install"),
+  skillName: Type.String(),
+  location: Type.String(),
+});
+
+export type SkillsInstallDetails = Static<typeof skillsInstallDetailsSchema>;
+
+export const skillsUninstallDetailsSchema = Type.Object({
+  kind: Type.Literal("skills_uninstall"),
+  skillName: Type.String(),
+  removed: Type.Boolean(),
+});
+
+export type SkillsUninstallDetails = Static<typeof skillsUninstallDetailsSchema>;
+
+export const skillsErrorDetailsSchema = Type.Object({
+  kind: Type.Literal("skills_error"),
+  action: StringEnum(["read", "install", "uninstall"]),
+  message: Type.String(),
+  requestedName: Type.Optional(Type.String()),
+  availableNames: Type.Optional(Type.Array(Type.String())),
+  externalDiscoveryEnabled: Type.Boolean(),
+});
+
+export type SkillsErrorDetails = Static<typeof skillsErrorDetailsSchema>;
 
 export type SkillsToolDetails =
   | SkillsListDetails
@@ -322,116 +413,142 @@ export type SkillsToolDetails =
   | SkillsUninstallDetails
   | SkillsErrorDetails;
 
-export interface WebSearchFallbackDetails {
-  fromProvider: string;
-  toProvider: string;
-  reason: string;
-}
+export const webSearchFallbackDetailsSchema = Type.Object({
+  fromProvider: Type.String(),
+  toProvider: Type.String(),
+  reason: Type.String(),
+});
 
-export interface WebSearchDetails {
-  kind: "web_search";
-  ok: boolean;
-  provider: string;
-  query: string;
-  sentQuery: string;
-  recency?: string;
-  siteFilters?: string[];
-  maxResults: number;
-  resultCount?: number;
-  proxied?: boolean;
-  proxyBaseUrl?: string;
-  fallback?: WebSearchFallbackDetails;
-  error?: string;
+export type WebSearchFallbackDetails = Static<typeof webSearchFallbackDetailsSchema>;
+
+export const webSearchDetailsSchema = Type.Object({
+  kind: Type.Literal("web_search"),
+  ok: Type.Boolean(),
+  provider: Type.String(),
+  query: Type.String(),
+  sentQuery: Type.String(),
+  recency: Type.Optional(Type.String()),
+  siteFilters: Type.Optional(Type.Array(Type.String())),
+  maxResults: Type.Number(),
+  resultCount: Type.Optional(Type.Number()),
+  proxied: Type.Optional(Type.Boolean()),
+  proxyBaseUrl: Type.Optional(Type.String()),
+  fallback: Type.Optional(webSearchFallbackDetailsSchema),
+  error: Type.Optional(Type.String()),
   /** `true` when the failure is due to the local CORS proxy being unreachable. */
-  proxyDown?: boolean;
-}
+  proxyDown: Type.Optional(Type.Boolean()),
+});
 
-export interface FetchPageDetails {
-  kind: "fetch_page";
-  ok: boolean;
-  url: string;
-  title?: string;
-  chars?: number;
-  truncated?: boolean;
-  proxied?: boolean;
-  proxyBaseUrl?: string;
-  contentType?: string;
-  error?: string;
+export type WebSearchDetails = Static<typeof webSearchDetailsSchema>;
+
+export const fetchPageDetailsSchema = Type.Object({
+  kind: Type.Literal("fetch_page"),
+  ok: Type.Boolean(),
+  url: Type.String(),
+  title: Type.Optional(Type.String()),
+  chars: Type.Optional(Type.Number()),
+  truncated: Type.Optional(Type.Boolean()),
+  proxied: Type.Optional(Type.Boolean()),
+  proxyBaseUrl: Type.Optional(Type.String()),
+  contentType: Type.Optional(Type.String()),
+  error: Type.Optional(Type.String()),
   /** `true` when the failure is due to the local CORS proxy being unreachable. */
-  proxyDown?: boolean;
-}
+  proxyDown: Type.Optional(Type.Boolean()),
+});
 
-export interface McpGatewayDetails {
-  kind: "mcp_gateway";
-  ok: boolean;
-  operation: string;
-  server?: string;
-  tool?: string;
-  proxied?: boolean;
-  proxyBaseUrl?: string;
-  resultPreview?: string;
-  error?: string;
+export type FetchPageDetails = Static<typeof fetchPageDetailsSchema>;
+
+export const mcpGatewayDetailsSchema = Type.Object({
+  kind: Type.Literal("mcp_gateway"),
+  ok: Type.Boolean(),
+  operation: Type.String(),
+  server: Type.Optional(Type.String()),
+  tool: Type.Optional(Type.String()),
+  proxied: Type.Optional(Type.Boolean()),
+  proxyBaseUrl: Type.Optional(Type.String()),
+  resultPreview: Type.Optional(Type.String()),
+  error: Type.Optional(Type.String()),
   /** `true` when the failure is due to the local CORS proxy being unreachable. */
-  proxyDown?: boolean;
-}
+  proxyDown: Type.Optional(Type.Boolean()),
+});
 
-export type FilesWorkspaceBackendKind = "native-directory" | "opfs" | "memory";
+export type McpGatewayDetails = Static<typeof mcpGatewayDetailsSchema>;
 
-export interface FilesWorkbookTagDetails {
-  workbookId: string;
-  workbookLabel: string;
-  taggedAt: number;
-}
+const filesWorkspaceBackendKindSchema = StringEnum(["native-directory", "opfs", "memory"]);
 
-export type FilesSourceKind = "workspace" | "builtin-doc";
+export type FilesWorkspaceBackendKind = Static<typeof filesWorkspaceBackendKindSchema>;
 
-export interface FilesListItemDetails {
-  path: string;
-  size: number;
-  mimeType: string;
-  fileKind: "text" | "binary";
-  modifiedAt: number;
-  sourceKind?: FilesSourceKind;
-  readOnly?: boolean;
-  workbookTag?: FilesWorkbookTagDetails;
-}
+export const filesWorkbookTagDetailsSchema = Type.Object({
+  workbookId: Type.String(),
+  workbookLabel: Type.String(),
+  taggedAt: Type.Number(),
+});
 
-export interface FilesListDetails {
-  kind: "files_list";
-  backend: FilesWorkspaceBackendKind;
-  count: number;
-  files: FilesListItemDetails[];
-}
+export type FilesWorkbookTagDetails = Static<typeof filesWorkbookTagDetailsSchema>;
 
-export interface FilesReadDetails {
-  kind: "files_read";
-  backend: FilesWorkspaceBackendKind;
-  path: string;
-  mode: "text" | "base64";
-  size: number;
-  mimeType: string;
-  fileKind: "text" | "binary";
-  sourceKind?: FilesSourceKind;
-  readOnly?: boolean;
-  truncated: boolean;
-  workbookTag?: FilesWorkbookTagDetails;
-}
+const filesSourceKindSchema = StringEnum(["workspace", "builtin-doc"]);
 
-export interface FilesWriteDetails {
-  kind: "files_write";
-  backend: FilesWorkspaceBackendKind;
-  path: string;
-  encoding: "text" | "base64";
-  chars: number;
-  workbookTag?: FilesWorkbookTagDetails;
-}
+export type FilesSourceKind = Static<typeof filesSourceKindSchema>;
 
-export interface FilesDeleteDetails {
-  kind: "files_delete";
-  backend: FilesWorkspaceBackendKind;
-  path: string;
-  workbookTag?: FilesWorkbookTagDetails;
-}
+const filesFileKindSchema = StringEnum(["text", "binary"]);
+
+export const filesListItemDetailsSchema = Type.Object({
+  path: Type.String(),
+  size: Type.Number(),
+  mimeType: Type.String(),
+  fileKind: filesFileKindSchema,
+  modifiedAt: Type.Number(),
+  sourceKind: Type.Optional(filesSourceKindSchema),
+  readOnly: Type.Optional(Type.Boolean()),
+  workbookTag: Type.Optional(filesWorkbookTagDetailsSchema),
+});
+
+export type FilesListItemDetails = Static<typeof filesListItemDetailsSchema>;
+
+export const filesListDetailsSchema = Type.Object({
+  kind: Type.Literal("files_list"),
+  backend: filesWorkspaceBackendKindSchema,
+  count: Type.Number(),
+  files: Type.Array(filesListItemDetailsSchema),
+});
+
+export type FilesListDetails = Static<typeof filesListDetailsSchema>;
+
+export const filesReadDetailsSchema = Type.Object({
+  kind: Type.Literal("files_read"),
+  backend: filesWorkspaceBackendKindSchema,
+  path: Type.String(),
+  mode: StringEnum(["text", "base64"]),
+  size: Type.Number(),
+  mimeType: Type.String(),
+  fileKind: filesFileKindSchema,
+  sourceKind: Type.Optional(filesSourceKindSchema),
+  readOnly: Type.Optional(Type.Boolean()),
+  truncated: Type.Boolean(),
+  workbookTag: Type.Optional(filesWorkbookTagDetailsSchema),
+});
+
+export type FilesReadDetails = Static<typeof filesReadDetailsSchema>;
+
+export const filesWriteDetailsSchema = Type.Object({
+  kind: Type.Literal("files_write"),
+  backend: filesWorkspaceBackendKindSchema,
+  path: Type.String(),
+  encoding: StringEnum(["text", "base64"]),
+  chars: Type.Number(),
+  workbookTag: Type.Optional(filesWorkbookTagDetailsSchema),
+});
+
+export type FilesWriteDetails = Static<typeof filesWriteDetailsSchema>;
+
+export const filesDeleteDetailsSchema = Type.Object({
+  kind: Type.Literal("files_delete"),
+  backend: filesWorkspaceBackendKindSchema,
+  path: Type.String(),
+  workbookTag: Type.Optional(filesWorkbookTagDetailsSchema),
+});
+
+export type FilesDeleteDetails = Static<typeof filesDeleteDetailsSchema>;
 
 export type FilesToolDetails =
   | FilesListDetails
@@ -439,29 +556,80 @@ export type FilesToolDetails =
   | FilesWriteDetails
   | FilesDeleteDetails;
 
-export type ExcelToolDetails =
-  | WriteCellsDetails
-  | FillFormulaDetails
-  | FormatCellsDetails
-  | ConditionalFormatDetails
-  | ModifyStructureDetails
-  | CommentsDetails
-  | ViewSettingsDetails
-  | ChartsDetails
-  | TraceDependenciesDetails
-  | ExplainFormulaDetails
-  | ReadRangeCsvDetails
-  | TmuxBridgeDetails
-  | PythonBridgeDetails
-  | LibreOfficeBridgeDetails
-  | PythonTransformRangeDetails
-  | WorkbookHistoryDetails
-  | SkillsToolDetails
-  | WebSearchDetails
-  | FetchPageDetails
-  | McpGatewayDetails
-  | FilesToolDetails
-  | ConnectionToolErrorDetails;
+/** Every details payload, keyed by its `kind` discriminator. */
+const toolDetailsSchemasByKind = {
+  write_cells: writeCellsDetailsSchema,
+  fill_formula: fillFormulaDetailsSchema,
+  format_cells: formatCellsDetailsSchema,
+  conditional_format: conditionalFormatDetailsSchema,
+  modify_structure: modifyStructureDetailsSchema,
+  comments: commentsDetailsSchema,
+  view_settings: viewSettingsDetailsSchema,
+  charts: chartsDetailsSchema,
+  trace_dependencies: traceDependenciesDetailsSchema,
+  explain_formula: explainFormulaDetailsSchema,
+  read_range_csv: readRangeCsvDetailsSchema,
+  tmux_bridge: tmuxBridgeDetailsSchema,
+  python_bridge: pythonBridgeDetailsSchema,
+  libreoffice_bridge: libreOfficeBridgeDetailsSchema,
+  python_transform_range: pythonTransformRangeDetailsSchema,
+  workbook_history: workbookHistoryDetailsSchema,
+  skills_list: skillsListDetailsSchema,
+  skills_read: skillsReadDetailsSchema,
+  skills_install: skillsInstallDetailsSchema,
+  skills_uninstall: skillsUninstallDetailsSchema,
+  skills_error: skillsErrorDetailsSchema,
+  web_search: webSearchDetailsSchema,
+  fetch_page: fetchPageDetailsSchema,
+  mcp_gateway: mcpGatewayDetailsSchema,
+  files_list: filesListDetailsSchema,
+  files_read: filesReadDetailsSchema,
+  files_write: filesWriteDetailsSchema,
+  files_delete: filesDeleteDetailsSchema,
+  connection_error: connectionToolErrorDetailsSchema,
+} satisfies Record<string, TSchema>;
+
+type ToolDetailsSchemasByKind = typeof toolDetailsSchemasByKind;
+
+export type ToolDetailsKind = keyof ToolDetailsSchemasByKind;
+
+export type ToolDetailsOfKind<K extends ToolDetailsKind> = Static<ToolDetailsSchemasByKind[K]>;
+
+export type ExcelToolDetails = { [K in ToolDetailsKind]: ToolDetailsOfKind<K> }[ToolDetailsKind];
+
+const TOOL_DETAILS_KINDS = new Set<string>(Object.keys(toolDetailsSchemasByKind));
+
+function isToolDetailsKind(kind: string): kind is ToolDetailsKind {
+  return TOOL_DETAILS_KINDS.has(kind);
+}
+
+const kindedDetailsSchema = Type.Object({ kind: Type.String() });
+
+/**
+ * Decode a tool result's `details` at the UI boundary.
+ *
+ * Returns `undefined` for details with no `kind`, an unknown `kind`, or a
+ * payload that does not match its kind's schema (for example a session
+ * persisted by an older build); callers then fall back to generic rendering.
+ * Extra properties such as `outputTruncation` are allowed and preserved.
+ */
+export function decodeToolDetails(raw: unknown): ExcelToolDetails | undefined {
+  if (!Value.Check(kindedDetailsSchema, raw) || !isToolDetailsKind(raw.kind)) return undefined;
+  return decodeToolDetailsOfKind(raw, raw.kind);
+}
+
+/** Decode `details` when the caller already knows which kind it expects. */
+export function decodeToolDetailsOfKind<K extends ToolDetailsKind>(
+  raw: unknown,
+  kind: K,
+): ToolDetailsOfKind<K> | undefined {
+  const schema: ToolDetailsSchemasByKind[K] = toolDetailsSchemasByKind[kind];
+  return Value.Check(schema, raw) ? raw : undefined;
+}
+
+export function getToolOutputTruncationDetails(raw: unknown): ToolOutputTruncationDetails | undefined {
+  return Value.Check(truncatedToolDetailsSchema, raw) ? raw.outputTruncation : undefined;
+}
 
 export type BridgeGateErrorDetails =
   | (TmuxBridgeDetails & { ok: false; gateReason: BridgeGateReason; skillHint: string })
@@ -474,603 +642,21 @@ export type BridgeGateErrorDetails =
     error: string;
   });
 
-function isOptionalString(value: unknown): value is string | undefined {
-  return value === undefined || typeof value === "string";
-}
-
-function isWebSearchFallbackDetails(value: unknown): value is WebSearchFallbackDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.fromProvider === "string" &&
-    typeof value.toProvider === "string" &&
-    typeof value.reason === "string"
-  );
-}
-
-function isOptionalWebSearchFallbackDetails(value: unknown): value is WebSearchFallbackDetails | undefined {
-  return value === undefined || isWebSearchFallbackDetails(value);
-}
-
-function isOptionalNumber(value: unknown): value is number | undefined {
-  return value === undefined || typeof value === "number";
-}
-
-function isOptionalBoolean(value: unknown): value is boolean | undefined {
-  return value === undefined || typeof value === "boolean";
-}
-
-function isBridgeGateReason(value: unknown): value is BridgeGateReason {
-  return value === "missing_bridge_url"
-    || value === "invalid_bridge_url"
-    || value === "bridge_unreachable";
-}
-
-function isOptionalBridgeGateReason(value: unknown): value is BridgeGateReason | undefined {
-  return value === undefined || isBridgeGateReason(value);
-}
-
-function isToolOutputTruncationStrategy(value: unknown): value is ToolOutputTruncationStrategy {
-  return value === "head" || value === "tail";
-}
-
-function isToolOutputTruncationReason(value: unknown): value is ToolOutputTruncationReason {
-  return value === "lines" || value === "bytes" || value === null;
-}
-
-export function isToolOutputTruncationDetails(value: unknown): value is ToolOutputTruncationDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    value.version === 1 &&
-    isToolOutputTruncationStrategy(value.strategy) &&
-    typeof value.truncated === "boolean" &&
-    isToolOutputTruncationReason(value.truncatedBy) &&
-    typeof value.totalLines === "number" &&
-    typeof value.totalBytes === "number" &&
-    typeof value.outputLines === "number" &&
-    typeof value.outputBytes === "number" &&
-    typeof value.maxLines === "number" &&
-    typeof value.maxBytes === "number" &&
-    isOptionalString(value.fullOutputWorkspacePath)
-  );
-}
-
-export function getToolOutputTruncationDetails(details: unknown): ToolOutputTruncationDetails | undefined {
-  if (!isToolsToolDetailsPayloadShape(details)) return undefined;
-  const value = details.outputTruncation;
-  return isToolOutputTruncationDetails(value)
-    ? value
-    : undefined;
-}
-
-function isOptionalTraceDependenciesMode(value: unknown): value is TraceDependenciesMode | undefined {
-  return value === undefined || value === "precedents" || value === "dependents";
-}
-
-function isOptionalTraceDependencySource(value: unknown): value is TraceDependencySource | undefined {
-  return value === undefined || value === "api" || value === "formula_scan" || value === "mixed" || value === "none";
-}
-
-function isOptionalStringArray(value: unknown): value is string[] | undefined {
-  return value === undefined || (Array.isArray(value) && value.every((item) => typeof item === "string"));
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function isSkillsSourceKind(value: unknown): value is SkillsSourceKind {
-  return value === "bundled" || value === "external";
-}
-
-function isSkillsListEntryDetails(value: unknown): value is SkillsListEntryDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.name === "string" &&
-    isSkillsSourceKind(value.sourceKind) &&
-    typeof value.location === "string"
-  );
-}
-
-function isRecoveryCheckpointDetails(value: unknown): value is RecoveryCheckpointDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  const status = value.status;
-  if (status !== "checkpoint_created" && status !== "not_available") return false;
-
-  return (
-    isOptionalString(value.snapshotId) &&
-    isOptionalString(value.reason)
-  );
-}
-
-function isOptionalRecoveryCheckpointDetails(value: unknown): value is RecoveryCheckpointDetails | undefined {
-  return value === undefined || isRecoveryCheckpointDetails(value);
-}
-
-function isWorkbookCellChange(value: unknown): value is WorkbookCellChangeSummary["sample"][number] {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  const beforeFormula = value.beforeFormula;
-  const afterFormula = value.afterFormula;
-
-  return (
-    typeof value.address === "string" &&
-    typeof value.beforeValue === "string" &&
-    typeof value.afterValue === "string" &&
-    (beforeFormula === undefined || typeof beforeFormula === "string") &&
-    (afterFormula === undefined || typeof afterFormula === "string")
-  );
-}
-
-function isWorkbookCellChangeSummary(value: unknown): value is WorkbookCellChangeSummary {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.changedCount === "number" &&
-    typeof value.truncated === "boolean" &&
-    Array.isArray(value.sample) &&
-    value.sample.every((item) => isWorkbookCellChange(item))
-  );
-}
-
-function isOptionalWorkbookCellChangeSummary(value: unknown): value is WorkbookCellChangeSummary | undefined {
-  return value === undefined || isWorkbookCellChangeSummary(value);
-}
-
-function isWorkbookHistorySnapshotSummary(value: unknown): value is WorkbookHistorySnapshotSummary {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.id === "string" &&
-    typeof value.at === "number" &&
-    typeof value.toolName === "string" &&
-    typeof value.address === "string" &&
-    typeof value.changedCount === "number" &&
-    typeof value.cellCount === "number"
-  );
-}
-
-function isOptionalWorkbookHistorySnapshotSummaryArray(
-  value: unknown,
-): value is WorkbookHistorySnapshotSummary[] | undefined {
-  return value === undefined || (Array.isArray(value) && value.every((item) => isWorkbookHistorySnapshotSummary(item)));
-}
-
-export function isWriteCellsDetails(value: unknown): value is WriteCellsDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  if (value.kind !== "write_cells") return false;
-  if (typeof value.blocked !== "boolean") return false;
-
-  return (
-    isOptionalString(value.address) &&
-    isOptionalNumber(value.existingCount) &&
-    isOptionalNumber(value.formulaErrorCount) &&
-    isOptionalWorkbookCellChangeSummary(value.changes) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-export function isFillFormulaDetails(value: unknown): value is FillFormulaDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  if (value.kind !== "fill_formula") return false;
-  if (typeof value.blocked !== "boolean") return false;
-
-  return (
-    isOptionalString(value.address) &&
-    isOptionalNumber(value.existingCount) &&
-    isOptionalNumber(value.formulaErrorCount) &&
-    isOptionalWorkbookCellChangeSummary(value.changes) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-export function isFormatCellsDetails(value: unknown): value is FormatCellsDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  if (value.kind !== "format_cells") return false;
-
-  return (
-    isOptionalString(value.address) &&
-    isOptionalNumber(value.warningsCount) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-export function isConditionalFormatDetails(value: unknown): value is ConditionalFormatDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "conditional_format") return false;
-
-  const action = value.action;
-  const validAction = action === undefined || action === "add" || action === "clear";
-  if (!validAction) return false;
-
-  return (
-    isOptionalString(value.address) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-export function isModifyStructureDetails(value: unknown): value is ModifyStructureDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "modify_structure") return false;
-
-  return (
-    isOptionalString(value.action) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-export function isCommentsDetails(value: unknown): value is CommentsDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "comments") return false;
-
-  return (
-    isOptionalString(value.action) &&
-    isOptionalString(value.address) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-export function isViewSettingsDetails(value: unknown): value is ViewSettingsDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "view_settings") return false;
-
-  return (
-    isOptionalString(value.action) &&
-    isOptionalString(value.address) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-function isChartPositionDetails(value: unknown): value is ChartPositionDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.top === "number" &&
-    typeof value.left === "number" &&
-    typeof value.width === "number" &&
-    typeof value.height === "number"
-  );
-}
-
-function isChartListItemDetails(value: unknown): value is ChartListItemDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.name === "string" &&
-    typeof value.chartType === "string" &&
-    typeof value.title === "string" &&
-    typeof value.worksheet === "string" &&
-    isChartPositionDetails(value.position)
-  );
-}
-
-function isOptionalChartListItemArray(value: unknown): value is ChartListItemDetails[] | undefined {
-  return value === undefined || (Array.isArray(value) && value.every((item) => isChartListItemDetails(item)));
-}
-
-function isChartImageDetails(value: unknown): value is ChartImageDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.base64 === "string" &&
-    value.mimeType === "image/png" &&
-    typeof value.width === "number" &&
-    typeof value.height === "number"
-  );
-}
-
-function isOptionalChartImageDetails(value: unknown): value is ChartImageDetails | undefined {
-  return value === undefined || isChartImageDetails(value);
-}
-
-export function isChartsDetails(value: unknown): value is ChartsDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "charts") return false;
-
-  return (
-    isOptionalString(value.action) &&
-    isOptionalString(value.name) &&
-    isOptionalString(value.address) &&
-    isOptionalString(value.sourceRange) &&
-    isOptionalNumber(value.count) &&
-    isOptionalChartListItemArray(value.charts) &&
-    isOptionalChartImageDetails(value.image) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery)
-  );
-}
-
-export function isReadRangeCsvDetails(value: unknown): value is ReadRangeCsvDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "read_range_csv") return false;
-  return (
-    typeof value.startCol === "number" &&
-    typeof value.startRow === "number" &&
-    Array.isArray(value.values) &&
-    typeof value.csv === "string"
-  );
-}
-
-export function isTraceDependenciesDetails(value: unknown): value is TraceDependenciesDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "trace_dependencies") return false;
-  if (!isToolsToolDetailsPayloadShape(value.root)) return false;
-
-  const root = value.root;
-  if (!(typeof root.address === "string" && Array.isArray(root.precedents))) return false;
-
-  return (
-    isOptionalTraceDependenciesMode(value.mode) &&
-    isOptionalNumber(value.maxDepth) &&
-    isOptionalNumber(value.nodeCount) &&
-    isOptionalNumber(value.edgeCount) &&
-    isOptionalTraceDependencySource(value.source) &&
-    isOptionalBoolean(value.truncated)
-  );
-}
-
-function isExplainFormulaReferenceDetail(value: unknown): value is ExplainFormulaReferenceDetail {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-
-  return (
-    typeof value.address === "string" &&
-    isOptionalString(value.valuePreview) &&
-    isOptionalString(value.formulaPreview)
-  );
-}
-
-export function isExplainFormulaDetails(value: unknown): value is ExplainFormulaDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "explain_formula") return false;
-
-  return (
-    typeof value.cell === "string" &&
-    typeof value.hasFormula === "boolean" &&
-    isOptionalString(value.formula) &&
-    isOptionalString(value.valuePreview) &&
-    typeof value.explanation === "string" &&
-    Array.isArray(value.references) &&
-    value.references.every((reference) => isExplainFormulaReferenceDetail(reference)) &&
-    isOptionalBoolean(value.truncated)
-  );
-}
-
-export function isTmuxBridgeDetails(value: unknown): value is TmuxBridgeDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "tmux_bridge") return false;
-
-  return (
-    typeof value.ok === "boolean" &&
-    typeof value.action === "string" &&
-    isOptionalString(value.bridgeUrl) &&
-    isOptionalString(value.session) &&
-    isOptionalNumber(value.sessionsCount) &&
-    isOptionalString(value.outputPreview) &&
-    isOptionalString(value.error) &&
-    isOptionalBridgeGateReason(value.gateReason) &&
-    isOptionalString(value.skillHint)
-  );
-}
-
-export function isPythonBridgeDetails(value: unknown): value is PythonBridgeDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "python_bridge") return false;
-
-  const truncated = value.truncated;
-
-  return (
-    typeof value.ok === "boolean" &&
-    typeof value.action === "string" &&
-    isOptionalString(value.bridgeUrl) &&
-    isOptionalNumber(value.exitCode) &&
-    isOptionalString(value.stdoutPreview) &&
-    isOptionalString(value.stderrPreview) &&
-    isOptionalString(value.resultPreview) &&
-    (truncated === undefined || typeof truncated === "boolean") &&
-    isOptionalString(value.error) &&
-    isOptionalBridgeGateReason(value.gateReason) &&
-    isOptionalString(value.skillHint)
-  );
-}
-
-export function isLibreOfficeBridgeDetails(value: unknown): value is LibreOfficeBridgeDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "libreoffice_bridge") return false;
-
-  return (
-    typeof value.ok === "boolean" &&
-    typeof value.action === "string" &&
-    isOptionalString(value.bridgeUrl) &&
-    isOptionalString(value.inputPath) &&
-    isOptionalString(value.targetFormat) &&
-    isOptionalString(value.outputPath) &&
-    isOptionalNumber(value.bytes) &&
-    isOptionalString(value.converter) &&
-    isOptionalString(value.error) &&
-    isOptionalBridgeGateReason(value.gateReason) &&
-    isOptionalString(value.skillHint)
-  );
-}
-
-export function isBridgeGateError(value: unknown): value is BridgeGateErrorDetails {
-  if (isTmuxBridgeDetails(value)) {
-    return value.ok === false
-      && isBridgeGateReason(value.gateReason)
-      && typeof value.skillHint === "string";
+/** A bridge tool result that failed before reaching the bridge, with a setup hint for the user. */
+export function isBridgeGateError(details: ExcelToolDetails): details is BridgeGateErrorDetails {
+  switch (details.kind) {
+    case "tmux_bridge":
+    case "python_bridge":
+    case "libreoffice_bridge":
+      return details.ok === false
+        && details.gateReason !== undefined
+        && details.skillHint !== undefined;
+    case "python_transform_range":
+      return details.blocked === false
+        && details.error !== undefined
+        && details.gateReason !== undefined
+        && details.skillHint !== undefined;
+    default:
+      return false;
   }
-
-  if (isPythonBridgeDetails(value)) {
-    return value.ok === false
-      && isBridgeGateReason(value.gateReason)
-      && typeof value.skillHint === "string";
-  }
-
-  if (isLibreOfficeBridgeDetails(value)) {
-    return value.ok === false
-      && isBridgeGateReason(value.gateReason)
-      && typeof value.skillHint === "string";
-  }
-
-  if (isPythonTransformRangeDetails(value)) {
-    return value.blocked === false
-      && typeof value.error === "string"
-      && isBridgeGateReason(value.gateReason)
-      && typeof value.skillHint === "string";
-  }
-
-  return false;
-}
-
-export function isPythonTransformRangeDetails(value: unknown): value is PythonTransformRangeDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "python_transform_range") return false;
-
-  return (
-    typeof value.blocked === "boolean" &&
-    isOptionalString(value.inputAddress) &&
-    isOptionalString(value.outputAddress) &&
-    isOptionalString(value.bridgeUrl) &&
-    isOptionalNumber(value.existingCount) &&
-    isOptionalNumber(value.rowsWritten) &&
-    isOptionalNumber(value.colsWritten) &&
-    isOptionalNumber(value.formulaErrorCount) &&
-    isOptionalWorkbookCellChangeSummary(value.changes) &&
-    isOptionalRecoveryCheckpointDetails(value.recovery) &&
-    isOptionalString(value.error) &&
-    isOptionalBridgeGateReason(value.gateReason) &&
-    isOptionalString(value.skillHint)
-  );
-}
-
-export function isWorkbookHistoryDetails(value: unknown): value is WorkbookHistoryDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "workbook_history") return false;
-
-  const action = value.action;
-  const validAction = action === "list" || action === "restore" || action === "delete" || action === "clear";
-  if (!validAction) return false;
-
-  return (
-    isOptionalNumber(value.count) &&
-    isOptionalWorkbookHistorySnapshotSummaryArray(value.snapshots) &&
-    isOptionalString(value.snapshotId) &&
-    isOptionalString(value.restoredSnapshotId) &&
-    isOptionalString(value.inverseSnapshotId) &&
-    isOptionalString(value.address) &&
-    isOptionalNumber(value.changedCount) &&
-    isOptionalNumber(value.deletedCount) &&
-    isOptionalString(value.error)
-  );
-}
-
-export function isSkillsListDetails(value: unknown): value is SkillsListDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "skills_list") return false;
-
-  return (
-    typeof value.count === "number" &&
-    isStringArray(value.names) &&
-    Array.isArray(value.entries) &&
-    value.entries.every((entry) => isSkillsListEntryDetails(entry)) &&
-    typeof value.externalDiscoveryEnabled === "boolean"
-  );
-}
-
-export function isSkillsReadDetails(value: unknown): value is SkillsReadDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "skills_read") return false;
-
-  return (
-    typeof value.skillName === "string" &&
-    isSkillsSourceKind(value.sourceKind) &&
-    typeof value.location === "string" &&
-    typeof value.cacheHit === "boolean" &&
-    typeof value.refreshed === "boolean" &&
-    typeof value.sessionScoped === "boolean" &&
-    isOptionalNumber(value.readCount)
-  );
-}
-
-export function isSkillsInstallDetails(value: unknown): value is SkillsInstallDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "skills_install") return false;
-
-  return (
-    typeof value.skillName === "string" &&
-    typeof value.location === "string"
-  );
-}
-
-export function isSkillsUninstallDetails(value: unknown): value is SkillsUninstallDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "skills_uninstall") return false;
-
-  return (
-    typeof value.skillName === "string" &&
-    typeof value.removed === "boolean"
-  );
-}
-
-export function isSkillsErrorDetails(value: unknown): value is SkillsErrorDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "skills_error") return false;
-
-  const action = value.action;
-  if (action !== "read" && action !== "install" && action !== "uninstall") return false;
-
-  return (
-    typeof value.message === "string" &&
-    isOptionalString(value.requestedName) &&
-    isOptionalStringArray(value.availableNames) &&
-    typeof value.externalDiscoveryEnabled === "boolean"
-  );
-}
-
-export function isWebSearchDetails(value: unknown): value is WebSearchDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "web_search") return false;
-
-  return (
-    typeof value.ok === "boolean" &&
-    typeof value.provider === "string" &&
-    typeof value.query === "string" &&
-    typeof value.sentQuery === "string" &&
-    isOptionalString(value.recency) &&
-    isOptionalStringArray(value.siteFilters) &&
-    typeof value.maxResults === "number" &&
-    isOptionalNumber(value.resultCount) &&
-    isOptionalBoolean(value.proxied) &&
-    isOptionalString(value.proxyBaseUrl) &&
-    isOptionalWebSearchFallbackDetails(value.fallback) &&
-    isOptionalString(value.error) &&
-    isOptionalBoolean(value.proxyDown)
-  );
-}
-
-function isConnectionToolErrorCode(value: unknown): value is ConnectionToolErrorDetails["errorCode"] {
-  return value === "missing_connection"
-    || value === "invalid_connection"
-    || value === "connection_auth_failed";
-}
-
-export function isConnectionToolErrorDetails(value: unknown): value is ConnectionToolErrorDetails {
-  if (!isToolsToolDetailsPayloadShape(value)) return false;
-  if (value.kind !== "connection_error") return false;
-
-  const reason = value.reason;
-
-  return (
-    value.ok === false &&
-    isConnectionToolErrorCode(value.errorCode) &&
-    typeof value.connectionId === "string" &&
-    typeof value.connectionTitle === "string" &&
-    (value.status === "connected" || value.status === "missing" || value.status === "invalid" || value.status === "error") &&
-    typeof value.setupHint === "string" &&
-    (reason === undefined || typeof reason === "string")
-  );
 }

--- a/src/tools/view-settings.ts
+++ b/src/tools/view-settings.ts
@@ -5,7 +5,7 @@
  */
 
 import { Type, type Static } from "typebox";
-import { StringEnum } from "@earendil-works/pi-ai";
+import { StringEnum } from "./string-enum.js";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { excelRun, parseCell, qualifiedAddress } from "../excel/helpers.js";
 import {

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -8,7 +8,7 @@ function isToolsWebSearchPayloadShape(value: unknown): value is Record<string, u
 
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { Type, type Static, type TSchema } from "typebox";
-import { StringEnum } from "@earendil-works/pi-ai";
+import { StringEnum } from "./string-enum.js";
 
 import { integrationsCommandHint } from "../integrations/naming.js";
 import { getErrorMessage } from "../utils/errors.js";

--- a/src/ui/bridge-setup-card.ts
+++ b/src/ui/bridge-setup-card.ts
@@ -3,16 +3,13 @@ import {
   DEFAULT_TMUX_BRIDGE_URL,
 } from "../tools/experimental-tool-gates.js";
 import { probeBridgeHealth } from "../tools/bridge-service-utils.js";
-import {
-  isLibreOfficeBridgeDetails,
-  isPythonBridgeDetails,
-  isPythonTransformRangeDetails,
-  isTmuxBridgeDetails,
-  type BridgeGateReason,
-  type LibreOfficeBridgeDetails,
-  type PythonBridgeDetails,
-  type PythonTransformRangeDetails,
-  type TmuxBridgeDetails,
+import type {
+  BridgeGateReason,
+  ExcelToolDetails,
+  LibreOfficeBridgeDetails,
+  PythonBridgeDetails,
+  PythonTransformRangeDetails,
+  TmuxBridgeDetails,
 } from "../tools/tool-details.js";
 import { t } from "../language/index.js";
 import { createCopyableCommand } from "./command-copy.js";
@@ -182,40 +179,23 @@ function toTransformRangeModel(details: PythonTransformRangeDetails): BridgeSetu
   };
 }
 
-export function resolveBridgeSetupCardModel(details: unknown): BridgeSetupCardModel | null {
-  if (isTmuxBridgeDetails(details)) {
-    return toTmuxModel(details);
+export function resolveBridgeSetupCardModel(details: ExcelToolDetails): BridgeSetupCardModel | null {
+  switch (details.kind) {
+    case "tmux_bridge":
+      return toTmuxModel(details);
+    case "python_bridge":
+      return toPythonModel(details);
+    case "libreoffice_bridge":
+      return toLibreOfficeModel(details);
+    case "python_transform_range":
+      return toTransformRangeModel(details);
+    default:
+      return null;
   }
-
-  if (isPythonBridgeDetails(details)) {
-    return toPythonModel(details);
-  }
-
-  if (isLibreOfficeBridgeDetails(details)) {
-    return toLibreOfficeModel(details);
-  }
-
-  if (isPythonTransformRangeDetails(details)) {
-    return toTransformRangeModel(details);
-  }
-
-  return null;
 }
 
-export function shouldShowBridgeSetupCard(details: unknown): details is BridgeSetupCardDetails {
+export function shouldShowBridgeSetupCard(details: ExcelToolDetails): details is BridgeSetupCardDetails {
   return resolveBridgeSetupCardModel(details) !== null;
-}
-
-export async function testBridgeSetupConnection(
-  details: unknown,
-  probeBridge: (bridgeUrl: string) => Promise<boolean> = probeBridgeHealth,
-): Promise<boolean> {
-  const model = resolveBridgeSetupCardModel(details);
-  if (!model || !model.probeUrl) {
-    return false;
-  }
-
-  return probeBridge(model.probeUrl);
 }
 
 export function mountBridgeSetupCard(

--- a/src/ui/tool-renderers.ts
+++ b/src/ui/tool-renderers.ts
@@ -26,22 +26,8 @@ import {
   shouldShowBridgeSetupCard,
 } from "./bridge-setup-card.js";
 import {
-  isChartsDetails,
-  isCommentsDetails,
-  isConditionalFormatDetails,
-  isExplainFormulaDetails,
-  isFillFormulaDetails,
-  isFormatCellsDetails,
-  isModifyStructureDetails,
-  isPythonTransformRangeDetails,
-  isReadRangeCsvDetails,
-  isSkillsInstallDetails,
-  isSkillsReadDetails,
-  isSkillsUninstallDetails,
-  isTraceDependenciesDetails,
-  isViewSettingsDetails,
-  isWorkbookHistoryDetails,
-  isWriteCellsDetails,
+  decodeToolDetails,
+  type ExcelToolDetails,
   type RecoveryCheckpointDetails,
   type WriteCellsDetails,
 } from "../tools/tool-details.js";
@@ -232,27 +218,24 @@ function renderImages(images: ImageContent[]): TemplateResult {
   `;
 }
 
-function getWorkbookCellChanges(details: unknown): WriteCellsDetails["changes"] | undefined {
-  if (isWriteCellsDetails(details)) {
-    return details.changes;
-  }
+type ToolDetails = ExcelToolDetails | undefined;
 
-  if (isFillFormulaDetails(details)) {
-    return details.changes;
+function getWorkbookCellChanges(details: ToolDetails): WriteCellsDetails["changes"] | undefined {
+  switch (details?.kind) {
+    case "write_cells":
+    case "fill_formula":
+    case "python_transform_range":
+      return details.changes;
+    default:
+      return undefined;
   }
-
-  if (isPythonTransformRangeDetails(details)) {
-    return details.changes;
-  }
-
-  return undefined;
 }
 
 function formatDiffValue(value: string): string {
   return value.length > 0 ? value : "∅";
 }
 
-function renderWorkbookCellDiff(details: unknown): TemplateResult {
+function renderWorkbookCellDiff(details: ToolDetails): TemplateResult {
   const changes = getWorkbookCellChanges(details);
   if (!changes || changes.changedCount <= 0) return html``;
 
@@ -296,8 +279,8 @@ function renderWorkbookCellDiff(details: unknown): TemplateResult {
   `;
 }
 
-function renderChartImageDetails(details: unknown, hasImageContent: boolean): TemplateResult {
-  if (hasImageContent || !isChartsDetails(details) || !details.image) return html``;
+function renderChartImageDetails(details: ToolDetails, hasImageContent: boolean): TemplateResult {
+  if (hasImageContent || details?.kind !== "charts" || !details.image) return html``;
 
   const src = `data:${details.image.mimeType};base64,${details.image.base64}`;
   const alt = details.name ? `Chart ${details.name}` : "Chart image";
@@ -309,8 +292,8 @@ function renderChartImageDetails(details: unknown, hasImageContent: boolean): Te
   `;
 }
 
-function renderExplainFormulaDetails(details: unknown): TemplateResult | null {
-  if (!isExplainFormulaDetails(details)) return null;
+function renderExplainFormulaDetails(details: ToolDetails): TemplateResult | null {
+  if (details?.kind !== "explain_formula") return null;
 
   if (!details.hasFormula) {
     return html`<div class="pi-tool-card__plain-text">${details.explanation}</div>`;
@@ -387,7 +370,7 @@ function buildChangeExplanationInputForTool(
   toolName: SupportedToolName,
   params: unknown,
   resultText: string | undefined,
-  details: unknown,
+  details: ToolDetails,
 ): ChangeExplanationInput | null {
   if (getToolExecutionMode(toolName, params) !== "mutate") return null;
 
@@ -401,7 +384,7 @@ function buildChangeExplanationInputForTool(
   const error = extractResultError(resultText);
   const blockedFromText = Boolean(resultText && isBlocked(resultText));
 
-  if (isWriteCellsDetails(details)) {
+  if (details?.kind === "write_cells") {
     return createChangeExplanationInput({
       toolName,
       blocked: details.blocked,
@@ -413,7 +396,7 @@ function buildChangeExplanationInputForTool(
     });
   }
 
-  if (isFillFormulaDetails(details)) {
+  if (details?.kind === "fill_formula") {
     return createChangeExplanationInput({
       toolName,
       blocked: details.blocked,
@@ -425,7 +408,7 @@ function buildChangeExplanationInputForTool(
     });
   }
 
-  if (isPythonTransformRangeDetails(details)) {
+  if (details?.kind === "python_transform_range") {
     return createChangeExplanationInput({
       toolName,
       blocked: details.blocked || blockedFromText,
@@ -438,7 +421,7 @@ function buildChangeExplanationInputForTool(
     });
   }
 
-  if (isWorkbookHistoryDetails(details) && details.action === "restore") {
+  if (details?.kind === "workbook_history" && details.action === "restore") {
     const historyError = optionalString(details.error);
     return createChangeExplanationInput({
       toolName,
@@ -451,7 +434,7 @@ function buildChangeExplanationInputForTool(
   }
 
   if (toolName === "format_cells") {
-    const detailsAddress = isFormatCellsDetails(details) ? details.address : undefined;
+    const detailsAddress = details?.kind === "format_cells" ? details.address : undefined;
     return createChangeExplanationInput({
       toolName,
       blocked: blockedFromText,
@@ -505,8 +488,8 @@ function buildChangeExplanationInputForTool(
   }
 
   if (toolName === "charts") {
-    const detailsAddress = isChartsDetails(details) ? details.address : undefined;
-    const detailsSource = isChartsDetails(details) ? details.sourceRange : undefined;
+    const detailsAddress = details?.kind === "charts" ? details.address : undefined;
+    const detailsSource = details?.kind === "charts" ? details.sourceRange : undefined;
     return createChangeExplanationInput({
       toolName,
       blocked: blockedFromText,
@@ -541,7 +524,7 @@ function renderChangeExplanationSection(
   toolName: SupportedToolName,
   params: unknown,
   resultText: string | undefined,
-  details: unknown,
+  details: ToolDetails,
 ): TemplateResult {
   const input = buildChangeExplanationInputForTool(toolName, params, resultText, details);
   if (!input) return html``;
@@ -687,41 +670,27 @@ function withRecoveryBadge(base: string, recovery: RecoveryCheckpointDetails | u
   return base.length > 0 ? `${base}, no backup` : " — no backup";
 }
 
-function recoveryBadgeForDetails(details: unknown): string {
-  if (isFormatCellsDetails(details)) {
-    return withRecoveryBadge("", details.recovery);
+function recoveryBadgeForDetails(details: ToolDetails): string {
+  switch (details?.kind) {
+    case "format_cells":
+    case "conditional_format":
+    case "modify_structure":
+    case "comments":
+    case "view_settings":
+    case "charts":
+      return withRecoveryBadge("", details.recovery);
+    default:
+      return "";
   }
-
-  if (isConditionalFormatDetails(details)) {
-    return withRecoveryBadge("", details.recovery);
-  }
-
-  if (isModifyStructureDetails(details)) {
-    return withRecoveryBadge("", details.recovery);
-  }
-
-  if (isCommentsDetails(details)) {
-    return withRecoveryBadge("", details.recovery);
-  }
-
-  if (isViewSettingsDetails(details)) {
-    return withRecoveryBadge("", details.recovery);
-  }
-
-  if (isChartsDetails(details)) {
-    return withRecoveryBadge("", details.recovery);
-  }
-
-  return "";
 }
 
 /** Append error / blocked badge to the detail string. */
 function badge(
   toolName: SupportedToolName,
   resultText: string | undefined,
-  details: unknown,
+  details: ToolDetails,
 ): string {
-  if (toolName === "write_cells" && isWriteCellsDetails(details)) {
+  if (toolName === "write_cells" && details?.kind === "write_cells") {
     if (details.blocked) return " — blocked";
     return withRecoveryBadge(
       mutationBadge(details.changes?.changedCount, details.formulaErrorCount),
@@ -729,7 +698,7 @@ function badge(
     );
   }
 
-  if (toolName === "fill_formula" && isFillFormulaDetails(details)) {
+  if (toolName === "fill_formula" && details?.kind === "fill_formula") {
     if (details.blocked) return " — blocked";
     return withRecoveryBadge(
       mutationBadge(details.changes?.changedCount, details.formulaErrorCount),
@@ -737,7 +706,7 @@ function badge(
     );
   }
 
-  if (toolName === "python_transform_range" && isPythonTransformRangeDetails(details)) {
+  if (toolName === "python_transform_range" && details?.kind === "python_transform_range") {
     if (details.blocked) return " — blocked";
     if (typeof details.error === "string" && details.error.length > 0) return " — error";
     return withRecoveryBadge(
@@ -779,7 +748,7 @@ function describeToolCall(
   toolName: SupportedToolName,
   params: unknown,
   resultText: string | undefined,
-  details: unknown,
+  details: ToolDetails,
 ): ToolDesc {
   const p = safeParseParams(params);
   const range = p.range as string | undefined;
@@ -801,7 +770,7 @@ function describeToolCall(
     case "write_cells": {
       const b = badge(toolName, resultText, details);
 
-      if (isWriteCellsDetails(details) && details.address) {
+      if (details?.kind === "write_cells" && details.address) {
         const action = details.blocked ? "Write" : "Edit";
         return toolDescWithAddress(action, details.address + b, details.address);
       }
@@ -814,7 +783,7 @@ function describeToolCall(
     case "fill_formula": {
       const b = badge(toolName, resultText, details);
 
-      if (isFillFormulaDetails(details) && details.address) {
+      if (details?.kind === "fill_formula" && details.address) {
         const action = details.blocked ? "Fill" : "Filled";
         return toolDescWithAddress(action, details.address + b, details.address);
       }
@@ -827,7 +796,7 @@ function describeToolCall(
     case "python_transform_range": {
       const b = badge(toolName, resultText, details);
 
-      if (isPythonTransformRangeDetails(details)) {
+      if (details?.kind === "python_transform_range") {
         const address = details.outputAddress ?? details.inputAddress;
         if (address) {
           const hasError = typeof details.error === "string" && details.error.length > 0;
@@ -843,7 +812,7 @@ function describeToolCall(
 
     // ── Format tools ──
     case "format_cells": {
-      const addr = isFormatCellsDetails(details) ? details.address : undefined;
+      const addr = details?.kind === "format_cells" ? details.address : undefined;
       const resolved = addr ?? range;
       const recovery = recoveryBadgeForDetails(details);
       return toolDescWithAddress("Format", (resolved ? compactRange(resolved) : "cells") + recovery, resolved);
@@ -895,13 +864,14 @@ function describeToolCall(
     case "charts": {
       const op = p.action as string | undefined;
       const recovery = recoveryBadgeForDetails(details);
-      const detailsName = isChartsDetails(details) ? details.name : undefined;
-      const detailsSource = isChartsDetails(details) ? details.sourceRange : undefined;
+      const chartDetails = details?.kind === "charts" ? details : undefined;
+      const detailsName = chartDetails?.name;
+      const detailsSource = chartDetails?.sourceRange;
       const chartName = detailsName ?? (p.name as string | undefined) ?? (p.new_name as string | undefined);
       const source = detailsSource ?? (p.source_range as string | undefined);
 
       if (op === "list") {
-        const count = isChartsDetails(details) && typeof details.count === "number" ? ` (${details.count})` : "";
+        const count = chartDetails?.count !== undefined ? ` (${chartDetails.count})` : "";
         return { action: "Charts", detail: `${(p.sheet as string | undefined) ?? "workbook"}${count}` };
       }
 
@@ -929,8 +899,8 @@ function describeToolCall(
       }
 
       if (op === "get_image") {
-        const size = isChartsDetails(details) && details.image
-          ? ` (${details.image.width}×${details.image.height}px)`
+        const size = chartDetails?.image
+          ? ` (${chartDetails.image.width}×${chartDetails.image.height}px)`
           : "";
         return {
           action: "Chart image",
@@ -969,7 +939,7 @@ function describeToolCall(
       const targetSheet = p.sheet as string | undefined;
       const targetSheetLabel = targetSheet ?? "active sheet";
       const targetRange = p.range as string | undefined;
-      const detailsAddress = isViewSettingsDetails(details) ? details.address : undefined;
+      const detailsAddress = details?.kind === "view_settings" ? details.address : undefined;
       const qualifiedRange = detailsAddress ?? qualifyRangeAddress(targetRange, targetSheet);
       const recovery = recoveryBadgeForDetails(details);
 
@@ -1039,14 +1009,13 @@ function describeToolCall(
       const refresh = p.refresh === true;
 
       if (action === "read") {
-        const detailName = isSkillsReadDetails(details)
-          ? details.skillName
-          : name ?? "name";
-        const sourceSuffix = isSkillsReadDetails(details)
-          ? (details.sourceKind === "external" ? " (external)" : " (bundled)")
+        const readDetails = details?.kind === "skills_read" ? details : undefined;
+        const detailName = readDetails?.skillName ?? name ?? "name";
+        const sourceSuffix = readDetails
+          ? (readDetails.sourceKind === "external" ? " (external)" : " (bundled)")
           : "";
 
-        if (isSkillsReadDetails(details) && details.cacheHit) {
+        if (readDetails?.cacheHit) {
           return { action: "Read skill", detail: `${detailName}${sourceSuffix} (cached)` };
         }
 
@@ -1058,18 +1027,17 @@ function describeToolCall(
       }
 
       if (action === "install") {
-        const installedName = isSkillsInstallDetails(details)
+        const installedName = details?.kind === "skills_install"
           ? details.skillName
           : name ?? "skill";
         return { action: "Install skill", detail: installedName };
       }
 
       if (action === "uninstall") {
-        const removedName = isSkillsUninstallDetails(details)
-          ? details.skillName
-          : name ?? "skill";
-        const removedSuffix = isSkillsUninstallDetails(details)
-          ? (details.removed ? "" : " (not found)")
+        const uninstallDetails = details?.kind === "skills_uninstall" ? details : undefined;
+        const removedName = uninstallDetails?.skillName ?? name ?? "skill";
+        const removedSuffix = uninstallDetails
+          ? (uninstallDetails.removed ? "" : " (not found)")
           : "";
         return { action: "Uninstall skill", detail: `${removedName}${removedSuffix}` };
       }
@@ -1142,7 +1110,9 @@ function createExcelMarkdownRenderer(toolName: SupportedToolName): ToolRenderer<
       const defaultExpanded = false;
 
       const resultText = result ? splitToolResultContent(result).text : undefined;
-      const desc = describeToolCall(toolName, params, resultText, result?.details);
+      // `details` is unknown at this seam: older persisted sessions may carry any shape.
+      const details = decodeToolDetails(result?.details);
+      const desc = describeToolCall(toolName, params, resultText, details);
       const detailContent = desc.address
         ? (desc.detail && desc.detail !== desc.address
           ? cellRefDisplay(desc.detail, desc.address)
@@ -1158,11 +1128,11 @@ function createExcelMarkdownRenderer(toolName: SupportedToolName): ToolRenderer<
         const cleanedText = stripYamlFrontmatter(text);
         const humanizedText = compactRangesInMarkdown(humanizeColorsInText(cleanedText));
         const useMarkdown = !json.isJson && looksLikeMarkdown(cleanedText);
-        const csvTable = isReadRangeCsvDetails(result.details)
-          ? renderCsvTable(result.details)
+        const csvTable = details?.kind === "read_range_csv"
+          ? renderCsvTable(details)
           : null;
-        const traceDetails = isTraceDependenciesDetails(result.details)
-          ? result.details
+        const traceDetails = details?.kind === "trace_dependencies"
+          ? details
           : null;
         const depTree = traceDetails
           ? renderDepTree(traceDetails.root, traceDetails.mode ?? "precedents")
@@ -1172,11 +1142,10 @@ function createExcelMarkdownRenderer(toolName: SupportedToolName): ToolRenderer<
             ? "Dependents"
             : "Precedents"
           : "Dependencies";
-        const formulaExplanation = renderExplainFormulaDetails(result.details);
+        const formulaExplanation = renderExplainFormulaDetails(details);
 
         // Search setup card: show inline guided setup when web_search fails
-        const resultDetails: unknown = result.details;
-        const searchSetupDetails = shouldShowSearchSetupCard(resultDetails) ? resultDetails : null;
+        const searchSetupDetails = details !== undefined && shouldShowSearchSetupCard(details) ? details : null;
         const initSearchSetup = (el: Element | undefined): void => {
           if (el instanceof HTMLElement && searchSetupDetails) {
             mountSearchSetupCard(el, searchSetupDetails);
@@ -1184,7 +1153,7 @@ function createExcelMarkdownRenderer(toolName: SupportedToolName): ToolRenderer<
         };
 
         // Bridge setup card: show inline setup for bridge-related failures.
-        const bridgeSetupDetails = shouldShowBridgeSetupCard(resultDetails) ? resultDetails : null;
+        const bridgeSetupDetails = details !== undefined && shouldShowBridgeSetupCard(details) ? details : null;
         const initBridgeSetup = (el: Element | undefined): void => {
           if (el instanceof HTMLElement && bridgeSetupDetails) {
             mountBridgeSetupCard(el, bridgeSetupDetails);
@@ -1240,10 +1209,10 @@ function createExcelMarkdownRenderer(toolName: SupportedToolName): ToolRenderer<
                           ? html`<div class="pi-tool-card__markdown"><markdown-block .content=${humanizedText || "(no output)"}></markdown-block></div>`
                           : html`<div class="pi-tool-card__plain-text">${humanizedText || "(no output)"}</div>`}
                     ${renderImages(images)}
-                    ${renderChartImageDetails(result.details, images.length > 0)}
+                    ${renderChartImageDetails(details, images.length > 0)}
                   </div>
-                  ${renderWorkbookCellDiff(result.details)}
-                  ${renderChangeExplanationSection(toolName, params, text, result.details)}
+                  ${renderWorkbookCellDiff(details)}
+                  ${renderChangeExplanationSection(toolName, params, text, details)}
                 </div>
               </div>
             </div>

--- a/src/ui/web-search-setup-card.ts
+++ b/src/ui/web-search-setup-card.ts
@@ -22,7 +22,7 @@ import {
   WEB_SEARCH_PROVIDER_INFO,
   type WebSearchProvider,
 } from "../tools/web-search-config.js";
-import { isWebSearchDetails, type WebSearchDetails } from "../tools/tool-details.js";
+import type { ExcelToolDetails, WebSearchDetails } from "../tools/tool-details.js";
 import { validateWebSearchApiKey } from "../tools/web-search.js";
 import { createCopyableCommand } from "./command-copy.js";
 import { AlertTriangle, Search, lucide } from "./lucide-icons.js";
@@ -360,6 +360,6 @@ export function mountSearchSetupCard(container: HTMLElement, details: WebSearchD
  * Returns true when the details indicate a web search failure that should
  * show the inline setup card.
  */
-export function shouldShowSearchSetupCard(details: unknown): details is WebSearchDetails {
-  return isWebSearchDetails(details) && details.ok === false;
+export function shouldShowSearchSetupCard(details: ExcelToolDetails): details is WebSearchDetails {
+  return details.kind === "web_search" && details.ok === false;
 }

--- a/tests/browser/ui-status.browser-test.ts
+++ b/tests/browser/ui-status.browser-test.ts
@@ -103,8 +103,12 @@ void test("the setup card renders the seven bridge-result states", async () => {
         const host = document.createElement("div");
         host.id = "bridge-fixture";
         document.body.appendChild(host);
-        const card = await import("/src/ui/bridge-setup-card.ts");
-        if (card.shouldShowBridgeSetupCard(details)) card.mountBridgeSetupCard(host, details);
+        const [card, { decodeToolDetails }] = await Promise.all([
+          import("/src/ui/bridge-setup-card.ts"),
+          import("/src/tools/tool-details.ts"),
+        ]);
+        const decoded = decodeToolDetails(details);
+        if (decoded && card.shouldShowBridgeSetupCard(decoded)) card.mountBridgeSetupCard(host, decoded);
       }, row.details);
       const setup = page.locator("#bridge-fixture .pi-bridge-setup");
       if (row.title === null) {

--- a/tests/experimental-tool-gates.test.ts
+++ b/tests/experimental-tool-gates.test.ts
@@ -8,13 +8,7 @@ import {
   applyExperimentalToolGates,
   buildOfficeJsExecuteApprovalMessage,
 } from "../src/tools/experimental-tool-gates.ts";
-import {
-  isBridgeGateError,
-  isLibreOfficeBridgeDetails,
-  isPythonBridgeDetails,
-  isPythonTransformRangeDetails,
-  isTmuxBridgeDetails,
-} from "../src/tools/tool-details.ts";
+import { decodeToolDetails, decodeToolDetailsOfKind, isBridgeGateError } from "../src/tools/tool-details.ts";
 
 const emptySchema = Type.Object({});
 
@@ -38,24 +32,27 @@ function createTestTool(
 }
 
 function assertTmuxGateError(
-  details: unknown,
+  raw: unknown,
   reason: "missing_bridge_url" | "bridge_unreachable",
 ): void {
-  assert.ok(isTmuxBridgeDetails(details));
+  const details = decodeToolDetailsOfKind(raw, "tmux_bridge");
+  assert.ok(details);
   assert.equal(details.ok, false);
   assert.equal(details.gateReason, reason);
   assert.equal(details.skillHint, "tmux-bridge");
 }
 
-function assertPythonGateError(details: unknown): void {
-  assert.ok(isPythonBridgeDetails(details));
+function assertPythonGateError(raw: unknown): void {
+  const details = decodeToolDetailsOfKind(raw, "python_bridge");
+  assert.ok(details);
   assert.equal(details.ok, false);
   assert.equal(details.gateReason, "bridge_unreachable");
   assert.equal(details.skillHint, "python-bridge");
 }
 
-function assertPythonTransformRangeGateError(details: unknown): void {
-  assert.ok(isPythonTransformRangeDetails(details));
+function assertPythonTransformRangeGateError(raw: unknown): void {
+  const details = decodeToolDetailsOfKind(raw, "python_transform_range");
+  assert.ok(details);
   assert.equal(details.blocked, false);
   assert.equal(details.gateReason, "bridge_unreachable");
   assert.equal(details.skillHint, "python-bridge");
@@ -63,10 +60,11 @@ function assertPythonTransformRangeGateError(details: unknown): void {
 }
 
 function assertLibreOfficeGateError(
-  details: unknown,
+  raw: unknown,
   reason: "missing_bridge_url" | "bridge_unreachable",
 ): void {
-  assert.ok(isLibreOfficeBridgeDetails(details));
+  const details = decodeToolDetailsOfKind(raw, "libreoffice_bridge");
+  assert.ok(details);
   assert.equal(details.ok, false);
   assert.equal(details.gateReason, reason);
   assert.equal(details.skillHint, "python-bridge");
@@ -100,10 +98,8 @@ void test("keeps tmux tool registered and returns structured gate errors", async
   assert.match(text, /default URL|URL override/i);
   assert.match(text, /Skill: tmux-bridge/i);
 
-  const resultDetails: unknown = result.details;
-  assertTmuxGateError(resultDetails, "missing_bridge_url");
-  assert.ok(isTmuxBridgeDetails(resultDetails));
-  assert.equal(resultDetails.action, "capture_pane");
+  assertTmuxGateError(result.details, "missing_bridge_url");
+  assert.equal(decodeToolDetailsOfKind(result.details, "tmux_bridge")?.action, "capture_pane");
 
   assert.equal(probeCalled, true);
 });
@@ -325,8 +321,9 @@ void test("python_transform_range gate errors keep transform detail kind", async
   assert.match(text, /not reachable/i);
   assert.match(text, /Skill: python-bridge/i);
 
-  const details: unknown = result.details;
-  assertPythonTransformRangeGateError(details);
+  assertPythonTransformRangeGateError(result.details);
+  const details = decodeToolDetails(result.details);
+  assert.ok(details);
   assert.equal(isBridgeGateError(details), true);
 
   assert.equal(executeCount, 0);

--- a/tests/extensions-runtime-manager-sandbox.test.ts
+++ b/tests/extensions-runtime-manager-sandbox.test.ts
@@ -19,7 +19,7 @@ import {
 import { BrowserModelRuntime } from "../src/models/browser-model-runtime.ts";
 import type { ProviderKeysStoreLike } from "../src/storage/local/provider-credentials-store.ts";
 import { failOnUnexpectedStream } from "./fail-on-unexpected-stream.ts";
-import { isConnectionToolErrorDetails } from "../src/tools/tool-details.ts";
+import { decodeToolDetailsOfKind } from "../src/tools/tool-details.ts";
 import { withConnectionPreflight } from "../src/tools/with-connection-preflight.ts";
 import {
   SANDBOX_BOOTSTRAP_KIND,
@@ -1298,11 +1298,10 @@ void test("connection preflight blocks missing connections before tool execution
   const result = await tools[0].execute("tool-call-1", { company: "Acme" });
 
   assert.equal(executed, false);
-  assert.equal(isConnectionToolErrorDetails(result.details), true);
-  if (isConnectionToolErrorDetails(result.details)) {
-    assert.equal(result.details.errorCode, "missing_connection");
-    assert.equal(result.details.connectionId, "ext.apollo.apollo");
-  }
+  const connectionError = decodeToolDetailsOfKind(result.details, "connection_error");
+  assert.ok(connectionError);
+  assert.equal(connectionError.errorCode, "missing_connection");
+  assert.equal(connectionError.connectionId, "ext.apollo.apollo");
 });
 
 void test("connection preflight maps runtime auth failures to connection_auth_failed", async () => {
@@ -1340,12 +1339,10 @@ void test("connection preflight maps runtime auth failures to connection_auth_fa
   });
 
   const result = await tools[0].execute("tool-call-2", { company: "Acme" });
-  assert.equal(isConnectionToolErrorDetails(result.details), true);
-
-  if (isConnectionToolErrorDetails(result.details)) {
-    assert.equal(result.details.errorCode, "connection_auth_failed");
-    assert.ok(!result.details.reason?.includes("top-secret-api-key"));
-  }
+  const connectionError = decodeToolDetailsOfKind(result.details, "connection_error");
+  assert.ok(connectionError);
+  assert.equal(connectionError.errorCode, "connection_auth_failed");
+  assert.ok(!connectionError.reason?.includes("top-secret-api-key"));
 
   const text = result.content[0]?.type === "text" ? result.content[0].text : "";
   assert.ok(!text.includes("top-secret-api-key"));
@@ -1392,13 +1389,11 @@ void test("connection preflight still redacts auth failures when status persiste
   });
 
   const result = await tools[0].execute("tool-call-2b", { company: "Acme" });
-  assert.equal(isConnectionToolErrorDetails(result.details), true);
-
-  if (isConnectionToolErrorDetails(result.details)) {
-    assert.equal(result.details.errorCode, "connection_auth_failed");
-    assert.equal(result.details.status, "error");
-    assert.ok(!result.details.reason?.includes("top-secret-api-key"));
-  }
+  const connectionError = decodeToolDetailsOfKind(result.details, "connection_error");
+  assert.ok(connectionError);
+  assert.equal(connectionError.errorCode, "connection_auth_failed");
+  assert.equal(connectionError.status, "error");
+  assert.ok(!connectionError.reason?.includes("top-secret-api-key"));
 
   const text = result.content[0]?.type === "text" ? result.content[0].text : "";
   assert.ok(!text.includes("top-secret-api-key"));
@@ -1453,13 +1448,11 @@ void test("connection preflight attributes auth failures to the matching require
   });
 
   const result = await tools[0].execute("tool-call-3", { dryRun: false });
-  assert.equal(isConnectionToolErrorDetails(result.details), true);
-
-  if (isConnectionToolErrorDetails(result.details)) {
-    assert.equal(result.details.errorCode, "connection_auth_failed");
-    assert.equal(result.details.connectionId, "ext.multi.billing");
-    assert.ok(!result.details.reason?.includes("billing-key"));
-  }
+  const connectionError = decodeToolDetailsOfKind(result.details, "connection_error");
+  assert.ok(connectionError);
+  assert.equal(connectionError.errorCode, "connection_auth_failed");
+  assert.equal(connectionError.connectionId, "ext.multi.billing");
+  assert.ok(!connectionError.reason?.includes("billing-key"));
 
   const crmState = await connectionManager.getState("ext.multi.crm");
   const billingState = await connectionManager.getState("ext.multi.billing");

--- a/tests/skills-tool.test.ts
+++ b/tests/skills-tool.test.ts
@@ -4,11 +4,7 @@ import { test } from "node:test";
 import type { AgentSkillDefinition } from "../src/skills/types.ts";
 import { createSkillReadCache } from "../src/skills/read-cache.ts";
 import {
-  isSkillsErrorDetails,
-  isSkillsInstallDetails,
-  isSkillsListDetails,
-  isSkillsReadDetails,
-  isSkillsUninstallDetails,
+  decodeToolDetailsOfKind,
 } from "../src/tools/tool-details.ts";
 import { createSkillsTool } from "../src/tools/skills.ts";
 
@@ -47,13 +43,13 @@ void test("skills list renders provenance and structured list details", async ()
   assert.match(text, /Available Agent Skills \(1\)/);
   assert.match(text, /source: bundled/i);
 
-  assert.ok(isSkillsListDetails(result.details));
-  if (!isSkillsListDetails(result.details)) return;
+  const resultDetails = decodeToolDetailsOfKind(result.details, "skills_list");
+  assert.ok(resultDetails);
 
-  assert.equal(result.details.count, 1);
-  assert.equal(result.details.externalDiscoveryEnabled, false);
-  assert.deepEqual(result.details.names, ["web-search"]);
-  assert.deepEqual(result.details.entries[0], {
+  assert.equal(resultDetails.count, 1);
+  assert.equal(resultDetails.externalDiscoveryEnabled, false);
+  assert.deepEqual(resultDetails.names, ["web-search"]);
+  assert.deepEqual(resultDetails.entries[0], {
     name: "web-search",
     sourceKind: "bundled",
     location: "skills/web-search/SKILL.md",
@@ -76,16 +72,17 @@ void test("skills read uses session cache and reports cacheHit details", async (
   const first = await tool.execute("call-read-1", { action: "read", name: "web-search" });
   const second = await tool.execute("call-read-2", { action: "read", name: "web-search" });
 
-  assert.ok(isSkillsReadDetails(first.details));
-  assert.ok(isSkillsReadDetails(second.details));
-  if (!isSkillsReadDetails(first.details) || !isSkillsReadDetails(second.details)) return;
+  const firstDetails = decodeToolDetailsOfKind(first.details, "skills_read");
+  const secondDetails = decodeToolDetailsOfKind(second.details, "skills_read");
+  assert.ok(firstDetails);
+  assert.ok(secondDetails);
 
-  assert.equal(first.details.cacheHit, false);
-  assert.equal(second.details.cacheHit, true);
-  assert.equal(first.details.sourceKind, "bundled");
-  assert.equal(second.details.sourceKind, "bundled");
-  assert.equal(second.details.location, "skills/web-search/SKILL.md");
-  assert.equal(second.details.readCount, 1);
+  assert.equal(firstDetails.cacheHit, false);
+  assert.equal(secondDetails.cacheHit, true);
+  assert.equal(firstDetails.sourceKind, "bundled");
+  assert.equal(secondDetails.sourceKind, "bundled");
+  assert.equal(secondDetails.location, "skills/web-search/SKILL.md");
+  assert.equal(secondDetails.readCount, 1);
 });
 
 void test("skills read with refresh=true bypasses cache and reports refreshed details", async () => {
@@ -108,12 +105,12 @@ void test("skills read with refresh=true bypasses cache and reports refreshed de
     refresh: true,
   });
 
-  assert.ok(isSkillsReadDetails(refreshed.details));
-  if (!isSkillsReadDetails(refreshed.details)) return;
+  const refreshedDetails = decodeToolDetailsOfKind(refreshed.details, "skills_read");
+  assert.ok(refreshedDetails);
 
-  assert.equal(refreshed.details.cacheHit, false);
-  assert.equal(refreshed.details.refreshed, true);
-  assert.equal(refreshed.details.readCount, 2);
+  assert.equal(refreshedDetails.cacheHit, false);
+  assert.equal(refreshedDetails.refreshed, true);
+  assert.equal(refreshedDetails.readCount, 2);
 });
 
 void test("skills read cache is session-scoped", async () => {
@@ -133,11 +130,11 @@ void test("skills read cache is session-scoped", async () => {
   currentSession = "session-b";
   const second = await tool.execute("call-read-b", { action: "read", name: "web-search" });
 
-  assert.ok(isSkillsReadDetails(second.details));
-  if (!isSkillsReadDetails(second.details)) return;
+  const secondDetails = decodeToolDetailsOfKind(second.details, "skills_read");
+  assert.ok(secondDetails);
 
-  assert.equal(second.details.cacheHit, false);
-  assert.equal(second.details.readCount, 1);
+  assert.equal(secondDetails.cacheHit, false);
+  assert.equal(secondDetails.readCount, 1);
 });
 
 void test("skills read without name returns structured error details", async () => {
@@ -153,11 +150,11 @@ void test("skills read without name returns structured error details", async () 
   const text = result.content[0]?.type === "text" ? result.content[0].text : "";
 
   assert.match(text, /name is required/i);
-  assert.ok(isSkillsErrorDetails(result.details));
-  if (!isSkillsErrorDetails(result.details)) return;
+  const resultDetails = decodeToolDetailsOfKind(result.details, "skills_error");
+  assert.ok(resultDetails);
 
-  assert.equal(result.details.externalDiscoveryEnabled, false);
-  assert.deepEqual(result.details.availableNames, ["web-search"]);
+  assert.equal(resultDetails.externalDiscoveryEnabled, false);
+  assert.deepEqual(resultDetails.availableNames, ["web-search"]);
 });
 
 void test("skills list includes external entries when discovery is enabled", async () => {
@@ -171,12 +168,12 @@ void test("skills list includes external entries when discovery is enabled", asy
 
   const result = await tool.execute("call-list-ext", { action: "list" });
 
-  assert.ok(isSkillsListDetails(result.details));
-  if (!isSkillsListDetails(result.details)) return;
+  const resultDetails = decodeToolDetailsOfKind(result.details, "skills_list");
+  assert.ok(resultDetails);
 
-  assert.equal(result.details.externalDiscoveryEnabled, true);
-  assert.deepEqual(result.details.names, ["custom-skill", "web-search"]);
-  assert.equal(result.details.entries.find((entry) => entry.name === "custom-skill")?.sourceKind, "external");
+  assert.equal(resultDetails.externalDiscoveryEnabled, true);
+  assert.deepEqual(resultDetails.names, ["custom-skill", "web-search"]);
+  assert.equal(resultDetails.entries.find((entry) => entry.name === "custom-skill")?.sourceKind, "external");
 });
 
 void test("skills read resolves external skill when discovery is enabled", async () => {
@@ -193,11 +190,11 @@ void test("skills read resolves external skill when discovery is enabled", async
   const text = result.content[0]?.type === "text" ? result.content[0].text : "";
   assert.match(text, /Custom Skill/);
 
-  assert.ok(isSkillsReadDetails(result.details));
-  if (!isSkillsReadDetails(result.details)) return;
+  const resultDetails = decodeToolDetailsOfKind(result.details, "skills_read");
+  assert.ok(resultDetails);
 
-  assert.equal(result.details.sourceKind, "external");
-  assert.equal(result.details.location, CUSTOM_EXTERNAL_SKILL.location);
+  assert.equal(resultDetails.sourceKind, "external");
+  assert.equal(resultDetails.location, CUSTOM_EXTERNAL_SKILL.location);
 });
 
 void test("skills tool exposes no skills when activation state is unreadable", async () => {
@@ -238,20 +235,20 @@ void test("skills list/read exclude disabled skills", async () => {
 
   const listResult = await tool.execute("call-list-disabled", { action: "list" });
 
-  assert.ok(isSkillsListDetails(listResult.details));
-  if (!isSkillsListDetails(listResult.details)) return;
+  const listResultDetails = decodeToolDetailsOfKind(listResult.details, "skills_list");
+  assert.ok(listResultDetails);
 
-  assert.deepEqual(listResult.details.names, ["web-search"]);
+  assert.deepEqual(listResultDetails.names, ["web-search"]);
 
   const readResult = await tool.execute("call-read-disabled", {
     action: "read",
     name: "custom-skill",
   });
 
-  assert.ok(isSkillsErrorDetails(readResult.details));
-  if (!isSkillsErrorDetails(readResult.details)) return;
+  const readResultDetails = decodeToolDetailsOfKind(readResult.details, "skills_error");
+  assert.ok(readResultDetails);
 
-  assert.match(readResult.details.message, /Skill not found: `custom-skill`/);
+  assert.match(readResultDetails.message, /Skill not found: `custom-skill`/);
 });
 
 void test("skills read ignores stale cache entries when skill becomes disabled", async () => {
@@ -274,10 +271,10 @@ void test("skills read ignores stale cache entries when skill becomes disabled",
     name: "web-search",
   });
 
-  assert.ok(isSkillsReadDetails(firstRead.details));
-  if (!isSkillsReadDetails(firstRead.details)) return;
+  const firstReadDetails = decodeToolDetailsOfKind(firstRead.details, "skills_read");
+  assert.ok(firstReadDetails);
 
-  assert.equal(firstRead.details.cacheHit, false);
+  assert.equal(firstReadDetails.cacheHit, false);
 
   disabled = true;
 
@@ -286,10 +283,10 @@ void test("skills read ignores stale cache entries when skill becomes disabled",
     name: "web-search",
   });
 
-  assert.ok(isSkillsErrorDetails(secondRead.details));
-  if (!isSkillsErrorDetails(secondRead.details)) return;
+  const secondReadDetails = decodeToolDetailsOfKind(secondRead.details, "skills_error");
+  assert.ok(secondReadDetails);
 
-  assert.match(secondRead.details.message, /Skill not found: `web-search`/);
+  assert.match(secondReadDetails.message, /Skill not found: `web-search`/);
 });
 
 void test("skills install writes external skill and emits structured install details", async () => {
@@ -325,11 +322,11 @@ void test("skills install writes external skill and emits structured install det
   assert.equal(installedMarkdown, markdown);
   assert.equal(changedReason, "catalog");
 
-  assert.ok(isSkillsInstallDetails(result.details));
-  if (!isSkillsInstallDetails(result.details)) return;
+  const resultDetails = decodeToolDetailsOfKind(result.details, "skills_install");
+  assert.ok(resultDetails);
 
-  assert.equal(result.details.skillName, "custom-skill");
-  assert.equal(result.details.location, "skills/external/custom-skill/SKILL.md");
+  assert.equal(resultDetails.skillName, "custom-skill");
+  assert.equal(resultDetails.location, "skills/external/custom-skill/SKILL.md");
 });
 
 void test("skills install requires markdown", async () => {
@@ -344,11 +341,11 @@ void test("skills install requires markdown", async () => {
     name: "custom-skill",
   });
 
-  assert.ok(isSkillsErrorDetails(result.details));
-  if (!isSkillsErrorDetails(result.details)) return;
+  const resultDetails = decodeToolDetailsOfKind(result.details, "skills_error");
+  assert.ok(resultDetails);
 
-  assert.equal(result.details.action, "install");
-  assert.match(result.details.message, /markdown is required/i);
+  assert.equal(resultDetails.action, "install");
+  assert.match(resultDetails.message, /markdown is required/i);
 });
 
 void test("skills uninstall reports removed state and emits refresh only when removed", async () => {
@@ -369,20 +366,20 @@ void test("skills uninstall reports removed state and emits refresh only when re
     name: "custom-skill",
   });
 
-  assert.ok(isSkillsUninstallDetails(removed.details));
-  if (!isSkillsUninstallDetails(removed.details)) return;
+  const removedDetails = decodeToolDetailsOfKind(removed.details, "skills_uninstall");
+  assert.ok(removedDetails);
 
-  assert.equal(removed.details.skillName, "custom-skill");
-  assert.equal(removed.details.removed, true);
+  assert.equal(removedDetails.skillName, "custom-skill");
+  assert.equal(removedDetails.removed, true);
 
   const missing = await tool.execute("call-uninstall-no", {
     action: "uninstall",
     name: "missing-skill",
   });
 
-  assert.ok(isSkillsUninstallDetails(missing.details));
-  if (!isSkillsUninstallDetails(missing.details)) return;
+  const missingDetails = decodeToolDetailsOfKind(missing.details, "skills_uninstall");
+  assert.ok(missingDetails);
 
-  assert.equal(missing.details.removed, false);
+  assert.equal(missingDetails.removed, false);
   assert.equal(changedCount, 1);
 });

--- a/tests/tool-details-decode.test.ts
+++ b/tests/tool-details-decode.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  decodeToolDetails,
+  decodeToolDetailsOfKind,
+  getToolOutputTruncationDetails,
+  isBridgeGateError,
+  type ToolOutputTruncationDetails,
+} from "../src/tools/tool-details.ts";
+
+const truncation: ToolOutputTruncationDetails = {
+  version: 1,
+  strategy: "head",
+  truncated: true,
+  truncatedBy: "lines",
+  totalLines: 40,
+  totalBytes: 800,
+  outputLines: 20,
+  outputBytes: 400,
+  maxLines: 20,
+  maxBytes: 10_000,
+};
+
+const writeCells = {
+  kind: "write_cells",
+  blocked: false,
+  address: "Sheet1!A1:B2",
+  changes: {
+    changedCount: 1,
+    truncated: false,
+    sample: [{ address: "Sheet1!A1", beforeValue: "", afterValue: "1" }],
+  },
+  recovery: { status: "checkpoint_created", snapshotId: "snap-1" },
+};
+
+void test("a well-formed payload decodes to its kind and keeps merged extras such as outputTruncation", () => {
+  const raw: unknown = { ...writeCells, outputTruncation: truncation };
+
+  const details = decodeToolDetails(raw);
+
+  assert.equal(details?.kind, "write_cells");
+  assert.equal(details, raw);
+  assert.deepEqual(getToolOutputTruncationDetails(raw), truncation);
+});
+
+void test("payloads that are not a known, well-formed details object decode to undefined", () => {
+  const cases: Record<string, unknown> = {
+    null: null,
+    array: [writeCells],
+    "no kind": { blocked: false },
+    "unknown kind": { ...writeCells, kind: "write_cellz" },
+    "wrong scalar type": { ...writeCells, blocked: "no" },
+    "enum outside its values": { ...writeCells, recovery: { status: "maybe" } },
+    "malformed nested sample": {
+      ...writeCells,
+      changes: { changedCount: 1, truncated: false, sample: [{ address: 1 }] },
+    },
+  };
+
+  for (const [name, raw] of Object.entries(cases)) {
+    assert.equal(decodeToolDetails(raw), undefined, name);
+  }
+});
+
+void test("decoding for an expected kind rejects a valid payload of another kind", () => {
+  assert.equal(decodeToolDetailsOfKind(writeCells, "charts"), undefined);
+  assert.equal(decodeToolDetailsOfKind(writeCells, "write_cells")?.address, "Sheet1!A1:B2");
+});
+
+void test("a dependency tree is validated to its leaves, not only at the root", () => {
+  const leaf = { address: "Sheet1!C1", value: 3, precedents: [] };
+  const tree = {
+    kind: "trace_dependencies",
+    root: { address: "Sheet1!A1", value: 1, formula: "=B1", precedents: [{ address: "Sheet1!B1", value: 2, precedents: [leaf] }] },
+    mode: "precedents",
+  };
+
+  assert.equal(decodeToolDetails(tree)?.kind, "trace_dependencies");
+
+  const brokenGrandchild = {
+    ...tree,
+    root: { ...tree.root, precedents: [{ address: "Sheet1!B1", value: 2, precedents: [{ ...leaf, address: 7 }] }] },
+  };
+  assert.equal(decodeToolDetails(brokenGrandchild), undefined);
+});
+
+void test("truncation metadata is readable whether or not the tool attached its own details", () => {
+  assert.deepEqual(getToolOutputTruncationDetails({ outputTruncation: truncation }), truncation);
+  assert.equal(getToolOutputTruncationDetails({ outputTruncation: { ...truncation, version: 2 } }), undefined);
+  assert.equal(getToolOutputTruncationDetails(writeCells), undefined);
+});
+
+void test("a bridge gate error is a failed bridge result that carries a gate reason and a skill hint", () => {
+  const gate = decodeToolDetails({
+    kind: "tmux_bridge",
+    ok: false,
+    action: "list_sessions",
+    gateReason: "bridge_unreachable",
+    skillHint: "tmux-bridge",
+  });
+  const noHint = decodeToolDetails({ kind: "tmux_bridge", ok: false, action: "list_sessions", gateReason: "bridge_unreachable" });
+  const blockedTransform = decodeToolDetails({
+    kind: "python_transform_range",
+    blocked: true,
+    error: "blocked",
+    gateReason: "bridge_unreachable",
+    skillHint: "python-bridge",
+  });
+  const succeeded = decodeToolDetails({ kind: "python_bridge", ok: true, action: "run_python", gateReason: "bridge_unreachable", skillHint: "python-bridge" });
+
+  assert.ok(gate && noHint && blockedTransform && succeeded);
+  assert.equal(isBridgeGateError(gate), true);
+  assert.equal(isBridgeGateError(noHint), false);
+  assert.equal(isBridgeGateError(blockedTransform), false);
+  assert.equal(isBridgeGateError(succeeded), false);
+});

--- a/tests/tools-experimental-gates.test.ts
+++ b/tests/tools-experimental-gates.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { createAllTools } from "../src/tools/index.ts";
 import { applyExperimentalToolGates } from "../src/tools/experimental-tool-gates.ts";
-import { isTmuxBridgeDetails } from "../src/tools/tool-details.ts";
+import { decodeToolDetailsOfKind } from "../src/tools/tool-details.ts";
 
 async function runtimeTools(dependencies: Parameters<typeof applyExperimentalToolGates>[1] = {}) {
   return applyExperimentalToolGates(createAllTools({ hostKind: "office" }), dependencies);
@@ -25,13 +25,11 @@ void test("the model-visible tmux tool re-checks bridge availability for each ex
   const tmux = findTool(tools, "tmux");
 
   const unreachable = await tmux.execute("call-unreachable", { action: "list_sessions" });
-  assert.ok(isTmuxBridgeDetails(unreachable.details));
-  assert.equal(unreachable.details.gateReason, "bridge_unreachable");
+  assert.equal(decodeToolDetailsOfKind(unreachable.details, "tmux_bridge")?.gateReason, "bridge_unreachable");
 
   bridgeUrl = undefined;
   const missing = await tmux.execute("call-missing", { action: "list_sessions" });
-  assert.ok(isTmuxBridgeDetails(missing.details));
-  assert.equal(missing.details.gateReason, "missing_bridge_url");
+  assert.equal(decodeToolDetailsOfKind(missing.details, "tmux_bridge")?.gateReason, "missing_bridge_url");
 });
 
 void test("the model-visible files and Office.js tools remain available without feature flags", async () => {


### PR DESCRIPTION
Types migration PR 2 (`docs/clean-base-followups.md`, "Boundary policy"): the largest guard file becomes schemas, plus a type-safety regression from #718 that I found on the way.

## 1. `StringEnum` literal types (`14eb543`) — regression fix

pi-ai's `StringEnum<T extends readonly string[]>` infers `T` as `readonly string[]` for an inline array, so #718 silently widened `Static<…>["action"]` to `string` in `modify_structure` and `view_settings` (the spread-from-`as const` call sites were unaffected). `src/tools/string-enum.ts` wraps pi-ai's with a `const` type parameter; every schema imports from there. Runtime JSON is byte-identical (verified), so no prompt-cache impact.

Not guarded by a test because `tests/` is not typechecked (`tsc -p tsconfig.eslint.json` → 533 errors; recorded as a follow-up). The `const` parameter is the structural guard.

## 2. Tool details are schemas, decoded once at the UI seam (`2cf2abb`)

`src/tools/tool-details.ts` had 54 hand-written guards next to the interfaces they checked, and the UI called a guard per lookup on an `unknown`. Now:

- Every payload is a TypeBox schema; the exported type is `Static<>` of it, so the tool constructing the payload and the UI validating it share one shape. `WorkbookCellChangeSummary` and `ConnectionToolErrorDetails` get schemas where they live.
- `decodeToolDetails(raw)` runs **once per tool card** (`Value.Check`, no codegen — WebView CSP), returns the `ExcelToolDetails` union or `undefined`; `tool-renderers`, `bridge-setup-card` and `web-search-setup-card` take the union and switch on `kind`. ~10–20 µs per decode.
- Extra properties are allowed, so `outputTruncation` still merges into any payload.
- Behaviour change: `trace_dependencies` trees are validated to the leaves (the old guard checked only the root's `address`/`precedents`). A malformed tree renders generically instead of half-rendering.
- `testBridgeSetupConnection` was exported and unused; removed.

Decision recorded in `src/tools/DECISIONS.md`; `AGENTS.md` tool-results section updated.

**Numbers:** ratchet 439 → **430** (rebased onto #722; baseline lowered); hand-written guards 233 → **179**.

## Verification

- `npm run check`, `npm test` **779 pass** (6 new in `tests/tool-details-decode.test.ts`; each fails against a seeded mutation — kind-agnostic decode: 3 fail, shallow tree check: 1 fails), `npm run test:browser` **84 pass** (the bridge-card fixtures now go through the seam), `npm run build` (+2.6 KB; `typebox/value` was already bundled).
- **Real Excel: passed** — see the acceptance comment (run on #721's branch, which includes this PR): diff table, precedents tree, CSV table, chart image and JSON result sections all rendered from decoded `details` after real tool calls in background Excel 16.112 with `openai-codex/gpt-5.6-sol`.


