### PR TITLE
refactor: settings reads are unknown by contract; one settings contract instead of 17

### DIFF
--- a/docs/clean-base-followups.md
+++ b/docs/clean-base-followups.md
@@ -54,13 +54,15 @@ migrations stay explicit.
 
 ### Caller-selected `get<T>()` for persisted settings
 
-`src/storage/local/settings-store.ts` still exposes `get<T = DynamicValue>()`
-and the IndexedDB backend asserts the result to whatever the caller asked for.
-Feature-owned readers exist for compaction, proxy and several other keys
-(`tests/storage-ownership-contract.test.ts` covers them), but the generic
-accessor remains the default path.
+Done (2026-09-11): `SettingsStore.get(key)` returns `unknown` and the caller
+parses it. The 17 structural copies of that contract across features were
+replaced by `SettingsReader` / `SettingsWriter` / `SettingsAccess` exported
+from `src/storage/local/settings-store.ts`; the optional `delete?` variants and
+their `set(key, "")` fallbacks went with them.
 
-Probe: `rg -n 'get<T' src/storage/local/settings-store.ts`
+Probe: `rg -n 'get<T' src/storage/local/settings-store.ts` (expect none) and
+`rg -n 'get\(key: string\): Promise<unknown>' src` (expect the shared contract
+and the extension `StorageAPI` only).
 
 ### Guidance still describes the old policy
 

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -78,6 +78,7 @@ The `check:innerhtml` script keeps raw `.innerHTML` out of application code.
 - Use bounded concurrency for unbounded/user-sized collections.
 - Keep retryable mutations idempotent or tied to stable logical identity.
 - Do not add hidden globals for time, randomness, IDs, workbook state, providers, or settings when a seam can pass the dependency explicitly.
+- Take settings as `SettingsReader` / `SettingsWriter` / `SettingsAccess` from `src/storage/local/settings-store.ts`; do not redeclare the `get`/`set`/`delete` shape locally. A read is `unknown` by contract, and the feature that owns the key parses it.
 
 ## Tests and verification
 

--- a/scripts/check-unknown-burndown.mjs
+++ b/scripts/check-unknown-burndown.mjs
@@ -12,7 +12,7 @@
  */
 import { spawnSync } from "node:child_process";
 
-const BASELINE = 461; // 2026-09-10: 384 no-unknown-parameters, 77 no-unknown-returns, 0 no-unknown-type-aliases
+const BASELINE = 439; // 2026-09-11: 373 no-unknown-parameters, 66 no-unknown-returns, 0 no-unknown-type-aliases
 
 const result = spawnSync(
   "npx",

--- a/src/audit/workbook-change-audit.ts
+++ b/src/audit/workbook-change-audit.ts
@@ -13,6 +13,7 @@ import {
   type ExecutionMode,
 } from "../execution/mode.js";
 import type { WorkbookCellChange } from "./cell-diff.js";
+import type { SettingsAccess } from "../storage/local/settings-store.js";
 
 const AUDIT_SETTING_KEY = "workbook.change-audit.v1";
 const MAX_AUDIT_ENTRIES = 500;
@@ -58,15 +59,9 @@ export interface AppendWorkbookChangeAuditEntryArgs {
   executionMode?: ExecutionMode;
 }
 
-interface SettingsStoreLike {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
-  delete(key: string): Promise<void>;
-}
-
 interface WorkbookChangeAuditLogDependencies {
-  settings: SettingsStoreLike | null;
-  getSettingsStore: () => Promise<SettingsStoreLike | null>;
+  settings: SettingsAccess | null;
+  getSettingsStore: () => Promise<SettingsAccess | null>;
   getWorkbookContext: () => Promise<WorkbookContext>;
   now: () => number;
   createId: () => string;
@@ -94,7 +89,7 @@ function defaultCreateId(): string {
   return `change_${Date.now().toString(36)}_${randomChunk}`;
 }
 
-function isSettingsStoreLike(value: unknown): value is SettingsStoreLike {
+function isSettingsStoreLike(value: unknown): value is SettingsAccess {
   if (!isAuditWorkbookChangeAuditPayloadShape(value)) return false;
 
   return (
@@ -104,7 +99,7 @@ function isSettingsStoreLike(value: unknown): value is SettingsStoreLike {
   );
 }
 
-async function defaultGetSettingsStore(): Promise<SettingsStoreLike | null> {
+async function defaultGetSettingsStore(): Promise<SettingsAccess | null> {
   try {
     const storageModule = await import("../storage/local/app-storage.js");
     const appStorage = storageModule.getAppStorage();

--- a/src/auth/cors-proxy.ts
+++ b/src/auth/cors-proxy.ts
@@ -17,13 +17,10 @@ import {
   validateOfficeProxyUrl,
 } from "./proxy-validation.js";
 import { rewriteDevProxyUrl } from "./dev-rewrites.js";
+import type { SettingsReader } from "../storage/local/settings-store.js";
 
 /** The original, un-patched fetch — use for requests that should bypass the proxy */
 export let originalFetch: typeof window.fetch;
-
-export interface CorsProxySettingsReader {
-  get(key: string): Promise<unknown>;
-}
 
 type ProxySettingsCache = {
   checkedAt: number;
@@ -42,7 +39,7 @@ function parseProxyEnabled(value: unknown): boolean {
 }
 
 export async function readCorsProxySettings(
-  settings: CorsProxySettingsReader,
+  settings: SettingsReader,
 ): Promise<{ enabled: boolean; url: string }> {
   try {
     const [enabled, url] = await Promise.all([
@@ -59,7 +56,7 @@ export async function readCorsProxySettings(
 }
 
 async function getEnabledProxyUrl(
-  injectedSettings?: CorsProxySettingsReader,
+  injectedSettings?: SettingsReader,
 ): Promise<string | undefined> {
   // OAuth flows are infrequent, but fetch() is frequent; cache for a short time.
   const now = Date.now();
@@ -143,7 +140,7 @@ function stripAnthropicBrowserHeader(init?: RequestInit): RequestInit | undefine
 /**
  * Install the fetch interceptor. Call once at boot.
  */
-export function installFetchInterceptor(settings?: CorsProxySettingsReader): void {
+export function installFetchInterceptor(settings?: SettingsReader): void {
   originalFetch = window.fetch.bind(window);
 
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {

--- a/src/auth/oauth-callback-capture.ts
+++ b/src/auth/oauth-callback-capture.ts
@@ -101,10 +101,10 @@ function wait(ms: number, signal: AbortSignal | undefined): Promise<void> {
 
 async function getEnabledLocalProxyUrl(): Promise<string | null> {
   const storage = getAppStorage();
-  const enabled = await storage.settings.get<boolean>("proxy.enabled");
+  const enabled = await storage.settings.get("proxy.enabled");
   if (!enabled) return null;
 
-  const rawUrl = await storage.settings.get<string>("proxy.url");
+  const rawUrl = await storage.settings.get("proxy.url");
   const proxyUrl = validateOfficeProxyUrl(resolveConfiguredProxyUrl(rawUrl));
   return isLoopbackProxyUrl(proxyUrl) ? proxyUrl : null;
 }

--- a/src/auth/oauth-storage.ts
+++ b/src/auth/oauth-storage.ts
@@ -13,12 +13,7 @@ function isAuthOauthStoragePayloadShape(value: unknown): value is Record<string,
  */
 
 import type { OAuthCredentials } from "@earendil-works/pi-ai";
-export interface OAuthSettingsStore {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
-  delete(key: string): Promise<void>;
-}
-
+import type { SettingsAccess } from "../storage/local/settings-store.js";
 export function isOAuthCredentials(value: unknown): value is OAuthCredentials {
   return (
     isAuthOauthStoragePayloadShape(value) &&
@@ -36,7 +31,7 @@ function oauthSettingsKey(providerId: string): string {
  * Load OAuth credentials from IndexedDB settings.
  */
 export async function loadOAuthCredentials(
-  settings: OAuthSettingsStore,
+  settings: SettingsAccess,
   providerId: string,
 ): Promise<OAuthCredentials | null> {
   try {
@@ -48,7 +43,7 @@ export async function loadOAuthCredentials(
 }
 
 export async function saveOAuthCredentials(
-  settings: OAuthSettingsStore,
+  settings: SettingsAccess,
   providerId: string,
   credentials: OAuthCredentials,
 ): Promise<void> {
@@ -56,7 +51,7 @@ export async function saveOAuthCredentials(
 }
 
 export async function clearOAuthCredentials(
-  settings: OAuthSettingsStore,
+  settings: SettingsAccess,
   providerId: string,
 ): Promise<void> {
   await settings.delete(oauthSettingsKey(providerId));

--- a/src/commands/builtins/experimental.ts
+++ b/src/commands/builtins/experimental.ts
@@ -200,7 +200,7 @@ async function defaultGetBridgeUrl(settingKey: string): Promise<string | undefin
 
   try {
     const settings = await getSettingsStore();
-    const value = await settings.get<string>(settingKey);
+    const value = await settings.get(settingKey);
     if (typeof value !== "string") return fallbackUrl;
 
     const trimmed = value.trim();

--- a/src/commands/builtins/extensions-hub-connections.ts
+++ b/src/commands/builtins/extensions-hub-connections.ts
@@ -6,9 +6,8 @@
  */
 
 import { INTEGRATION_IDS } from "../../integrations/catalog.js";
-import type { IntegrationSettingsStore } from "../../integrations/store.js";
-import type { WebSearchConfigStore } from "../../tools/web-search-config.js";
-import type { McpConfigStore, McpServerConfig } from "../../tools/mcp-config.js";
+import type { SettingsAccess } from "../../storage/local/settings-store.js";
+import type { McpServerConfig } from "../../tools/mcp-config.js";
 import {
   getExternalToolsEnabled,
   getSessionIntegrationIds,
@@ -66,10 +65,6 @@ import { t } from "../../language/index.js";
 import type { ExtensionsHubDependencies } from "./settings-pages/dependencies.js";
 import { renderExtensionConnectionsSection } from "./extensions-hub-extension-connections.js";
 
-type SettingsStore = IntegrationSettingsStore & WebSearchConfigStore & McpConfigStore & {
-  delete?: (key: string) => Promise<void>;
-};
-
 // ── Helpers ─────────────────────────────────────────
 
 function normalizeProvider(value: string): WebSearchProvider {
@@ -78,7 +73,7 @@ function normalizeProvider(value: string): WebSearchProvider {
 }
 
 export async function readBridgeUrls(
-  settings: SettingsStore,
+  settings: SettingsAccess,
 ): Promise<{ pythonUrl: string; tmuxUrl: string }> {
   try {
     const [pythonUrl, tmuxUrl] = await Promise.all([
@@ -185,7 +180,7 @@ function createBridgeSetupCommand(command: string): HTMLDivElement {
 
 export async function renderConnectionsTab(args: {
   container: HTMLElement;
-  settings: SettingsStore;
+  settings: SettingsAccess;
   deps: ExtensionsHubDependencies;
   isBusy: () => boolean;
   runMutation: (action: () => Promise<void>, reason: "toggle" | "scope" | "external-toggle" | "config", msg?: string) => Promise<void>;
@@ -556,7 +551,7 @@ export async function renderConnectionsTab(args: {
 
 function renderMcpServerCard(
   server: McpServerConfig,
-  settings: SettingsStore,
+  settings: SettingsAccess,
   isBusy: () => boolean,
   runMutation: (action: () => Promise<void>, reason: "toggle" | "scope" | "external-toggle" | "config", msg?: string) => Promise<void>,
 ): HTMLElement {
@@ -645,7 +640,7 @@ function renderBridgeCard(args: {
   placeholder: string;
   currentUrl: string;
   hasCustomUrl: boolean;
-  settings: SettingsStore;
+  settings: SettingsAccess;
   runMutation: (action: () => Promise<void>, reason: "toggle" | "scope" | "external-toggle" | "config", msg?: string) => Promise<void>;
 }): HTMLElement {
   const card = createItemCard({
@@ -689,11 +684,7 @@ function renderBridgeCard(args: {
 
     void args.runMutation(async () => {
       if (useDefaultUrl) {
-        if (typeof args.settings.delete === "function") {
-          await args.settings.delete(args.settingKey);
-        } else {
-          await args.settings.set(args.settingKey, "");
-        }
+        await args.settings.delete(args.settingKey);
       } else {
         await args.settings.set(args.settingKey, normalizedCandidateUrl);
       }

--- a/src/commands/builtins/extensions-hub-mcp-probe.ts
+++ b/src/commands/builtins/extensions-hub-mcp-probe.ts
@@ -1,11 +1,11 @@
 import { APP_NAME, APP_VERSION } from "../../app/metadata.js";
-import { type IntegrationSettingsStore } from "../../integrations/store.js";
 import { getEnabledProxyBaseUrl, resolveOutboundRequestUrl } from "../../tools/external-fetch.js";
 import { type McpServerConfig } from "../../tools/mcp-config.js";
 import {
   getHttpErrorReason,
   runWithTimeoutAbort,
 } from "../../utils/network.js";
+import type { SettingsWriter } from "../../storage/local/settings-store.js";
 function isExtensionsHubMcpProbePayloadShape(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -25,7 +25,7 @@ async function postJsonRpc(args: {
   server: McpServerConfig;
   method: string;
   params?: unknown;
-  settings: IntegrationSettingsStore;
+  settings: SettingsWriter;
   expectResponse?: boolean;
 }): Promise<{ response: unknown; proxied: boolean; proxyBaseUrl?: string } | null> {
   const { server, method, params, settings, expectResponse = true } = args;
@@ -98,7 +98,7 @@ async function postJsonRpc(args: {
 
 export async function probeMcpServer(
   server: McpServerConfig,
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
 ): Promise<{ toolCount: number; proxied: boolean; proxyBaseUrl?: string }> {
   await postJsonRpc({
     server,

--- a/src/commands/builtins/settings-pages/proxy-page.ts
+++ b/src/commands/builtins/settings-pages/proxy-page.ts
@@ -20,14 +20,10 @@ import {
 } from "../../../ui/extensions-hub-components.js";
 import type { SettingsShellPage } from "../../../ui/settings-shell.js";
 import { showToast } from "../../../ui/toast.js";
+import type { SettingsWriter } from "../../../storage/local/settings-store.js";
 
 function isProxyPagePayloadShape(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-interface SettingsStore {
-  get<T>(key: string): Promise<T | null>;
-  set(key: string, value: unknown): Promise<void>;
 }
 
 function resolveProxyCallout(args: {
@@ -77,7 +73,7 @@ export function createProxyPage(): SettingsShellPage {
     parentId: "root",
     title: () => t("settings.section.proxy"),
     render: (ctx) => {
-      const settingsStore: SettingsStore = getAppStorage().settings;
+      const settingsStore: SettingsWriter = getAppStorage().settings;
 
       const card = document.createElement("div");
       card.className = "pi-overlay-surface pi-settings-proxy-card";
@@ -254,8 +250,8 @@ export function createProxyPage(): SettingsShellPage {
 
       void (async () => {
         try {
-          const storedEnabled = await settingsStore.get<boolean>("proxy.enabled");
-          const storedUrl = await settingsStore.get<string>("proxy.url");
+          const storedEnabled = await settingsStore.get("proxy.enabled");
+          const storedUrl = await settingsStore.get("proxy.url");
 
           enabled = storedEnabled === true;
           proxyUrl = typeof storedUrl === "string" && storedUrl.trim().length > 0

--- a/src/commands/builtins/settings-pages/root-page.ts
+++ b/src/commands/builtins/settings-pages/root-page.ts
@@ -87,7 +87,7 @@ function buildProvidersGroup(ctx: SettingsPageContext): HTMLElement {
     }
 
     try {
-      const proxyEnabled = await storage.settings.get<boolean>("proxy.enabled");
+      const proxyEnabled = await storage.settings.get("proxy.enabled");
       proxyRow.setValue(proxyEnabled === true ? t("settings.value.on") : t("settings.value.off"));
     } catch {
       // leave preview empty

--- a/src/compaction/settings.ts
+++ b/src/compaction/settings.ts
@@ -1,8 +1,6 @@
-export const COMPACTION_ENABLED_SETTING_KEY = "compaction.enabled";
+import type { SettingsReader } from "../storage/local/settings-store.js";
 
-export interface CompactionSettingsStore {
-  get(key: string): Promise<unknown>;
-}
+export const COMPACTION_ENABLED_SETTING_KEY = "compaction.enabled";
 
 /**
  * Reads the persisted auto-compaction preference.
@@ -11,7 +9,7 @@ export interface CompactionSettingsStore {
  * cannot be read. Only persisted boolean values override that safe default.
  */
 export async function readAutoCompactionEnabled(
-  settings: CompactionSettingsStore,
+  settings: SettingsReader,
 ): Promise<boolean> {
   try {
     const value = await settings.get(COMPACTION_ENABLED_SETTING_KEY);

--- a/src/connections/manager.ts
+++ b/src/connections/manager.ts
@@ -2,7 +2,6 @@ import {
   loadConnectionStoreDocument,
   loadConnectionStoreDocumentForUpdate,
   saveConnectionStoreDocument,
-  type ConnectionSettingsStore,
   type StoredConnectionRecord,
 } from "./store.js";
 import type {
@@ -14,6 +13,7 @@ import type {
   ConnectionState,
   ConnectionStatus,
 } from "./types.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 interface RegisteredConnectionDefinition extends ConnectionDefinition {
   ownerId: string;
@@ -309,7 +309,7 @@ function toPublicConnectionDefinition(
 }
 
 async function mutateConnectionRecord(args: {
-  settings: ConnectionSettingsStore;
+  settings: SettingsWriter;
   connectionId: string;
   mutator: (record: StoredConnectionRecord | undefined) => StoredConnectionRecord | null;
 }): Promise<boolean> {
@@ -339,11 +339,11 @@ async function mutateConnectionRecord(args: {
 }
 
 export class ConnectionManager {
-  private readonly settings: ConnectionSettingsStore;
+  private readonly settings: SettingsWriter;
   private readonly definitions = new Map<string, RegisteredConnectionDefinition>();
   private readonly listeners = new Set<ConnectionManagerListener>();
 
-  constructor(options: { settings: ConnectionSettingsStore }) {
+  constructor(options: { settings: SettingsWriter }) {
     this.settings = options.settings;
   }
 

--- a/src/connections/store.ts
+++ b/src/connections/store.ts
@@ -1,4 +1,5 @@
 import type { ConnectionSecrets, ConnectionStatus } from "./types.js";
+import type { SettingsReader, SettingsWriter } from "../storage/local/settings-store.js";
 
 function isConnectionsStorePayloadShape(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -6,15 +7,6 @@ function isConnectionsStorePayloadShape(value: unknown): value is Record<string,
 
 export const CONNECTION_STORE_KEY = "connections.store.v1";
 const CONNECTION_STORE_VERSION = 1;
-
-export interface ConnectionSettingsReader {
-  get(key: string): Promise<unknown>;
-}
-
-export interface ConnectionSettingsStore extends ConnectionSettingsReader {
-  set(key: string, value: unknown): Promise<void>;
-  delete?(key: string): Promise<void>;
-}
 
 export interface StoredConnectionRecord {
   status?: ConnectionStatus;
@@ -91,7 +83,7 @@ function normalizeDocument(value: unknown): ConnectionStoreDocument {
 }
 
 export async function loadConnectionStoreDocument(
-  settings: ConnectionSettingsReader,
+  settings: SettingsReader,
 ): Promise<Record<string, StoredConnectionRecord>> {
   try {
     const raw = await settings.get(CONNECTION_STORE_KEY);
@@ -106,14 +98,14 @@ export async function loadConnectionStoreDocument(
  * storage failures propagate so a write cannot replace unread sibling records.
  */
 export async function loadConnectionStoreDocumentForUpdate(
-  settings: ConnectionSettingsStore,
+  settings: SettingsWriter,
 ): Promise<Record<string, StoredConnectionRecord>> {
   const raw = await settings.get(CONNECTION_STORE_KEY);
   return normalizeDocument(raw).items;
 }
 
 export async function saveConnectionStoreDocument(
-  settings: ConnectionSettingsStore,
+  settings: SettingsWriter,
   items: Record<string, StoredConnectionRecord>,
 ): Promise<void> {
   await settings.set(CONNECTION_STORE_KEY, {

--- a/src/extensions/runtime-manager-activation.ts
+++ b/src/extensions/runtime-manager-activation.ts
@@ -33,7 +33,8 @@ import {
   qualifyExtensionConnectionId,
 } from "./owner-identifiers.js";
 import type { SandboxActivationOptions } from "./sandbox-runtime.js";
-import type { ExtensionSettingsStore, StoredExtensionEntry } from "./store.js";
+import type { StoredExtensionEntry } from "./store.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 type HostActivationBridge = Pick<
   CreateExtensionAPIOptions,
@@ -239,7 +240,7 @@ export interface RuntimeManagerActivationBridge {
 
 export interface BuildRuntimeManagerActivationBridgeOptions {
   entry: StoredExtensionEntry;
-  settings: ExtensionSettingsStore;
+  settings: SettingsWriter;
   connectionManager: ConnectionManager;
   getRequiredActiveAgent: () => Agent;
   afterInjectAgentContext?: () => Promise<void> | void;

--- a/src/extensions/runtime-manager.ts
+++ b/src/extensions/runtime-manager.ts
@@ -46,7 +46,6 @@ import {
 import {
   loadStoredExtensions,
   saveStoredExtensions,
-  type ExtensionSettingsStore,
   type StoredExtensionEntry,
   type StoredExtensionSource,
 } from "./store.js";
@@ -84,6 +83,7 @@ import type {
   BrowserModelRuntime,
   BrowserProviderRegistration,
 } from "../models/browser-model-runtime.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 type AnyAgentTool = AgentTool;
 
@@ -171,7 +171,7 @@ export interface ExtensionRuntimeStatus {
 }
 
 export interface ExtensionRuntimeManagerOptions {
-  settings: ExtensionSettingsStore;
+  settings: SettingsWriter;
   connectionManager: ConnectionManager;
   modelRuntime: BrowserModelRuntime;
   getActiveAgent: () => Agent | null;
@@ -185,7 +185,7 @@ export interface ExtensionRuntimeManagerOptions {
 }
 
 export class ExtensionRuntimeManager {
-  private readonly settings: ExtensionSettingsStore;
+  private readonly settings: SettingsWriter;
   private readonly connectionManager: ConnectionManager;
   private readonly modelRuntime: BrowserModelRuntime;
   private readonly getActiveAgent: () => Agent | null;

--- a/src/extensions/storage-store.ts
+++ b/src/extensions/storage-store.ts
@@ -1,3 +1,5 @@
+import type { SettingsWriter } from "../storage/local/settings-store.js";
+
 function isExtensionsStorageStorePayloadShape(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -10,11 +12,6 @@ const MAX_EXTENSION_STORAGE_BYTES = 1_000_000;
 interface ExtensionStorageDocument {
   version: number;
   items: Record<string, Record<string, unknown>>;
-}
-
-export interface ExtensionStorageSettings {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
 }
 
 function normalizeStorageDocument(raw: unknown): ExtensionStorageDocument {
@@ -41,7 +38,7 @@ function normalizeStorageDocument(raw: unknown): ExtensionStorageDocument {
   };
 }
 
-async function readStorageDocument(settings: ExtensionStorageSettings): Promise<ExtensionStorageDocument> {
+async function readStorageDocument(settings: SettingsWriter): Promise<ExtensionStorageDocument> {
   try {
     const raw = await settings.get(EXTENSION_STORAGE_KEY);
     return normalizeStorageDocument(raw);
@@ -51,14 +48,14 @@ async function readStorageDocument(settings: ExtensionStorageSettings): Promise<
 }
 
 async function loadStorageDocumentForUpdate(
-  settings: ExtensionStorageSettings,
+  settings: SettingsWriter,
 ): Promise<ExtensionStorageDocument> {
   const raw = await settings.get(EXTENSION_STORAGE_KEY);
   return normalizeStorageDocument(raw);
 }
 
 async function saveStorageDocument(
-  settings: ExtensionStorageSettings,
+  settings: SettingsWriter,
   document: ExtensionStorageDocument,
 ): Promise<void> {
   await settings.set(EXTENSION_STORAGE_KEY, {
@@ -81,7 +78,7 @@ function calculateSerializedSize(value: unknown): number {
 }
 
 export async function getExtensionStorageValue(
-  settings: ExtensionStorageSettings,
+  settings: SettingsWriter,
   extensionId: string,
   key: string,
 ): Promise<unknown> {
@@ -91,7 +88,7 @@ export async function getExtensionStorageValue(
 }
 
 export async function setExtensionStorageValue(
-  settings: ExtensionStorageSettings,
+  settings: SettingsWriter,
   extensionId: string,
   key: string,
   value: unknown,
@@ -112,7 +109,7 @@ export async function setExtensionStorageValue(
 }
 
 export async function deleteExtensionStorageValue(
-  settings: ExtensionStorageSettings,
+  settings: SettingsWriter,
   extensionId: string,
   key: string,
 ): Promise<void> {
@@ -136,7 +133,7 @@ export async function deleteExtensionStorageValue(
 }
 
 export async function listExtensionStorageKeys(
-  settings: ExtensionStorageSettings,
+  settings: SettingsWriter,
   extensionId: string,
 ): Promise<string[]> {
   const document = await readStorageDocument(settings);
@@ -145,7 +142,7 @@ export async function listExtensionStorageKeys(
 }
 
 export async function clearExtensionStorage(
-  settings: ExtensionStorageSettings,
+  settings: SettingsWriter,
   extensionId: string,
 ): Promise<void> {
   const document = await loadStorageDocumentForUpdate(settings);

--- a/src/extensions/store.ts
+++ b/src/extensions/store.ts
@@ -15,15 +15,11 @@ import {
   type StoredExtensionPermissions,
   type StoredExtensionTrust,
 } from "./permissions.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 export const EXTENSIONS_REGISTRY_STORAGE_KEY = "extensions.registry.v2";
 export const LEGACY_EXTENSIONS_REGISTRY_STORAGE_KEY = "extensions.registry.v1";
 const EXTENSIONS_REGISTRY_VERSION = 2;
-
-export interface ExtensionSettingsStore {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
-}
 
 export const BUILTIN_SNAKE_EXTENSION_ID = "builtin.snake";
 const BUILTIN_SNAKE_EXTENSION_NAME = "Snake";
@@ -275,7 +271,7 @@ export function createDefaultExtensionEntries(
 }
 
 export async function saveStoredExtensions(
-  settings: ExtensionSettingsStore,
+  settings: SettingsWriter,
   items: StoredExtensionEntry[],
 ): Promise<void> {
   await settings.set(EXTENSIONS_REGISTRY_STORAGE_KEY, createRegistryDocument(items));
@@ -288,7 +284,7 @@ export async function saveStoredExtensions(
  * Legacy `extensions.registry.v1` data is migrated to `extensions.registry.v2`.
  * Storage read failures propagate so defaults cannot replace an unread registry.
  */
-export async function loadStoredExtensions(settings: ExtensionSettingsStore): Promise<StoredExtensionEntry[]> {
+export async function loadStoredExtensions(settings: SettingsWriter): Promise<StoredExtensionEntry[]> {
   const normalizedCurrent = normalizeDocument(await settings.get(EXTENSIONS_REGISTRY_STORAGE_KEY));
 
   if (normalizedCurrent && normalizedCurrent.version >= EXTENSIONS_REGISTRY_VERSION) {

--- a/src/files/workspace.ts
+++ b/src/files/workspace.ts
@@ -33,6 +33,7 @@ import {
   type WorkspaceFileWorkbookTag,
   type WorkspaceSnapshot,
 } from "./types.js";
+import type { SettingsAccess } from "../storage/local/settings-store.js";
 
 const NATIVE_HANDLE_SETTING_KEY = "files.workspace.nativeHandle.v1";
 const METADATA_SETTING_KEY = "files.workspace.metadata.v1";
@@ -332,13 +333,7 @@ function createAuditEntryId(): string {
   return `audit_${Date.now().toString(36)}_${randomChunk}`;
 }
 
-export interface FilesWorkspaceSettingsStore {
-  get<T>(key: string): Promise<T | null>;
-  set(key: string, value: unknown): Promise<void>;
-  delete(key: string): Promise<void>;
-}
-
-function isSettingsStoreLike(value: unknown): value is FilesWorkspaceSettingsStore {
+function isSettingsStoreLike(value: unknown): value is SettingsAccess {
   if (!isFilesWorkspacePayloadShape(value)) return false;
 
   return (
@@ -348,7 +343,7 @@ function isSettingsStoreLike(value: unknown): value is FilesWorkspaceSettingsSto
   );
 }
 
-async function getSettingsStore(): Promise<FilesWorkspaceSettingsStore | null> {
+async function getSettingsStore(): Promise<SettingsAccess | null> {
   try {
     const storageModule = await import("../storage/local/app-storage.js");
     const appStorage = storageModule.getAppStorage();
@@ -364,7 +359,7 @@ async function readPersistedNativeHandle(): Promise<FileSystemDirectoryHandle | 
   if (!settings) return null;
 
   try {
-    const stored = await settings.get<unknown>(NATIVE_HANDLE_SETTING_KEY);
+    const stored = await settings.get(NATIVE_HANDLE_SETTING_KEY);
     return isDirectoryHandle(stored) ? stored : null;
   } catch {
     return null;
@@ -569,7 +564,7 @@ export function buildWorkspaceContextSummary(args: WorkspaceContextSummaryArgs):
 export interface FilesWorkspaceOptions {
   initialBackend?: WorkspaceBackend;
   initialWorkspaceBackend?: WorkspaceBackend;
-  settings?: FilesWorkspaceSettingsStore | null;
+  settings?: SettingsAccess | null;
 }
 
 export class FilesWorkspace {
@@ -586,7 +581,7 @@ export class FilesWorkspace {
   private auditLoaded = false;
   private auditEntries: FilesWorkspaceAuditEntry[] = [];
 
-  private readonly settings: FilesWorkspaceSettingsStore | null | undefined;
+  private readonly settings: SettingsAccess | null | undefined;
   private readonly scratchCleanupByBackend = new WeakMap<WorkspaceBackend, Promise<void>>();
 
   constructor(options: FilesWorkspaceOptions = {}) {
@@ -745,7 +740,7 @@ export class FilesWorkspace {
     dispatchWorkspaceChanged({ reason: "backend" });
   }
 
-  private resolveSettings(): Promise<FilesWorkspaceSettingsStore | null> {
+  private resolveSettings(): Promise<SettingsAccess | null> {
     return this.settings === undefined ? getSettingsStore() : Promise.resolve(this.settings);
   }
 
@@ -759,7 +754,7 @@ export class FilesWorkspace {
     }
 
     try {
-      const raw = await settings.get<unknown>(METADATA_SETTING_KEY);
+      const raw = await settings.get(METADATA_SETTING_KEY);
       const parsed = parsePersistedMetadata(raw);
       this.metadataByPath.clear();
       for (const [path, tag] of parsed) {
@@ -803,7 +798,7 @@ export class FilesWorkspace {
     }
 
     try {
-      const raw = await settings.get<unknown>(AUDIT_TRAIL_SETTING_KEY);
+      const raw = await settings.get(AUDIT_TRAIL_SETTING_KEY);
       this.auditEntries = parsePersistedAuditTrail(raw);
       this.auditLoaded = true;
       return true;

--- a/src/integrations/store.ts
+++ b/src/integrations/store.ts
@@ -12,13 +12,9 @@
  */
 
 import { getDefaultEnabledIntegrationIds } from "./catalog.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 export type IntegrationScope = "session" | "workbook";
-
-export interface IntegrationSettingsStore {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
-}
 
 export interface SessionIntegrationIdsOptions {
   /**
@@ -84,7 +80,7 @@ export function normalizeIntegrationIds(raw: unknown, knownIntegrationIds: reado
 }
 
 async function readScopeIntegrationIds(
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
   scope: IntegrationScope,
   identifier: string,
   knownIntegrationIds: readonly string[],
@@ -108,7 +104,7 @@ async function readScopeIntegrationIds(
 }
 
 async function setScopeIntegrationIds(
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
   scope: IntegrationScope,
   identifier: string,
   integrationIds: readonly string[],
@@ -123,7 +119,7 @@ async function setScopeIntegrationIds(
 }
 
 export async function getSessionIntegrationIds(
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
   sessionId: string,
   knownIntegrationIds: readonly string[],
   options?: SessionIntegrationIdsOptions,
@@ -138,7 +134,7 @@ export async function getSessionIntegrationIds(
 }
 
 export async function setSessionIntegrationIds(
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
   sessionId: string,
   integrationIds: readonly string[],
   knownIntegrationIds: readonly string[],
@@ -147,7 +143,7 @@ export async function setSessionIntegrationIds(
 }
 
 export async function getWorkbookIntegrationIds(
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
   workbookId: string,
   knownIntegrationIds: readonly string[],
 ): Promise<string[]> {
@@ -155,7 +151,7 @@ export async function getWorkbookIntegrationIds(
 }
 
 export async function setWorkbookIntegrationIds(
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
   workbookId: string,
   integrationIds: readonly string[],
   knownIntegrationIds: readonly string[],
@@ -164,7 +160,7 @@ export async function setWorkbookIntegrationIds(
 }
 
 export async function setIntegrationEnabledInScope(args: {
-  settings: IntegrationSettingsStore;
+  settings: SettingsWriter;
   scope: IntegrationScope;
   identifier: string;
   integrationId: string;
@@ -192,7 +188,7 @@ export async function setIntegrationEnabledInScope(args: {
 }
 
 export async function resolveConfiguredIntegrationIds(args: {
-  settings: IntegrationSettingsStore;
+  settings: SettingsWriter;
   sessionId: string;
   workbookId: string | null;
   knownIntegrationIds: readonly string[];
@@ -231,7 +227,7 @@ function parseStoredBoolean(value: unknown): boolean {
   return false;
 }
 
-export async function getExternalToolsEnabled(settings: IntegrationSettingsStore): Promise<boolean> {
+export async function getExternalToolsEnabled(settings: SettingsWriter): Promise<boolean> {
   const raw = await settings.get(EXTERNAL_TOOLS_ENABLED_SETTING_KEY);
   // Default ON so web search is available once a provider API key is configured.
   if (raw == null) return true;
@@ -239,7 +235,7 @@ export async function getExternalToolsEnabled(settings: IntegrationSettingsStore
 }
 
 export async function setExternalToolsEnabled(
-  settings: IntegrationSettingsStore,
+  settings: SettingsWriter,
   enabled: boolean,
 ): Promise<void> {
   await settings.set(EXTERNAL_TOOLS_ENABLED_SETTING_KEY, enabled ? "1" : "0");

--- a/src/storage/local/settings-store.ts
+++ b/src/storage/local/settings-store.ts
@@ -8,7 +8,27 @@
 import { Store } from "./store.js";
 import type { StoreConfig } from "./types.js";
 
-export class SettingsStore extends Store {
+/**
+ * Read side of the settings bag. Settings are a key-value bag written by many
+ * features, so a read is `unknown` by contract: the feature that owns the key
+ * parses it at this seam. Features depend on this contract rather than the
+ * class so tests can pass an in-memory store.
+ */
+export interface SettingsReader {
+  get(key: string): Promise<unknown>;
+}
+
+/** Read and write side of the settings bag. */
+export interface SettingsWriter extends SettingsReader {
+  set(key: string, value: unknown): Promise<void>;
+}
+
+/** Full access to the settings bag, including key removal. */
+export interface SettingsAccess extends SettingsWriter {
+  delete(key: string): Promise<void>;
+}
+
+export class SettingsStore extends Store implements SettingsAccess {
   getConfig(): StoreConfig {
     return {
       name: "settings",
@@ -16,11 +36,11 @@ export class SettingsStore extends Store {
     };
   }
 
-  async get<T = unknown>(key: string): Promise<T | null> {
-    return this.getBackend().get<T>("settings", key);
+  async get(key: string): Promise<unknown> {
+    return this.getBackend().get<unknown>("settings", key);
   }
 
-  async set<T = unknown>(key: string, value: T): Promise<void> {
+  async set(key: string, value: unknown): Promise<void> {
     await this.getBackend().set("settings", key, value);
   }
 

--- a/src/taskpane/background-extension-verification.ts
+++ b/src/taskpane/background-extension-verification.ts
@@ -2,7 +2,6 @@ import type { ConnectionManager } from "../connections/manager.js";
 import {
   loadConnectionStoreDocumentForUpdate,
   saveConnectionStoreDocument,
-  type ConnectionSettingsStore,
 } from "../connections/store.js";
 import {
   ALL_EXTENSION_CAPABILITIES,
@@ -21,6 +20,7 @@ import {
 import type { BrowserModelRuntime } from "../models/browser-model-runtime.js";
 import { getAppStorage } from "../storage/local/app-storage.js";
 import type { SessionRuntime } from "./session-runtime-manager.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 export const EXTENSION_VERIFICATION_COMMAND_TYPES = [
   "assertLastAssistantText",
@@ -294,7 +294,7 @@ function setExperiment(payload: unknown): JsonRecord {
 
 export async function stageInlineExtensionUpgrade(
   payload: unknown,
-  settings: ConnectionSettingsStore = getAppStorage().settings,
+  settings: SettingsWriter = getAppStorage().settings,
 ): Promise<JsonRecord> {
   const extensionId = stringField(payload, "extensionId");
   const code = stringField(payload, "code");

--- a/src/taskpane/proxy-status.ts
+++ b/src/taskpane/proxy-status.ts
@@ -6,6 +6,7 @@
  */
 
 import { DEFAULT_PROXY_URL, normalizeProxyUrl } from "../auth/proxy-validation.js";
+import type { SettingsReader } from "../storage/local/settings-store.js";
 
 const CHECK_INTERVAL_MS = 30_000;
 const CHECK_TIMEOUT_MS = 1_500;
@@ -41,14 +42,10 @@ function dispatchProxyStateChanged(state: ProxyState): void {
   document.dispatchEvent(new CustomEvent("pi:proxy-state-changed", { detail: { state } }));
 }
 
-interface ProxySettingsReader {
-  get<T>(key: string): Promise<T | null>;
-}
-
-export async function checkProxyOnce(settings: ProxySettingsReader): Promise<ProxyState> {
+export async function checkProxyOnce(settings: SettingsReader): Promise<ProxyState> {
   let proxyUrl: string = DEFAULT_PROXY_URL;
   try {
-    const raw = await settings.get<string>("proxy.url");
+    const raw = await settings.get("proxy.url");
     const stored = typeof raw === "string" ? raw.trim() : "";
     if (stored.length > 0) {
       proxyUrl = stored;
@@ -68,7 +65,7 @@ export async function checkProxyOnce(settings: ProxySettingsReader): Promise<Pro
   return newState;
 }
 
-export function startProxyPolling(settings: ProxySettingsReader): () => void {
+export function startProxyPolling(settings: SettingsReader): () => void {
   void checkProxyOnce(settings);
 
   intervalId = setInterval(() => {

--- a/src/taskpane/settings.ts
+++ b/src/taskpane/settings.ts
@@ -4,18 +4,11 @@ import {
 } from "../auth/proxy-validation.js";
 import type { SpreadsheetHostKind } from "../host/index.js";
 import type { SupportedLanguage } from "../language/index.js";
+import type { SettingsReader, SettingsWriter } from "../storage/local/settings-store.js";
 
 export const TASKPANE_LANGUAGE_SETTING_KEY = "language";
 export const TASKPANE_PROXY_ENABLED_SETTING_KEY = "proxy.enabled";
 export const TASKPANE_PROXY_URL_SETTING_KEY = "proxy.url";
-
-export interface TaskpaneSettingsStore {
-  get(key: string): Promise<unknown>;
-}
-
-interface WritableTaskpaneSettingsStore extends TaskpaneSettingsStore {
-  set(key: string, value: unknown): Promise<void>;
-}
 
 export interface TaskpaneProxySettings {
   enabled: boolean;
@@ -34,7 +27,7 @@ function parseProxyEnabled(value: unknown): boolean {
  * cannot be read. Persisted values retain their existing string format.
  */
 export async function readTaskpaneLanguage(
-  settings: TaskpaneSettingsStore,
+  settings: SettingsReader,
 ): Promise<SupportedLanguage> {
   try {
     const value = await settings.get(TASKPANE_LANGUAGE_SETTING_KEY);
@@ -53,7 +46,7 @@ export async function readTaskpaneLanguage(
  * for persisted non-boolean values.
  */
 export async function readTaskpaneProxySettings(
-  settings: TaskpaneSettingsStore,
+  settings: SettingsReader,
 ): Promise<TaskpaneProxySettings> {
   const [enabled, url] = await Promise.all([
     settings.get(TASKPANE_PROXY_ENABLED_SETTING_KEY),
@@ -67,7 +60,7 @@ export async function readTaskpaneProxySettings(
 }
 
 export async function ensureDefaultProxyUrl(
-  settings: WritableTaskpaneSettingsStore,
+  settings: SettingsWriter,
   hostKind: SpreadsheetHostKind,
 ): Promise<void> {
   try {

--- a/src/tools/bridge-service-utils.ts
+++ b/src/tools/bridge-service-utils.ts
@@ -46,7 +46,7 @@ export async function getBridgeSetting(settingKey: string): Promise<string | und
   try {
     const storageModule = await import("../storage/local/app-storage.js");
     const storage = storageModule.getAppStorage();
-    const value = await storage.settings.get<string>(settingKey);
+    const value = await storage.settings.get(settingKey);
     if (typeof value !== "string") {
       return undefined;
     }

--- a/src/tools/external-fetch.ts
+++ b/src/tools/external-fetch.ts
@@ -7,10 +7,7 @@ import {
   DEFAULT_PROXY_URL,
   validateOfficeProxyUrl,
 } from "../auth/proxy-validation.js";
-
-export interface ProxyAwareSettingsStore {
-  get(key: string): Promise<unknown>;
-}
+import type { SettingsReader } from "../storage/local/settings-store.js";
 
 export interface ResolvedOutboundRequest {
   requestUrl: string;
@@ -29,7 +26,7 @@ function parseEnabledFlag(value: unknown): boolean {
 }
 
 export async function getEnabledProxyBaseUrl(
-  settings: ProxyAwareSettingsStore,
+  settings: SettingsReader,
 ): Promise<string | undefined> {
   try {
     const enabledRaw = await settings.get("proxy.enabled");

--- a/src/tools/fetch-page.ts
+++ b/src/tools/fetch-page.ts
@@ -7,12 +7,12 @@ import { Type, type Static, type TSchema } from "typebox";
 
 import { getErrorMessage } from "../utils/errors.js";
 import { runWithTimeoutAbort } from "../utils/network.js";
+import type { SettingsReader } from "../storage/local/settings-store.js";
 import {
   buildProxyDownErrorMessage,
   getEnabledProxyBaseUrl,
   isLikelyProxyConnectionError,
   resolveOutboundRequestUrl,
-  type ProxyAwareSettingsStore,
 } from "./external-fetch.js";
 
 const FETCH_PAGE_TIMEOUT_MS = 15_000;
@@ -321,7 +321,7 @@ function enforceDomainRateLimit(hostname: string, now: number): void {
 
 async function defaultGetConfig(): Promise<FetchPageToolConfig> {
   const storageModule = await import("../storage/local/app-storage.js");
-  const settings: ProxyAwareSettingsStore = storageModule.getAppStorage().settings;
+  const settings: SettingsReader = storageModule.getAppStorage().settings;
   const proxyBaseUrl = await getEnabledProxyBaseUrl(settings);
   return {
     ...proxyBaseUrlArg(proxyBaseUrl),

--- a/src/tools/mcp-config.ts
+++ b/src/tools/mcp-config.ts
@@ -12,17 +12,13 @@ import {
   saveConnectionStoreDocument,
   type StoredConnectionRecord,
 } from "../connections/store.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 export const MCP_SERVERS_SETTING_KEY = "mcp.servers.v1";
 const MCP_SERVERS_DOC_VERSION = 1;
 
 /** Connection-store record for MCP server bearer tokens keyed by server id. */
 export const MCP_SERVER_TOKENS_CONNECTION_ID = "builtin.mcp.servers";
-
-export interface McpConfigStore {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
-}
 
 export interface McpServerConfig {
   id: string;
@@ -224,7 +220,7 @@ function areTokenMapsEqual(left: Readonly<Record<string, string>>, right: Readon
   return JSON.stringify(normalizeTokenMap(left)) === JSON.stringify(normalizeTokenMap(right));
 }
 
-async function loadLegacyMcpServers(settings: McpConfigStore): Promise<McpServerConfig[]> {
+async function loadLegacyMcpServers(settings: SettingsWriter): Promise<McpServerConfig[]> {
   try {
     return normalizeServers(await settings.get(MCP_SERVERS_SETTING_KEY));
   } catch {
@@ -232,7 +228,7 @@ async function loadLegacyMcpServers(settings: McpConfigStore): Promise<McpServer
   }
 }
 
-async function loadLegacyMcpServersForUpdate(settings: McpConfigStore): Promise<McpServerConfig[]> {
+async function loadLegacyMcpServersForUpdate(settings: SettingsWriter): Promise<McpServerConfig[]> {
   return normalizeServers(await settings.get(MCP_SERVERS_SETTING_KEY));
 }
 
@@ -243,19 +239,19 @@ function readConnectionStoreMcpTokens(
 }
 
 async function loadConnectionStoreMcpTokens(
-  settings: McpConfigStore,
+  settings: SettingsWriter,
 ): Promise<Record<string, string>> {
   return readConnectionStoreMcpTokens(await loadConnectionStoreDocument(settings));
 }
 
 async function loadConnectionStoreMcpTokensForUpdate(
-  settings: McpConfigStore,
+  settings: SettingsWriter,
 ): Promise<Record<string, string>> {
   return readConnectionStoreMcpTokens(await loadConnectionStoreDocumentForUpdate(settings));
 }
 
 async function writeConnectionStoreMcpTokens(
-  settings: McpConfigStore,
+  settings: SettingsWriter,
   tokensByServerId: Readonly<Record<string, string>>,
 ): Promise<void> {
   const normalizedTokens = normalizeTokenMap(tokensByServerId);
@@ -304,7 +300,7 @@ function mergeServersWithConnectionTokens(args: {
 }
 
 export async function migrateLegacyMcpTokensToConnectionStore(
-  settings: McpConfigStore,
+  settings: SettingsWriter,
 ): Promise<boolean> {
   const [legacyServers, connectionTokens] = await Promise.all([
     loadLegacyMcpServersForUpdate(settings),
@@ -335,7 +331,7 @@ export async function migrateLegacyMcpTokensToConnectionStore(
   return true;
 }
 
-export async function loadMcpServers(settings: McpConfigStore): Promise<McpServerConfig[]> {
+export async function loadMcpServers(settings: SettingsWriter): Promise<McpServerConfig[]> {
   const [legacyServers, connectionTokens] = await Promise.all([
     loadLegacyMcpServers(settings),
     loadConnectionStoreMcpTokens(settings),
@@ -348,7 +344,7 @@ export async function loadMcpServers(settings: McpConfigStore): Promise<McpServe
 }
 
 export async function saveMcpServers(
-  settings: McpConfigStore,
+  settings: SettingsWriter,
   servers: readonly McpServerConfig[],
 ): Promise<void> {
   const normalized = uniqueById(normalizeServers(servers));

--- a/src/tools/mcp.ts
+++ b/src/tools/mcp.ts
@@ -16,17 +16,16 @@ import {
   getHttpErrorReason,
   runWithTimeoutAbort,
 } from "../utils/network.js";
-import type { ProxyAwareSettingsStore } from "./external-fetch.js";
 import {
   buildProxyDownErrorMessage,
   getEnabledProxyBaseUrl,
   isLikelyProxyConnectionError,
   resolveOutboundRequestUrl,
 } from "./external-fetch.js";
+import type { SettingsReader, SettingsWriter } from "../storage/local/settings-store.js";
 import {
   loadMcpServers,
   type McpServerConfig,
-  type McpConfigStore,
 } from "./mcp-config.js";
 
 const MCP_CLIENT_NAME = APP_NAME;
@@ -333,8 +332,8 @@ function matchesSearch(tool: McpToolDescriptor, query: string): boolean {
 async function defaultGetRuntimeConfig(): Promise<McpRuntimeConfig> {
   const storageModule = await import("../storage/local/app-storage.js");
   const settingsStore = storageModule.getAppStorage().settings;
-  const configStore: McpConfigStore = settingsStore;
-  const proxyStore: ProxyAwareSettingsStore = settingsStore;
+  const configStore: SettingsWriter = settingsStore;
+  const proxyStore: SettingsReader = settingsStore;
 
   const [servers, proxyBaseUrl] = await Promise.all([
     loadMcpServers(configStore),

--- a/src/tools/python-run.ts
+++ b/src/tools/python-run.ts
@@ -219,14 +219,14 @@ export async function getDefaultPythonBridgeConfig(): Promise<PythonBridgeConfig
   try {
     const settings = await getSettingsStore();
 
-    const urlValue = await settings.get<string>(PYTHON_BRIDGE_URL_SETTING_KEY);
+    const urlValue = await settings.get(PYTHON_BRIDGE_URL_SETTING_KEY);
     const configuredUrl = typeof urlValue === "string" ? urlValue.trim() : "";
     if (configuredUrl.length > 0) {
       rawUrl = configuredUrl;
       source = "configured";
     }
 
-    const tokenValue = await settings.get<string>(PYTHON_BRIDGE_TOKEN_SETTING_KEY);
+    const tokenValue = await settings.get(PYTHON_BRIDGE_TOKEN_SETTING_KEY);
     token = typeof tokenValue === "string" && tokenValue.trim().length > 0
       ? tokenValue.trim()
       : undefined;

--- a/src/tools/tmux.ts
+++ b/src/tools/tmux.ts
@@ -356,13 +356,13 @@ async function defaultGetBridgeConfig(): Promise<TmuxBridgeConfig | null> {
     const storageModule = await import("../storage/local/app-storage.js");
     const settings = storageModule.getAppStorage().settings;
 
-    const urlValue = await settings.get<string>(TMUX_BRIDGE_URL_SETTING_KEY);
+    const urlValue = await settings.get(TMUX_BRIDGE_URL_SETTING_KEY);
     const configuredUrl = typeof urlValue === "string" ? urlValue.trim() : "";
     if (configuredUrl.length > 0) {
       rawUrl = configuredUrl;
     }
 
-    const tokenValue = await settings.get<string>(TMUX_BRIDGE_TOKEN_SETTING_KEY);
+    const tokenValue = await settings.get(TMUX_BRIDGE_TOKEN_SETTING_KEY);
     token = typeof tokenValue === "string" && tokenValue.trim().length > 0
       ? tokenValue.trim()
       : undefined;

--- a/src/tools/web-search-config.ts
+++ b/src/tools/web-search-config.ts
@@ -8,6 +8,7 @@ import {
   saveConnectionStoreDocument,
   type StoredConnectionRecord,
 } from "../connections/store.js";
+import type { SettingsAccess, SettingsReader } from "../storage/local/settings-store.js";
 
 export const WEB_SEARCH_PROVIDER_SETTING_KEY = "web.search.provider";
 export const WEB_SEARCH_BRAVE_API_KEY_SETTING_KEY = "web.search.brave.apiKey";
@@ -108,15 +109,6 @@ const WEB_SEARCH_CONNECTION_SECRET_FIELD_BY_PROVIDER: Record<WebSearchProvider, 
   brave: "brave_api_key",
 };
 
-export interface WebSearchConfigReader {
-  get(key: string): Promise<unknown>;
-}
-
-export interface WebSearchConfigStore extends WebSearchConfigReader {
-  set(key: string, value: unknown): Promise<void>;
-  delete?(key: string): Promise<void>;
-}
-
 export interface WebSearchProviderConfig {
   provider: WebSearchProvider;
   apiKeys: Partial<Record<WebSearchProvider, string>>;
@@ -151,7 +143,7 @@ function setApiKeyIfPresent(
 }
 
 async function readWebSearchSetting(
-  settings: WebSearchConfigReader,
+  settings: SettingsReader,
   key: string,
 ): Promise<unknown> {
   try {
@@ -172,7 +164,7 @@ function parseLegacyWebSearchApiKeys(
 }
 
 async function loadLegacyWebSearchApiKeys(
-  settings: WebSearchConfigReader,
+  settings: SettingsReader,
 ): Promise<Partial<Record<WebSearchProvider, string>>> {
   const values = await Promise.all(WEB_SEARCH_PROVIDERS.map((provider) =>
     readWebSearchSetting(settings, WEB_SEARCH_API_KEY_BY_PROVIDER_SETTING_KEY[provider])));
@@ -180,7 +172,7 @@ async function loadLegacyWebSearchApiKeys(
 }
 
 async function loadLegacyWebSearchApiKeysForUpdate(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
 ): Promise<Partial<Record<WebSearchProvider, string>>> {
   const values = await Promise.all(WEB_SEARCH_PROVIDERS.map((provider) =>
     settings.get(WEB_SEARCH_API_KEY_BY_PROVIDER_SETTING_KEY[provider])));
@@ -202,19 +194,19 @@ function readConnectionStoreWebSearchApiKeys(
 }
 
 async function loadConnectionStoreWebSearchApiKeys(
-  settings: WebSearchConfigReader,
+  settings: SettingsReader,
 ): Promise<Partial<Record<WebSearchProvider, string>>> {
   return readConnectionStoreWebSearchApiKeys(await loadConnectionStoreDocument(settings));
 }
 
 async function loadConnectionStoreWebSearchApiKeysForUpdate(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
 ): Promise<Partial<Record<WebSearchProvider, string>>> {
   return readConnectionStoreWebSearchApiKeys(await loadConnectionStoreDocumentForUpdate(settings));
 }
 
 async function loadWebSearchApiKeysForUpdate(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
 ): Promise<Partial<Record<WebSearchProvider, string>>> {
   const [connectionApiKeys, legacyApiKeys] = await Promise.all([
     loadConnectionStoreWebSearchApiKeysForUpdate(settings),
@@ -242,7 +234,7 @@ function mergeApiKeys(args: {
 
 
 async function writeConnectionStoreWebSearchApiKeys(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   apiKeys: Partial<Record<WebSearchProvider, string>>,
 ): Promise<void> {
   const items = await loadConnectionStoreDocumentForUpdate(settings);
@@ -278,21 +270,14 @@ async function writeConnectionStoreWebSearchApiKeys(
 }
 
 async function clearLegacyWebSearchApiKey(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   provider: WebSearchProvider,
 ): Promise<void> {
-  const key = WEB_SEARCH_API_KEY_BY_PROVIDER_SETTING_KEY[provider];
-
-  if (typeof settings.delete === "function") {
-    await settings.delete(key);
-    return;
-  }
-
-  await settings.set(key, "");
+  await settings.delete(WEB_SEARCH_API_KEY_BY_PROVIDER_SETTING_KEY[provider]);
 }
 
 export async function migrateLegacyWebSearchApiKeysToConnectionStore(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
 ): Promise<boolean> {
   const [legacyApiKeys, connectionApiKeys] = await Promise.all([
     loadLegacyWebSearchApiKeysForUpdate(settings),
@@ -326,7 +311,7 @@ export async function migrateLegacyWebSearchApiKeysToConnectionStore(
 }
 
 export async function loadWebSearchProviderConfig(
-  settings: WebSearchConfigReader,
+  settings: SettingsReader,
 ): Promise<WebSearchProviderConfig> {
   const [providerRaw, connectionApiKeys, legacyApiKeys] = await Promise.all([
     readWebSearchSetting(settings, WEB_SEARCH_PROVIDER_SETTING_KEY),
@@ -352,14 +337,14 @@ export async function loadWebSearchProviderConfig(
 }
 
 export async function saveWebSearchProvider(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   provider: WebSearchProvider,
 ): Promise<void> {
   await settings.set(WEB_SEARCH_PROVIDER_SETTING_KEY, provider);
 }
 
 export async function saveWebSearchApiKey(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   provider: WebSearchProvider,
   apiKey: string,
 ): Promise<void> {
@@ -379,7 +364,7 @@ export async function saveWebSearchApiKey(
 }
 
 export async function clearWebSearchApiKey(
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   provider: WebSearchProvider,
 ): Promise<void> {
   const currentApiKeys = await loadWebSearchApiKeysForUpdate(settings);

--- a/src/tools/web-search-setup-detection.ts
+++ b/src/tools/web-search-setup-detection.ts
@@ -5,11 +5,11 @@ import {
   isApiKeyRequired,
   loadWebSearchProviderConfig,
   WEB_SEARCH_PROVIDERS,
-  type WebSearchConfigStore,
   type WebSearchProvider,
   type WebSearchProviderConfig,
 } from "./web-search-config.js";
 import type { WebSearchDetails } from "./tool-details.js";
+import type { SettingsAccess } from "../storage/local/settings-store.js";
 
 export type WebSearchSetupMode =
   | { type: "needs_key" }
@@ -53,7 +53,7 @@ function findAlternativeProvider(
 
 export async function detectWebSearchSetupContext(
   details: WebSearchDetails,
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   deps?: WebSearchSetupDetectionDeps,
 ): Promise<WebSearchSetupContext> {
   const [providerConfig, proxyBaseUrl] = await Promise.all([

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -21,7 +21,6 @@ import {
   getEnabledProxyBaseUrl,
   isLikelyProxyConnectionError,
   resolveOutboundRequestUrl,
-  type ProxyAwareSettingsStore,
 } from "./external-fetch.js";
 import {
   getApiKeyForProvider,
@@ -32,6 +31,7 @@ import {
   type WebSearchProviderInfo,
   WEB_SEARCH_PROVIDER_INFO,
 } from "./web-search-config.js";
+import type { SettingsReader } from "../storage/local/settings-store.js";
 
 const WEB_SEARCH_TIMEOUT_MS = 12_000;
 
@@ -669,7 +669,7 @@ function buildResultMarkdown(args: {
 
 async function defaultGetConfig(): Promise<WebSearchToolConfig> {
   const storageModule = await import("../storage/local/app-storage.js");
-  const settings: ProxyAwareSettingsStore = storageModule.getAppStorage().settings;
+  const settings: SettingsReader = storageModule.getAppStorage().settings;
 
   const [providerConfig, proxyBaseUrl] = await Promise.all([
     loadWebSearchProviderConfig(settings),

--- a/src/ui/web-search-setup-card.ts
+++ b/src/ui/web-search-setup-card.ts
@@ -20,7 +20,6 @@ import {
   checkApiKeyFormat,
   saveWebSearchApiKey,
   WEB_SEARCH_PROVIDER_INFO,
-  type WebSearchConfigStore,
   type WebSearchProvider,
 } from "../tools/web-search-config.js";
 import { isWebSearchDetails, type WebSearchDetails } from "../tools/tool-details.js";
@@ -29,6 +28,7 @@ import { createCopyableCommand } from "./command-copy.js";
 import { AlertTriangle, Search, lucide } from "./lucide-icons.js";
 import { showToast } from "./toast.js";
 import { t } from "../language/index.js";
+import type { SettingsAccess } from "../storage/local/settings-store.js";
 
 const PROXY_COMMAND = "npx pi-for-excel-proxy";
 
@@ -111,7 +111,7 @@ function createProxyStep(options: ProxyStepOptions): HTMLDivElement {
 function createKeyStep(
   provider: WebSearchProvider,
   stepNumber: number | null,
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   proxyBaseUrl: string | undefined,
   onSaved: () => void,
 ): HTMLDivElement {
@@ -219,7 +219,7 @@ function createKeyStep(
 
 function buildCardContent(
   context: WebSearchSetupContext,
-  settings: WebSearchConfigStore,
+  settings: SettingsAccess,
   onDismiss: () => void,
 ): { title: string; body: DocumentFragment } {
   const body = document.createDocumentFragment();

--- a/src/workbook/recovery-log.ts
+++ b/src/workbook/recovery-log.ts
@@ -24,7 +24,6 @@ import {
 import {
   defaultGetSettingsStore,
   readPersistedWorkbookRecoveryPayload,
-  type SettingsStoreLike,
   writePersistedWorkbookRecoveryPayload,
 } from "./recovery/log-store.js";
 import {
@@ -56,6 +55,7 @@ import {
 } from "./recovery/grid.js";
 import { estimateModifyStructureCellCount } from "./recovery/structure-state.js";
 import { MAX_RECOVERY_CELLS, MAX_RECOVERY_ENTRIES } from "./recovery/constants.js";
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 export { MAX_RECOVERY_CELLS };
 
@@ -168,8 +168,8 @@ interface WorkbookRangeState {
 }
 
 interface WorkbookRecoveryLogDependencies {
-  settings: SettingsStoreLike | null;
-  getSettingsStore: () => Promise<SettingsStoreLike | null>;
+  settings: SettingsWriter | null;
+  getSettingsStore: () => Promise<SettingsWriter | null>;
   getWorkbookContext: () => Promise<WorkbookContext>;
   getDocumentInstance: () => DocumentInstanceIdentity | null;
   now: () => number;

--- a/src/workbook/recovery/log-store.ts
+++ b/src/workbook/recovery/log-store.ts
@@ -11,15 +11,11 @@ import {
   MAX_RECOVERY_ENTRIES,
   RETENTION_LIMIT_SETTING_KEY,
 } from "./constants.js";
+import type { SettingsWriter } from "../../storage/local/settings-store.js";
 
 export const RECOVERY_SETTING_KEY = "workbook.recovery-snapshots.v1";
 
-export interface SettingsStoreLike {
-  get<T>(key: string): Promise<T | null>;
-  set(key: string, value: unknown): Promise<void>;
-}
-
-function isSettingsStoreLike(value: unknown): value is SettingsStoreLike {
+function isSettingsStoreLike(value: unknown): value is SettingsWriter {
   if (!isWorkbookRecoveryLogStorePayloadShape(value)) return false;
 
   return (
@@ -28,7 +24,7 @@ function isSettingsStoreLike(value: unknown): value is SettingsStoreLike {
   );
 }
 
-export async function defaultGetSettingsStore(): Promise<SettingsStoreLike | null> {
+export async function defaultGetSettingsStore(): Promise<SettingsWriter | null> {
   try {
     const storageModule = await import("../../storage/local/app-storage.js");
     const appStorage = storageModule.getAppStorage();
@@ -40,17 +36,17 @@ export async function defaultGetSettingsStore(): Promise<SettingsStoreLike | nul
 }
 
 export async function readPersistedWorkbookRecoveryPayload(
-  settings: SettingsStoreLike | null,
+  settings: SettingsWriter | null,
 ): Promise<unknown> {
   if (!settings) {
     return null;
   }
 
-  return settings.get<unknown>(RECOVERY_SETTING_KEY);
+  return settings.get(RECOVERY_SETTING_KEY);
 }
 
 export async function writePersistedWorkbookRecoveryPayload(
-  settings: SettingsStoreLike | null,
+  settings: SettingsWriter | null,
   payload: unknown,
 ): Promise<void> {
   if (!settings) {
@@ -73,7 +69,7 @@ export async function readRetentionLimit(): Promise<number> {
   if (!settings) return MAX_RECOVERY_ENTRIES;
 
   try {
-    const raw = await settings.get<unknown>(RETENTION_LIMIT_SETTING_KEY);
+    const raw = await settings.get(RETENTION_LIMIT_SETTING_KEY);
     return clampRetentionLimit(raw);
   } catch {
     return MAX_RECOVERY_ENTRIES;

--- a/src/workbook/session-association.ts
+++ b/src/workbook/session-association.ts
@@ -5,10 +5,7 @@
  * in `SettingsStore` using a dedicated key prefix.
  */
 
-export interface SessionAssociationSettingsStore {
-  get(key: string): Promise<unknown>;
-  set(key: string, value: unknown): Promise<void>;
-}
+import type { SettingsWriter } from "../storage/local/settings-store.js";
 
 const SESSION_WORKBOOK_PREFIX = "session.workbook.v1.";
 const WORKBOOK_LATEST_SESSION_PREFIX = "workbook.latestSession.v1.";
@@ -22,7 +19,7 @@ export function workbookLatestSessionKey(workbookId: string): string {
 }
 
 export async function getSessionWorkbookId(
-  settings: SessionAssociationSettingsStore,
+  settings: SettingsWriter,
   sessionId: string,
 ): Promise<string | null> {
   const value = await settings.get(sessionWorkbookKey(sessionId));
@@ -36,7 +33,7 @@ export async function getSessionWorkbookId(
  * workbook won't accidentally "move" it).
  */
 export async function linkSessionToWorkbook(
-  settings: SessionAssociationSettingsStore,
+  settings: SettingsWriter,
   sessionId: string,
   workbookId: string,
 ): Promise<void> {
@@ -47,7 +44,7 @@ export async function linkSessionToWorkbook(
 }
 
 export async function setLatestSessionForWorkbook(
-  settings: SessionAssociationSettingsStore,
+  settings: SettingsWriter,
   workbookId: string,
   sessionId: string,
 ): Promise<void> {
@@ -55,7 +52,7 @@ export async function setLatestSessionForWorkbook(
 }
 
 export async function getLatestSessionForWorkbook(
-  settings: SessionAssociationSettingsStore,
+  settings: SettingsWriter,
   workbookId: string,
 ): Promise<string | null> {
   const value = await settings.get(workbookLatestSessionKey(workbookId));
@@ -76,7 +73,7 @@ export interface SessionWorkbookPartition {
  * - `foreignSessionIds`: linked to another workbook
  */
 export async function partitionSessionIdsByWorkbook(
-  settings: SessionAssociationSettingsStore,
+  settings: SettingsWriter,
   sessionIds: string[],
   workbookId: string,
 ): Promise<SessionWorkbookPartition> {


### PR DESCRIPTION
Types migration, "Caller-selected `get<T>()`" item from `docs/clean-base-followups.md`. Independent of #720 / #721 (based on `main`; the only overlap is the ratchet number in `scripts/check-unknown-burndown.mjs`).

## What changes

- **`SettingsStore.get(key)` returns `unknown`.** The generic `get<T>()` let a caller pick a type the IndexedDB backend then asserted. Every caller already `typeof`-checked or `=== true`-checked the value, so dropping the generic changes no behaviour; it removes the way to skip the check. `set` likewise takes `unknown` rather than a caller-chosen `T`.
- **One settings contract.** 17 modules had redeclared `{ get, set?, delete? }` structurally so tests could pass in-memory stores (`SettingsStoreLike` ×2, `IntegrationSettingsStore`, `ExtensionSettingsStore`, `OAuthSettingsStore`, `CorsProxySettingsReader`, `WebSearchConfigStore`, `McpConfigStore`, `ConnectionSettingsStore`, …). They now take `SettingsReader` (get), `SettingsWriter` (get+set) or `SettingsAccess` (get+set+delete) exported from `src/storage/local/settings-store.ts`, which `SettingsStore implements`. Each module takes the narrowest one it uses.
- **Optional `delete?` is gone.** `WebSearchConfigStore` and `ConnectionSettingsStore` declared `delete?` and two call sites branched `typeof settings.delete === "function" ? delete : set(key, "")`. The real store has `delete`; the branch only served hypothetical fakes (every test fake defines `delete`). Clearing a legacy web-search API key or a bridge URL now always deletes the key.
- `docs/coding-standards.md` gains one line: take settings as the shared contract, do not redeclare the shape. `docs/clean-base-followups.md` marks the item done with a probe.

**Numbers:** ratchet 461 → **439** (returns 77 → 66, parameters 384 → 373). Bundle unchanged (types only; same chunk hash).

## Tests

No new tests: nothing observable through the real store changes, and a test that a method lacks a type parameter is not expressible at runtime (`tests/` is not typechecked). The guards are `npm run check` (tsc + lint) and the lowered ratchet. `npm test` **773 pass**, `npm run test:context` **607 pass** (`tests/storage-ownership-contract.test.ts` covers the feature-owned readers through the same contract), `npm run build` clean.

## Real Excel

Not applicable as a behaviour gate: the change is type-level plus the two `delete` branches, whose real-store path is unchanged. The background Excel lane is still blocked (ribbon button absent after relaunch, and today the accessibility tree returned the application as its own window; both recorded as papercuts).
