### PR TITLE
excel-background-verification: open the pane without the foreground; read persisted settings independently

### DIFF
--- a/.agents/skills/excel-background-verification/SKILL.md
+++ b/.agents/skills/excel-background-verification/SKILL.md
@@ -51,7 +51,24 @@ Excel opens the pane on document open and the `Open Pi` ribbon button appears fo
 
 If `clients` is still empty, inspect Excel with `computer_use` / `sky.get_app_state`. Check the workbook, pane, manifest URL and server before changing caches. For a pane showing a network error, use a semantic accessibility `AXPress` on Try Again after starting the server.
 
-Use background semantic accessibility actions only. If an action requires foreground focus or raw keyboard/mouse input, report the blocker. Record the foreground app and window before and after the test.
+Use background semantic accessibility actions only. Record the foreground app and window before and after the test.
+
+### Before you call it blocked
+
+Everything below has looked like a foreground-only step and was worked around in the background. Report a blocker only after these are exhausted, and say which one you hit.
+
+| Looks like | Is | Do |
+|---|---|---|
+| No `Open Pi` button on the ribbon after Excel relaunched; manifest is intact | Sideloaded add-ins are absent from the ribbon cache until activated once per Excel process | `scratch-workbook.py create` and `open -g` into it; the pane opens from the document and the button appears |
+| Home-tab *Add-ins* flyout does not open (AXPress toggles the button, no popover window) | It does not render for a background app | Not needed; use the document bootstrap above |
+| `sky.get_app_state` fails with `cgWindowNotFound`, or Excel lists `AXApplication` as its only window | Seen once right after `open -g` with no document | Wait for the launch to settle and query again; otherwise quit Excel and `open -g` straight into the scratch workbook, which exposed a normal `AXStandardWindow` |
+| `computer_use` click does nothing | `element_index` was passed as a number | Pass it as a string, e.g. `"63"` |
+| `setTimeout is not defined` inside `computer_use` | The JS sandbox has no timers | Sequence `sky` calls with `await`; wait in the shell (`sleep`) between calls |
+| AppleScript `save workbook as` returns `Parameter error (-50)` | Path built from `POSIX path of (path to home folder)` | Pass a literal absolute path string, inside the Excel container |
+| Pane cannot be reloaded after switching the Vite worktree | The document auto-open fires once per process | `Close Pi for Excel` then `Open Pi` through `computer_use` |
+| Persisted state cannot be checked without trusting the pane | It can | `read-taskpane-setting.py <key>` decodes the record from WebKit's IndexedDB |
+
+Opening a workbook does not activate Excel: both `open -g -a "Microsoft Excel" <file>` and `osascript -e 'tell application "Microsoft Excel" to open POSIX file "…"'` leave the frontmost app unchanged.
 
 ## Run the test
 

--- a/.agents/skills/excel-background-verification/SKILL.md
+++ b/.agents/skills/excel-background-verification/SKILL.md
@@ -11,7 +11,6 @@ Follow the acceptance policy in `docs/coding-standards.md`. The model performs t
 
 Run from the worktree containing the code under test. You need:
 
-- a scratch workbook open in Excel with the Pi taskpane loaded
 - the sideloaded manifest pointing to `https://localhost:3141/src/taskpane.html`
 - trusted `cert.pem` and `key.pem` files in the worktree
 - an approved current model with working authentication
@@ -35,9 +34,22 @@ VITE_PID=$!
 curl --fail https://localhost:3157/health
 ```
 
-Wait for server readiness before probing. Keep the bridge loopback-only and tokened; do not print or commit its token. Start `npm run proxy:https` if the configured provider route needs the local CORS proxy.
+Wait for server readiness before probing. Keep the bridge loopback-only and tokened; do not print or commit its token. Start `npm run proxy:https` if the configured provider route needs the local CORS proxy (the `openai-codex` route does).
 
-If `clients` is empty, inspect Excel with `computer_use` / `sky.get_app_state`. Check the workbook, pane, manifest URL and server before changing caches. For a pane showing a network error, use a semantic accessibility `AXPress` on Try Again after starting the server.
+### Open the pane without the foreground
+
+Excel for Mac does not put a sideloaded add-in on the ribbon until it has been activated once in the running process, and the Home-tab "Add-ins" flyout does not render for a background app. Bootstrap through the document instead: a workbook can carry an auto-open task pane part that references the sideloaded manifest (`store="developer" storeType="Registry"`).
+
+```bash
+SCRATCH=~/Library/Containers/com.microsoft.Excel/Data/Documents/pi-e2e-scratch.xlsx
+python3 .agents/skills/excel-background-verification/scripts/scratch-workbook.py create "$SCRATCH"
+open -g -a "Microsoft Excel" "$SCRATCH"      # launch straight into the workbook, in the background
+sleep 12; curl --fail https://localhost:3157/health   # expect one client
+```
+
+Excel opens the pane on document open and the `Open Pi` ribbon button appears for the rest of the process. The auto-open fires once per Excel process: to reload the pane (for example after switching the Vite worktree) press `Close Pi for Excel` and then `Open Pi` through `computer_use`, passing `element_index` as a string. Keep the scratch workbook inside the Excel container so the sandbox never raises a "Grant File Access" sheet; `scratch-workbook.py tag <existing.xlsx>` adds the part to a workbook Excel has saved.
+
+If `clients` is still empty, inspect Excel with `computer_use` / `sky.get_app_state`. Check the workbook, pane, manifest URL and server before changing caches. For a pane showing a network error, use a semantic accessibility `AXPress` on Try Again after starting the server.
 
 Use background semantic accessibility actions only. If an action requires foreground focus or raw keyboard/mouse input, report the blocker. Record the foreground app and window before and after the test.
 
@@ -84,7 +96,9 @@ bridge officeProbe
 
 | Symptom | Check |
 |---|---|
-| No bridge client | Workbook and Pi pane open; Vite URL and bridge environment configured |
+| No bridge client | Pane not open: bootstrap with `scratch-workbook.py` and `open -g` into the workbook, or press `Open Pi` on the ribbon if the add-in has been activated this process; Vite URL and bridge environment configured |
+| Pane does not auto-open from a second tagged workbook | Expected within one Excel process; press `Open Pi` instead, or quit and relaunch Excel into the workbook |
+| Pane opens as "New Office Add-in" with an add-in error or endless loading | The webextension reference does not resolve; keep `store="developer" storeType="Registry"` and the manifest `<Id>` |
 | Pane loads, model returns `Load failed` | Configured proxy is running and reachable |
 | Cannot set the WebKit textarea through accessibility | Submit through the bridge |
 | Unsaved workbook has no workbook ID | Identify it through the client and sheet/range evidence; `documentIdentityProbe` shows both host URL sources beside the resolved context |
@@ -92,6 +106,17 @@ bridge officeProbe
 | Model turn fails with `Importing a module script failed.` | `npm ci` ran under the live Vite server and wiped `node_modules/.vite/deps`; restart Vite and reload the pane |
 
 Use `officeProbe`, `readRange`, `readUsedRange` and `listCharts` for independent inspection. `workbookWriteProbe` is a reversible Office.js diagnostic, not a model test. `writeRange` and `clearRange` can prepare fixtures, but must not perform the work the model is meant to do. `configureProxy` changes saved settings; restore them after transport-specific tests.
+
+For anything the taskpane persists (recovery snapshots, files-workspace metadata and audit trail, settings), read the record straight out of Excel's WebKit IndexedDB rather than through the pane:
+
+```bash
+python3 .agents/skills/excel-background-verification/scripts/read-taskpane-setting.py --list
+python3 .agents/skills/excel-background-verification/scripts/read-taskpane-setting.py workbook.recovery-snapshots.v1
+```
+
+It copies the database and its WAL and decodes one record to JSON, so a before/after diff shows exactly which entries a change dropped, kept or rewrote.
+
+Rendered tool cards are visible in the pane's accessibility tree (`HTML content` under the `Pi for Excel` container), which is how to assert diff tables, trees and images. The dump truncates on long chats; scroll the `HTML content` element with `sky.scroll` or start a fresh chat with `submitInput` `{"text":"/new"}`. Slash commands such as `/new` and `/history` go through the real composer with `submitInput`; `submitPrompt` sends text to the model.
 
 ## Report and clean up
 

--- a/.agents/skills/excel-background-verification/scripts/read-taskpane-setting.py
+++ b/.agents/skills/excel-background-verification/scripts/read-taskpane-setting.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Read a persisted taskpane setting straight from Excel's WebKit IndexedDB.
+
+The taskpane stores settings in the `settings` object store of its IndexedDB
+database. Excel for Mac keeps that database at
+~/Library/Containers/com.microsoft.Excel/Data/Library/WebKit/WebsiteData/…/IndexedDB/…/IndexedDB.sqlite3
+(plus a WAL that holds the latest writes). This script copies the database files
+and decodes one record outside the app, so a verification run can assert what
+was persisted independently of the pane's own code.
+
+Usage:
+  read-taskpane-setting.py <key> [--list]
+
+Prints JSON. Records are WebKit SerializedScriptValue v15; the decoder covers
+the subset the settings store writes (objects, arrays, strings, numbers,
+booleans, null/undefined, dates) and the string constant pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+CONTAINER = Path.home() / "Library/Containers/com.microsoft.Excel/Data/Library/WebKit/WebsiteData/Default"
+SERIALIZATION_VERSION = 15
+STRING_POOL_MARKER = 0xFFFFFFFE
+TERMINATOR = 0xFFFFFFFF
+STRING_IS_8BIT = 0x80000000
+
+
+class Decoder:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.pos = 0
+        self.pool: list[str] = []
+
+    def u8(self) -> int:
+        value = self.data[self.pos]
+        self.pos += 1
+        return value
+
+    def u32(self) -> int:
+        value = struct.unpack_from("<I", self.data, self.pos)[0]
+        self.pos += 4
+        return value
+
+    def string(self, header: int) -> str:
+        if header == STRING_POOL_MARKER:
+            size = len(self.pool)
+            if size <= 0xFF:
+                index = self.u8()
+            elif size <= 0xFFFF:
+                index = struct.unpack_from("<H", self.data, self.pos)[0]
+                self.pos += 2
+            else:
+                index = self.u32()
+            return self.pool[index]
+        length = header & ~STRING_IS_8BIT
+        if header & STRING_IS_8BIT:
+            text = self.data[self.pos : self.pos + length].decode("latin-1")
+            self.pos += length
+        else:
+            text = self.data[self.pos : self.pos + length * 2].decode("utf-16-le")
+            self.pos += length * 2
+        self.pool.append(text)
+        return text
+
+    def properties(self, into: dict[str, object]) -> None:
+        while True:
+            header = self.u32()
+            if header == TERMINATOR:
+                return
+            name = self.string(header)
+            into[name] = self.value()
+
+    def value(self) -> object:
+        tag = self.u8()
+        if tag == 0x01:  # ArrayTag
+            out: list[object] = [None] * self.u32()
+            while True:
+                index = self.u32()
+                if index == TERMINATOR:
+                    break
+                out[index] = self.value()
+            self.properties({})
+            return out
+        if tag == 0x02:  # ObjectTag
+            obj: dict[str, object] = {}
+            self.properties(obj)
+            return obj
+        if tag in (0x03, 0x04):  # Undefined, Null
+            return None
+        if tag == 0x05:  # IntTag
+            value = struct.unpack_from("<i", self.data, self.pos)[0]
+            self.pos += 4
+            return value
+        if tag == 0x06:
+            return 0
+        if tag == 0x07:
+            return 1
+        if tag == 0x08:
+            return False
+        if tag == 0x09:
+            return True
+        if tag in (0x0A, 0x0B):  # Double, Date
+            value = struct.unpack_from("<d", self.data, self.pos)[0]
+            self.pos += 8
+            return value
+        if tag == 0x10:  # StringTag
+            return self.string(self.u32())
+        if tag == 0x11:  # EmptyStringTag
+            return ""
+        raise ValueError(f"unhandled serialization tag 0x{tag:02x} at offset {self.pos - 1}")
+
+
+def decode_key(raw: str | bytes) -> str:
+    data = raw.encode("latin-1") if isinstance(raw, str) else bytes(raw)
+    # WebKit IDB key: 0x00, type byte 0x60 (string), u32 length, UTF-16LE characters.
+    if len(data) >= 6 and data[1] == 0x60:
+        length = struct.unpack_from("<I", data, 2)[0]
+        return data[6 : 6 + length * 2].decode("utf-16-le")
+    return data.decode("latin-1")
+
+
+def copy_database() -> Path:
+    candidates = sorted(CONTAINER.glob("*/*/IndexedDB/*/IndexedDB.sqlite3"), key=lambda p: p.stat().st_mtime)
+    if not candidates:
+        sys.exit(f"no IndexedDB.sqlite3 under {CONTAINER}; has the taskpane run in Excel?")
+    source = candidates[-1]
+    scratch = Path(tempfile.mkdtemp(prefix="pi-idb-"))
+    for suffix in ("", "-wal", "-shm"):
+        candidate = source.with_name(source.name + suffix)
+        if candidate.exists():
+            shutil.copy2(candidate, scratch / candidate.name)
+    return scratch / source.name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("key", nargs="?")
+    parser.add_argument("--list", action="store_true", help="list setting keys instead of decoding one")
+    args = parser.parse_args()
+    if not args.key and not args.list:
+        parser.error("a key is required unless --list is given")
+
+    database = copy_database()
+    try:
+        connection = sqlite3.connect(database)
+        store = connection.execute("select id from ObjectStoreInfo where name = 'settings'").fetchone()
+        if store is None:
+            sys.exit("no `settings` object store in the taskpane database")
+        rows = connection.execute("select key, value from Records where objectStoreID = ?", (store[0],)).fetchall()
+    finally:
+        shutil.rmtree(database.parent, ignore_errors=True)
+
+    if args.list:
+        print(json.dumps(sorted(decode_key(key) for key, _ in rows), indent=1))
+        return
+
+    for key, value in rows:
+        if decode_key(key) != args.key:
+            continue
+        decoder = Decoder(bytes(value))
+        version = decoder.u32()
+        if version != SERIALIZATION_VERSION:
+            sys.exit(f"unexpected SerializedScriptValue version {version}")
+        print(json.dumps(decoder.value(), indent=1))
+        return
+    sys.exit(f"no setting named {args.key!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/excel-background-verification/scripts/scratch-workbook.py
+++ b/.agents/skills/excel-background-verification/scripts/scratch-workbook.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Create (or tag) a scratch workbook that opens the sideloaded Pi taskpane by itself.
+
+Excel for Mac does not put a sideloaded add-in on the ribbon until the add-in has
+been activated once in that Excel profile, and the Home-tab "Add-ins" flyout does
+not render for a background app. A workbook can carry an auto-open task pane part
+(`xl/webextensions`); when it references the sideloaded manifest with
+`store="developer" storeType="Registry"`, Excel opens the taskpane on document
+open without needing the foreground. After that first activation the "Open Pi"
+ribbon button exists and responds to a semantic AXPress.
+
+Usage:
+  scratch-workbook.py create <path.xlsx> [--addin-id ID]
+  scratch-workbook.py tag <existing.xlsx> [--addin-id ID]
+
+`create` writes a minimal one-sheet workbook plus the auto-open part. `tag` adds
+the part to an existing workbook in place. Save the workbook inside the Excel
+container (~/Library/Containers/com.microsoft.Excel/Data/Documents/) so the
+sandbox does not raise a "Grant File Access" sheet.
+
+The add-in ID defaults to the <Id> in the repository manifest.xml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import uuid
+import zipfile
+from pathlib import Path
+
+CONTENT_TYPES_OVERRIDES = (
+    '<Override PartName="/xl/webextensions/taskpanes.xml" '
+    'ContentType="application/vnd.ms-office.webextensiontaskpanes+xml"/>'
+    '<Override PartName="/xl/webextensions/webextension1.xml" '
+    'ContentType="application/vnd.ms-office.webextension+xml"/>'
+)
+ROOT_REL = (
+    '<Relationship Id="rIdPiTaskpanes" '
+    'Type="http://schemas.microsoft.com/office/2011/relationships/webextensiontaskpanes" '
+    'Target="xl/webextensions/taskpanes.xml"/>'
+)
+TASKPANES_XML = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<wetp:taskpanes xmlns:wetp="http://schemas.microsoft.com/office/webextensions/taskpanes/2010/11">'
+    '<wetp:taskpane dockstate="right" visibility="1" width="420" row="1">'
+    '<wetp:webextensionref xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId1"/>'
+    "</wetp:taskpane></wetp:taskpanes>"
+)
+TASKPANES_RELS = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" Type="http://schemas.microsoft.com/office/2011/relationships/webextension" '
+    'Target="webextension1.xml"/></Relationships>'
+)
+
+MINIMAL_WORKBOOK = {
+    "[Content_Types].xml": (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+        '<Default Extension="xml" ContentType="application/xml"/>'
+        '<Override PartName="/xl/workbook.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>'
+        '<Override PartName="/xl/worksheets/sheet1.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+        "</Types>"
+    ),
+    "_rels/.rels": (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        '<Relationship Id="rId1" '
+        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+        'Target="xl/workbook.xml"/></Relationships>'
+    ),
+    "xl/workbook.xml": (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+        'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+        '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>'
+    ),
+    "xl/_rels/workbook.xml.rels": (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        '<Relationship Id="rId1" '
+        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
+        'Target="worksheets/sheet1.xml"/></Relationships>'
+    ),
+    "xl/worksheets/sheet1.xml": (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        "<sheetData/></worksheet>"
+    ),
+}
+
+
+def default_addin_id() -> str:
+    manifest = Path(__file__).resolve().parents[4] / "manifest.xml"
+    match = re.search(r"<Id>([^<]+)</Id>", manifest.read_text())
+    if not match:
+        sys.exit(f"could not find <Id> in {manifest}")
+    return match.group(1)
+
+
+def webextension_xml(addin_id: str) -> str:
+    # Excel keys document-level add-in instances by this GUID within a running
+    # process; a fresh one per workbook keeps a second scratch workbook from
+    # being treated as the already-open instance.
+    instance_id = "{" + str(uuid.uuid4()).upper() + "}"
+    reference = f'<we:reference id="{addin_id}" version="1.0.0.0" store="developer" storeType="Registry"/>'
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<we:webextension xmlns:we="http://schemas.microsoft.com/office/webextensions/webextension/2010/11" '
+        f'id="{instance_id}">{reference}'
+        "<we:alternateReferences/><we:properties/><we:bindings/>"
+        '<we:snapshot xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"/>'
+        "</we:webextension>"
+    )
+
+
+def with_taskpane_parts(parts: dict[str, bytes], addin_id: str) -> dict[str, bytes]:
+    out = {name: data for name, data in parts.items() if not name.startswith("xl/webextensions/")}
+    content_types = out["[Content_Types].xml"].decode()
+    if "webextensiontaskpanes" not in content_types:
+        out["[Content_Types].xml"] = content_types.replace("</Types>", CONTENT_TYPES_OVERRIDES + "</Types>").encode()
+    rels = out["_rels/.rels"].decode()
+    if "webextensiontaskpanes" not in rels:
+        out["_rels/.rels"] = rels.replace("</Relationships>", ROOT_REL + "</Relationships>").encode()
+    out["xl/webextensions/taskpanes.xml"] = TASKPANES_XML.encode()
+    out["xl/webextensions/_rels/taskpanes.xml.rels"] = TASKPANES_RELS.encode()
+    out["xl/webextensions/webextension1.xml"] = webextension_xml(addin_id).encode()
+    return out
+
+
+def write_workbook(path: Path, parts: dict[str, bytes]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
+        for name, data in parts.items():
+            zout.writestr(name, data)
+    os.replace(tmp, path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("mode", choices=("create", "tag"))
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--addin-id", default=None)
+    args = parser.parse_args()
+    addin_id = args.addin_id or default_addin_id()
+
+    if args.mode == "create":
+        parts = {name: data.encode() for name, data in MINIMAL_WORKBOOK.items()}
+    else:
+        with zipfile.ZipFile(args.path) as zin:
+            parts = {item.filename: zin.read(item.filename) for item in zin.infolist()}
+
+    write_workbook(args.path, with_taskpane_parts(parts, addin_id))
+    print(f"{args.mode}: {args.path} opens add-in {addin_id} on document open")
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ Notes for agents working in this repo.
 
 Use the local acceptance policy in `docs/coding-standards.md` and the `.agents/skills/excel-background-verification/SKILL.md` workflow.
 
+The Excel lane runs entirely in the background, including opening the pane after a relaunch (the skill bootstraps it from the scratch workbook) and reading what the taskpane persisted (straight from WebKit's IndexedDB). Work through the skill's "Before you call it blocked" table before reporting the lane blocked; each row there has been hit and worked around.
+
 - `npm run check`
 - `npm run build`
 - `npm run test:models`
@@ -147,3 +149,5 @@ If local changes do not show up:
 4. If still stale, clear WKWebView cache and relaunch Excel:
    - `rm -rf ~/Library/Containers/com.microsoft.Excel/Data/Library/WebKit/`
    - `rm -rf ~/Library/Containers/com.microsoft.Excel/Data/Library/Caches/WebKit/`
+
+No `Open Pi` ribbon button after a relaunch is expected, not a stale manifest: Excel keeps sideloaded add-ins out of the ribbon cache until they have been activated once in the running process. Open the pane from a workbook that carries the auto-open part (`.agents/skills/excel-background-verification/scripts/scratch-workbook.py`); the button appears after that. Clearing the WebKit cache also deletes the taskpane's IndexedDB (sessions, recovery snapshots, files-workspace state), so do it last.

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -86,6 +86,7 @@ Use [Behavior tests and acceptance gates](./testing.md) for contract selection, 
 
 - Accept behavior changes and dependency upgrades through a real taskpane prompt → model → tools → workbook test, with independent read-back and scratch cleanup. Keep the host in the background.
 - Unit tests, CI, builds and direct host probes support this acceptance test. If it is blocked, report the missing coverage and obtain an explicit waiver before accepting the change. Documentation-only changes need no runtime test.
+- Blocked means the skill's "Before you call it blocked" table is exhausted. A missing ribbon button, an unopenable Add-ins flyout, or an accessibility tree that needs a moment are documented non-blockers with background workarounds.
 - For prompt/context/tool-disclosure/session wiring, run `npm run test:context`.
 - For proxy/bridge/auth/HTML safety paths, run `npm run test:security`.
 - For model/provider registry changes, run `npm run test:models` and consult `docs/model-updates.md`.


### PR DESCRIPTION
Harness only; no product code. Unblocks the background Excel acceptance lane that #720, #721 and #723 were waiting on (their acceptance runs used exactly this).

## Problem

After an Excel relaunch the sideloaded add-in has no ribbon button: Excel for Mac registers the manifest (`Wef/…/Manifests/`) but only writes store add-ins to the ribbon cache (`Wef/AppCommands/<ver>/`) until the add-in has been activated once in the running process. The Home-tab *Add-ins* flyout is the only UI path and it does not render for a background app (AXPress toggles the button state, no popover window appears in the CGWindow list). So the lane could not open the pane without stealing focus.

## Fix

A workbook can carry an auto-open task pane part (`xl/webextensions`). When it references the sideloaded manifest with `store="developer" storeType="Registry"`, Excel opens the pane on document open, in the background, and `Open Pi` appears on the ribbon for the rest of the process.

- `scripts/scratch-workbook.py create <path>` writes a minimal one-sheet workbook with that part (fresh instance GUID per workbook, add-in ID read from `manifest.xml`); `tag <existing.xlsx>` adds the part to a workbook Excel has saved.
- `scripts/read-taskpane-setting.py <key>` copies the taskpane's WebKit IndexedDB (+ WAL) and decodes one `settings` record (SerializedScriptValue v15 incl. the string constant pool) to JSON — an independent readout of recovery snapshots, files-workspace metadata/audit, etc.
- `SKILL.md`: bootstrap sequence, reload via `Close Pi for Excel` → `Open Pi` (string `element_index`), independent readouts, AX-dump truncation, and three new diagnose rows.
- Second commit: a "Before you call it blocked" table in the skill (every step that looked foreground-only and was worked around in the background, with what to do instead); `AGENTS.md` and `docs/coding-standards.md` say blocked means that table is exhausted; the manifest-gotcha section says the missing `Open Pi` button after a relaunch is expected, not a stale manifest, and that the WebKit cache clear also deletes the taskpane's IndexedDB.

## Verified in Excel 16.112

- Quit Excel; `scratch-workbook.py create` → `open -g -a "Microsoft Excel" <file>`: pane opened as *Pi for Excel* with the configured model, bridge client registered, `Open Pi` on the ribbon, frontmost app unchanged (checked before/after every step).
- Same in-process again with a second tagged workbook: no auto-open (documented; use the ribbon button). Quit + relaunch into it: auto-open works again.
- `storeType="uploadfiledevcatalog"` alone → *New Office Add-in* / *Add-in Error*; `FileSystem` alone → endless *Loading…*; `Registry` resolves.
- `read-taskpane-setting.py` decoded `files.workspace.*` and `workbook.recovery-snapshots.v1` before/after each step of the #721 and #723 runs (legacy entries preserved verbatim, counts as expected).

`npm run check` clean; `tests/docs-skills-drift.test.ts` passes (skill scripts are not part of the bundled skills catalog).

