### PR TITLE
dependabot: typebox follows pi-ai, do not propose it alone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       - dependency-name: "eslint"
         update-types:
           - "version-update:semver-major"
+      # typebox is pinned to the exact version @earendil-works/pi-ai depends on
+      # so one copy ships (scripts/check-pi-deps-lockstep.mjs fails otherwise).
+      # It moves only when pi-ai moves, in the pi-stack bump.
+      - dependency-name: "typebox"
     groups:
       pi-stack:
         patterns:

--- a/docs/model-updates.md
+++ b/docs/model-updates.md
@@ -56,7 +56,8 @@ Prices are registry values in USD per million tokens. All three models:
   - `@earendil-works/pi-ai`
   - `@earendil-works/pi-agent-core`
 - `.github/workflows/dependabot-pi-automerge.yml` auto-approves + enables auto-merge for that Dependabot group (merge still waits for green checks).
-- `npm run check` includes `scripts/check-pi-deps-lockstep.mjs`, which enforces the dependency policy below (`pi-ai` === `pi-agent-core`, exact pins, single shared `pi-ai` copy in the lockfile).
+- `npm run check` includes `scripts/check-pi-deps-lockstep.mjs`, which enforces the dependency policy below (`pi-ai` === `pi-agent-core`, exact pins, single shared `pi-ai` copy in the lockfile, `typebox` pinned to the version `pi-ai` depends on).
+- Dependabot ignores `typebox`: it is bumped by hand as part of a pi-stack bump, to whatever `npm view @earendil-works/pi-ai@<version> dependencies.typebox` says. A Dependabot PR that bumps `typebox` on its own fails the lockstep check by design.
 
 ## Step-by-step
 
@@ -94,6 +95,7 @@ npm view @earendil-works/pi-agent-core versions --json
 
 ```bash
 npm install @earendil-works/pi-ai@<version> @earendil-works/pi-agent-core@<version> --save-exact
+npm install typebox@"$(npm view @earendil-works/pi-ai@<version> dependencies.typebox)" --save-exact
 ```
 
 ### 4) Verify the new model IDs exist in the registry


### PR DESCRIPTION
Config + docs only.

#719 fails `check:pi-lockstep` because the minor-and-patch group bumps `typebox` 1.3.7 → 1.3.28, while `@earendil-works/pi-ai` 0.85.1 (current, and latest) still depends on 1.3.7. The pin exists so a single typebox copy ships, shared by first-party schemas and pi-ai's validation; that bump can only land with a pi-stack bump whose pi-ai declares it.

- `.github/dependabot.yml`: ignore `typebox` (with the reason in a comment).
- `docs/model-updates.md`: state the rule and add the `npm install typebox@$(npm view pi-ai@<v> dependencies.typebox)` line to the bump step.

After merge: `@dependabot recreate` on #719 so it carries only the `typescript-eslint` 8.69.0 → 8.70.0 update.

Runtime testing not applicable (no source changes); `npm run check:pi-lockstep` passes.