### PR TITLE
excel-background-verification: read the pane tree without computer_use

### DIFF
--- a/.agents/skills/excel-background-verification/SKILL.md
+++ b/.agents/skills/excel-background-verification/SKILL.md
@@ -67,6 +67,7 @@ Everything below has looked like a foreground-only step and was worked around in
 | AppleScript `save workbook as` returns `Parameter error (-50)` | Path built from `POSIX path of (path to home folder)` | Pass a literal absolute path string, inside the Excel container |
 | Pane cannot be reloaded after switching the Vite worktree | The document auto-open fires once per process | `Close Pi for Excel` then `Open Pi` through `computer_use` |
 | Persisted state cannot be checked without trusting the pane | It can | `read-taskpane-setting.py <key>` decodes the record from WebKit's IndexedDB |
+| `computer_use` returns `codex app-server exited before returning a response` on every call | The tool's own server is down; Excel is fine | Read the tree with `scripts/axdump.swift` (below); pressing buttons waits for the tool to come back |
 
 Opening a workbook does not activate Excel: both `open -g -a "Microsoft Excel" <file>` and `osascript -e 'tell application "Microsoft Excel" to open POSIX file "…"'` leave the frontmost app unchanged.
 
@@ -134,6 +135,16 @@ python3 .agents/skills/excel-background-verification/scripts/read-taskpane-setti
 It copies the database and its WAL and decodes one record to JSON, so a before/after diff shows exactly which entries a change dropped, kept or rewrote.
 
 Rendered tool cards are visible in the pane's accessibility tree (`HTML content` under the `Pi for Excel` container), which is how to assert diff tables, trees and images. The dump truncates on long chats; scroll the `HTML content` element with `sky.scroll` or start a fresh chat with `submitInput` `{"text":"/new"}`. Slash commands such as `/new` and `/history` go through the real composer with `submitInput`; `submitPrompt` sends text to the model.
+
+When `computer_use` is unavailable, the same tree is readable without it. System Events stops at the web area, so use the `AXUIElement` walker:
+
+```bash
+swiftc -O -o /tmp/axdump .agents/skills/excel-background-verification/scripts/axdump.swift
+/tmp/axdump "Microsoft Excel" > "$RUN_DIR/pane-ax.txt"
+rg -n 'AXTable|AXLink|AXPreformattedStyleGroup|value="' "$RUN_DIR/pane-ax.txt" | tail -60
+```
+
+It prints role, subrole, title, value, description and URL per element, indented by depth, and does not press anything.
 
 ## Report and clean up
 

--- a/.agents/skills/excel-background-verification/scripts/axdump.swift
+++ b/.agents/skills/excel-background-verification/scripts/axdump.swift
@@ -1,0 +1,59 @@
+// Print the accessibility tree of an app's first window, one element per line,
+// descending into WebKit web areas. System Events stops at the web area, so
+// this is how to read rendered taskpane content when computer_use is unavailable.
+//
+//   swiftc -O -o /tmp/axdump axdump.swift && /tmp/axdump "Microsoft Excel" > ax.txt
+//
+// Needs Accessibility permission for the terminal running it. Read-only.
+import Cocoa
+import ApplicationServices
+
+let args = CommandLine.arguments
+let appName = args.count > 1 ? args[1] : "Microsoft Excel"
+let maxDepth = args.count > 2 ? Int(args[2]) ?? 60 : 60
+let maxElements = 20_000
+
+guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.localizedName == appName }) else {
+    FileHandle.standardError.write("app not running: \(appName)\n".data(using: .utf8)!)
+    exit(2)
+}
+let application = AXUIElementCreateApplication(app.processIdentifier)
+
+func attribute(_ element: AXUIElement, _ name: String) -> AnyObject? {
+    var value: AnyObject?
+    return AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success ? value : nil
+}
+
+func text(_ element: AXUIElement, _ name: String) -> String {
+    guard let value = attribute(element, name) else { return "" }
+    if let string = value as? String { return string }
+    if let number = value as? NSNumber { return number.stringValue }
+    if let url = value as? URL { return url.absoluteString }
+    return ""
+}
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+    attribute(element, kAXChildrenAttribute) as? [AXUIElement] ?? []
+}
+
+var printed = 0
+
+func walk(_ element: AXUIElement, depth: Int) {
+    if depth > maxDepth || printed >= maxElements { return }
+    var parts = [text(element, kAXRoleAttribute)]
+    let subrole = text(element, kAXSubroleAttribute)
+    if !subrole.isEmpty { parts.append("(\(subrole))") }
+    for (label, name) in [("title", kAXTitleAttribute), ("value", kAXValueAttribute), ("desc", kAXDescriptionAttribute), ("url", kAXURLAttribute)] {
+        let value = text(element, name)
+        if !value.isEmpty { parts.append("\(label)=\"\(value.prefix(200))\"") }
+    }
+    print(String(repeating: "  ", count: depth) + parts.joined(separator: " "))
+    printed += 1
+    for child in children(element) { walk(child, depth: depth + 1) }
+}
+
+guard let windows = attribute(application, kAXWindowsAttribute) as? [AXUIElement], let window = windows.first else {
+    FileHandle.standardError.write("no windows for \(appName)\n".data(using: .utf8)!)
+    exit(3)
+}
+walk(window, depth: 0)


### PR DESCRIPTION
Harness only.

During the #727 acceptance run the `computer_use` server failed on every call (`codex app-server exited before returning a response`, including `list_apps`) and did not recover. The rendered markdown still had to be asserted, and System Events cannot descend into the WKWebView web area.

- `scripts/axdump.swift`: read-only `AXUIElement` walker; prints one element per line (role, subrole, title, value, description, URL), indented by depth, descending into `AXWebArea`. Compiles with the stock toolchain (`swiftc -O`), needs Accessibility permission for the terminal.
- `SKILL.md`: how to use it, and a row in the "Before you call it blocked" table for the `computer_use` outage.

Used as the reader for the #727 evidence (table, nested list, fenced block, link all located in the dump). Runtime testing not applicable to the product; `tests/docs-skills-drift.test.ts` passes.